### PR TITLE
저장소 관련 도메인 엔티티를 구현합니다.

### DIFF
--- a/ChaGok/Domain/Sources/Domain.swift
+++ b/ChaGok/Domain/Sources/Domain.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-/// ChaGok Domain layer
-/// 엔티티, 유스케이스, 리포지토리 프로토콜 등 비즈니스 로직의 핵심을 담습니다.
-public enum ChaGokDomain {
-    // Domain 모델 및 유스케이스 추가
-}

--- a/ChaGok/Domain/Sources/Entity/FileFormat.swift
+++ b/ChaGok/Domain/Sources/Entity/FileFormat.swift
@@ -1,0 +1,22 @@
+//
+//  FileFormat.swift
+//  Domain
+//
+//  Created by Tom Choi on 2/9/26.
+//
+
+import Foundation
+
+/// FileFormat은 녹음 파일의 파일 형식을 나타내는 열거형입니다.
+/// - mp3: MP3 파일.
+/// - wav: WAV 파일.
+/// - aac: AAC 파일.
+/// - m4a: M4A 파일.
+/// - other: 기타 파일 형식.
+public enum FileFormat {
+    case mp3
+    case wav
+    case aac
+    case m4a
+    case other(String)
+}

--- a/ChaGok/Domain/Sources/Entity/RecordingFile.swift
+++ b/ChaGok/Domain/Sources/Entity/RecordingFile.swift
@@ -1,0 +1,59 @@
+//
+//  RecordingFile.swift
+//  Domain
+//
+//  Created by Tom Choi on 2/9/26.
+//
+
+import Foundation
+
+public struct RecordingFile {
+    public let id: UUID
+    public let fileURL: URL
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let duration: TimeInterval
+    public let fileFormat: FileFormat
+    public let fileSize: Int64
+    public let fileName: String
+    public let title: String
+    public let description: String
+    public let tags: [String]
+    public let isFavorite: Bool
+
+    public init(
+        id: UUID,
+        fileURL: URL,
+        createdAt: Date,
+        updatedAt: Date,
+        duration: TimeInterval,
+        fileFormat: FileFormat,
+        fileSize: Int64,
+        fileName: String,
+        title: String,
+        description: String,
+        tags: [String],
+        isFavorite: Bool
+    ) {
+        self.id = id
+        self.fileURL = fileURL
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.duration = duration
+        self.fileFormat = fileFormat
+        self.fileSize = fileSize
+        self.fileName = fileName
+        self.title = title
+        self.description = description
+        self.tags = tags
+        self.isFavorite = isFavorite
+    }
+}
+
+public enum FileFormat {
+    case mp3
+    case wav
+    case aac
+    case m4a
+    case other(String)
+}

--- a/ChaGok/Domain/Sources/Entity/RecordingFile.swift
+++ b/ChaGok/Domain/Sources/Entity/RecordingFile.swift
@@ -7,6 +7,18 @@
 
 import Foundation
 
+/// RecordingFile은 녹음 파일을 나타내는 엔티티입니다.
+/// - id: 녹음 파일의 고유 식별자.
+/// - fileURL: 녹음 파일의 URL.
+/// - createdAt: 녹음 파일의 생성 시간.
+/// - updatedAt: 녹음 파일의 업데이트 시간.
+/// - duration: 녹음 파일의 재생 시간.
+/// - fileFormat: 녹음 파일의 파일 형식.
+/// - fileSize: 녹음 파일의 파일 크기.
+/// - fileName: 녹음 파일의 파일 이름.
+/// - title: 녹음 파일의 제목.
+/// - description: 녹음 파일의 설명.
+/// - tags: 녹음 파일의 태그.
 public struct RecordingFile {
     public let id: UUID
     public let fileURL: URL
@@ -19,7 +31,6 @@ public struct RecordingFile {
     public let title: String
     public let description: String
     public let tags: [String]
-    public let isFavorite: Bool
 
     public init(
         id: UUID,
@@ -33,7 +44,6 @@ public struct RecordingFile {
         title: String,
         description: String,
         tags: [String],
-        isFavorite: Bool
     ) {
         self.id = id
         self.fileURL = fileURL
@@ -46,14 +56,5 @@ public struct RecordingFile {
         self.title = title
         self.description = description
         self.tags = tags
-        self.isFavorite = isFavorite
     }
-}
-
-public enum FileFormat {
-    case mp3
-    case wav
-    case aac
-    case m4a
-    case other(String)
 }

--- a/ChaGok/Domain/Sources/Entity/StorageInfo.swift
+++ b/ChaGok/Domain/Sources/Entity/StorageInfo.swift
@@ -12,13 +12,30 @@ import Foundation
 /// - freeBytes: 저장소의 남은(여유) 바이트 수.
 /// - appUsedBytes: 앱이 사용한 바이트 수.
 /// - usageRatio: 앱 사용량 비율.
+/// - usedBytes: 기기 전체 사용량.
+/// - freeRatio: 여유 공간 비율.
+/// - isLowStorage(threshold:): 저장 공간 부족 여부. 쓰레시홀드는 호출 측에서 전달.
 public struct StorageInfo {
     public let totalBytes: Int64
     public let freeBytes: Int64
     public let appUsedBytes: Int64
 
     public var usageRatio: Double {
-        Double(appUsedBytes) / Double(totalBytes)
+        guard totalBytes > 0 else { return 0 }
+        return Double(appUsedBytes) / Double(totalBytes)
+    }
+
+    public var usedBytes: Int64 {
+        max(0, totalBytes - freeBytes)
+    }
+
+    public var freeRatio: Double {
+        guard totalBytes > 0 else { return 0 }
+        return Double(freeBytes) / Double(totalBytes)
+    }
+
+    public func isLowStorage(threshold: Int64) -> Bool {
+        freeBytes < threshold
     }
 
     public init(totalBytes: Int64, freeBytes: Int64, appUsedBytes: Int64) {

--- a/ChaGok/Domain/Sources/Entity/StorageInfo.swift
+++ b/ChaGok/Domain/Sources/Entity/StorageInfo.swift
@@ -1,0 +1,24 @@
+//
+//  StorageInfo.swift
+//  Domain
+//
+//  Created by Tom Choi on 2/9/26.
+//
+
+import Foundation
+
+public struct StorageInfo {
+    public let totalBytes: Int64
+    public let freeBytes: Int64
+    public let appUsedBytes: Int64
+    
+    public var usageRatio: Double {
+        Double(appUsedBytes) / Double(totalBytes)
+    }
+
+    public init(totalBytes: Int64, freeBytes: Int64, appUsedBytes: Int64) {
+        self.totalBytes = totalBytes
+        self.freeBytes = freeBytes
+        self.appUsedBytes = appUsedBytes
+    }
+}

--- a/ChaGok/Domain/Sources/Entity/StorageInfo.swift
+++ b/ChaGok/Domain/Sources/Entity/StorageInfo.swift
@@ -7,11 +7,16 @@
 
 import Foundation
 
+/// StorageInfo는 기기의 저장소 정보를 담고 있는 구조체입니다.
+/// - totalBytes: 저장소의 전체 바이트 수.
+/// - freeBytes: 저장소의 남은(여유) 바이트 수.
+/// - appUsedBytes: 앱이 사용한 바이트 수.
+/// - usageRatio: 앱 사용량 비율.
 public struct StorageInfo {
     public let totalBytes: Int64
     public let freeBytes: Int64
     public let appUsedBytes: Int64
-    
+
     public var usageRatio: Double {
         Double(appUsedBytes) / Double(totalBytes)
     }

--- a/ChaGok/Domain/Sources/Repository/StorageRepository.swift
+++ b/ChaGok/Domain/Sources/Repository/StorageRepository.swift
@@ -1,0 +1,18 @@
+//
+//  StorageRepository.swift
+//  Domain
+//
+//  Created by Tom Choi on 2/9/26.
+//
+
+import Foundation
+
+/// StorageRepository는 저장소 정보를 조회하고, 녹음 파일을 관리하는 리포지토리 프로토콜입니다.
+/// - fetchStorageInfo(): 저장소 정보를 조회합니다.
+/// - fetchRecordingFiles(): 녹음 파일을 조회합니다.
+/// - deleteFiles(ids:): 녹음 파일을 삭제합니다.
+public protocol StorageRepository {
+    func fetchStorageInfo() async throws -> StorageInfo
+    func fetchRecordingFiles() async throws -> [RecordingFile]
+    func deleteFiles(ids: [UUID]) async throws -> Int
+}

--- a/ChaGok/Domain/Tests/DomainTests.swift
+++ b/ChaGok/Domain/Tests/DomainTests.swift
@@ -1,4 +1,0 @@
-import Testing
-@testable import Domain
-
-@Test func placeholder() {}

--- a/ChaGok/Domain/Tests/Entity/FileFormatTests.swift
+++ b/ChaGok/Domain/Tests/Entity/FileFormatTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import XCTest
+@testable import Domain
+
+final class FileFormatTests: XCTestCase {
+
+    // MARK: - R: Right - 각 case 존재 및 기대값
+
+    func test_FileFormat_mp3_case가존재한다() {
+        let format: FileFormat = .mp3
+        if case .mp3 = format { return }
+        XCTFail("FileFormat.mp3 should match")
+    }
+
+    func test_FileFormat_wav_case가존재한다() {
+        let format: FileFormat = .wav
+        if case .wav = format { return }
+        XCTFail("FileFormat.wav should match")
+    }
+
+    func test_FileFormat_aac_case가존재한다() {
+        let format: FileFormat = .aac
+        if case .aac = format { return }
+        XCTFail("FileFormat.aac should match")
+    }
+
+    func test_FileFormat_m4a_case가존재한다() {
+        let format: FileFormat = .m4a
+        if case .m4a = format { return }
+        XCTFail("FileFormat.m4a should match")
+    }
+
+    func test_FileFormat_other_연관값이저장된다() {
+        let format: FileFormat = .other("custom")
+        if case let .other(value) = format {
+            XCTAssertEqual(value, "custom")
+        } else {
+            XCTFail("FileFormat.other should match with associated value")
+        }
+    }
+
+    // MARK: - B: Boundary - other 경계
+
+    func test_FileFormat_other_빈문자열도허용된다() {
+        let format: FileFormat = .other("")
+        if case let .other(value) = format {
+            XCTAssertEqual(value, "")
+        } else {
+            XCTFail("FileFormat.other(\"\") should match")
+        }
+    }
+
+    func test_FileFormat_other_긴문자열도저장된다() {
+        let long = String(repeating: "x", count: 1000)
+        let format: FileFormat = .other(long)
+        if case let .other(value) = format {
+            XCTAssertEqual(value, long)
+        } else {
+            XCTFail("FileFormat.other(long) should match")
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Entity/RecordingFileTests.swift
+++ b/ChaGok/Domain/Tests/Entity/RecordingFileTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import XCTest
+@testable import Domain
+
+final class RecordingFileTests: XCTestCase {
+
+    // MARK: - R: Right - init 후 프로퍼티 일치
+
+    func test_RecordingFile_init_전달한값이프로퍼티와일치한다() {
+        let id = UUID()
+        let url = URL(fileURLWithPath: "/tmp/recording.m4a")
+        let createdAt = Date(timeIntervalSince1970: 1000)
+        let updatedAt = Date(timeIntervalSince1970: 2000)
+        let duration: TimeInterval = 120.5
+        let format: FileFormat = .m4a
+        let fileSize: Int64 = 1024
+        let fileName = "recording.m4a"
+        let title = "제목"
+        let description = "설명"
+        let tags = ["회의", "녹음"]
+
+        let sut = RecordingFile(
+            id: id,
+            fileURL: url,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            duration: duration,
+            fileFormat: format,
+            fileSize: fileSize,
+            fileName: fileName,
+            title: title,
+            description: description,
+            tags: tags
+        )
+
+        XCTAssertEqual(sut.id, id)
+        XCTAssertEqual(sut.fileURL, url)
+        XCTAssertEqual(sut.createdAt, createdAt)
+        XCTAssertEqual(sut.updatedAt, updatedAt)
+        XCTAssertEqual(sut.duration, duration)
+        if case .m4a = sut.fileFormat { } else { XCTFail("fileFormat should be m4a") }
+        XCTAssertEqual(sut.fileSize, fileSize)
+        XCTAssertEqual(sut.fileName, fileName)
+        XCTAssertEqual(sut.title, title)
+        XCTAssertEqual(sut.description, description)
+        XCTAssertEqual(sut.tags, tags)
+    }
+
+    // MARK: - B: Boundary - 빈 값, 0 값
+
+    func test_RecordingFile_Boundary_빈tags가능() {
+        let sut = RecordingFile(
+            id: UUID(),
+            fileURL: URL(fileURLWithPath: "/tmp/a.m4a"),
+            createdAt: Date(),
+            updatedAt: Date(),
+            duration: 0,
+            fileFormat: .m4a,
+            fileSize: 0,
+            fileName: "a.m4a",
+            title: "",
+            description: "",
+            tags: []
+        )
+        XCTAssertTrue(sut.tags.isEmpty)
+        XCTAssertEqual(sut.duration, 0)
+        XCTAssertEqual(sut.fileSize, 0)
+        XCTAssertEqual(sut.title, "")
+        XCTAssertEqual(sut.description, "")
+    }
+
+    func test_RecordingFile_Boundary_createdAt와updatedAt가같아도생성된다() {
+        let date = Date()
+        let sut = RecordingFile(
+            id: UUID(),
+            fileURL: URL(fileURLWithPath: "/tmp/a.m4a"),
+            createdAt: date,
+            updatedAt: date,
+            duration: 0,
+            fileFormat: .mp3,
+            fileSize: 0,
+            fileName: "a.mp3",
+            title: "t",
+            description: "d",
+            tags: []
+        )
+        XCTAssertEqual(sut.createdAt, sut.updatedAt)
+    }
+}

--- a/ChaGok/Domain/Tests/Entity/StorageInfoTests.swift
+++ b/ChaGok/Domain/Tests/Entity/StorageInfoTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import XCTest
+@testable import Domain
+
+final class StorageInfoTests: XCTestCase {
+
+    // MARK: - usageRatio (R: Right, E: Error - division by zero)
+
+    func test_usageRatio_totalBytes가0이면_0을반환한다() {
+        let sut = StorageInfo(totalBytes: 0, freeBytes: 0, appUsedBytes: 0)
+        XCTAssertEqual(sut.usageRatio, 0)
+    }
+
+    func test_usageRatio_정상값이면_앱사용량비율을반환한다() {
+        let sut = StorageInfo(totalBytes: 100, freeBytes: 40, appUsedBytes: 20)
+        XCTAssertEqual(sut.usageRatio, 0.2)
+    }
+
+    func test_usageRatio_appUsedBytes가totalBytes를넘어도_비율은1을초과할수있다() {
+        let sut = StorageInfo(totalBytes: 100, freeBytes: 0, appUsedBytes: 150)
+        XCTAssertEqual(sut.usageRatio, 1.5)
+    }
+
+    func test_usageRatio_Boundary_totalBytes가1일때() {
+        let sut = StorageInfo(totalBytes: 1, freeBytes: 0, appUsedBytes: 1)
+        XCTAssertEqual(sut.usageRatio, 1.0)
+    }
+
+    // MARK: - usedBytes (R, B, C)
+
+    func test_usedBytes_totalMinusFree를반환한다() {
+        let sut = StorageInfo(totalBytes: 100, freeBytes: 30, appUsedBytes: 10)
+        XCTAssertEqual(sut.usedBytes, 70)
+    }
+
+    func test_usedBytes_freeBytes가totalBytes를넘으면_0을반환한다() {
+        let sut = StorageInfo(totalBytes: 100, freeBytes: 120, appUsedBytes: 0)
+        XCTAssertEqual(sut.usedBytes, 0)
+    }
+
+    func test_usedBytes_CrossCheck_수동계산과일치한다() {
+        let sut = StorageInfo(totalBytes: 100, freeBytes: 30, appUsedBytes: 10)
+        let expected = max(0, sut.totalBytes - sut.freeBytes)
+        XCTAssertEqual(sut.usedBytes, expected)
+    }
+
+    func test_usedBytes_Inverse_usedBytes와freeBytes의합은totalBytes이다() {
+        let sut = StorageInfo(totalBytes: 100, freeBytes: 30, appUsedBytes: 10)
+        XCTAssertEqual(sut.usedBytes + sut.freeBytes, sut.totalBytes)
+    }
+
+    // MARK: - freeRatio (R, E, C)
+
+    func test_freeRatio_totalBytes가0이면_0을반환한다() {
+        let sut = StorageInfo(totalBytes: 0, freeBytes: 0, appUsedBytes: 0)
+        XCTAssertEqual(sut.freeRatio, 0)
+    }
+
+    func test_freeRatio_정상값이면_freeBytes비율을반환한다() {
+        let sut = StorageInfo(totalBytes: 100, freeBytes: 40, appUsedBytes: 20)
+        XCTAssertEqual(sut.freeRatio, 0.4)
+    }
+
+    func test_freeRatio_CrossCheck_수동계산과일치한다() {
+        let sut = StorageInfo(totalBytes: 100, freeBytes: 40, appUsedBytes: 20)
+        let expected = Double(sut.freeBytes) / Double(sut.totalBytes)
+        XCTAssertEqual(sut.freeRatio, expected)
+    }
+
+    func test_freeRatio_Inverse_totalBytes가양수일때_freeRatio와usedRatio의합은1이다() {
+        let sut = StorageInfo(totalBytes: 100, freeBytes: 40, appUsedBytes: 20)
+        let usedRatio = Double(sut.usedBytes) / Double(sut.totalBytes)
+        XCTAssertEqual(sut.freeRatio + usedRatio, 1.0, accuracy: 0.0001)
+    }
+
+    // MARK: - isLowStorage (R, B)
+
+    func test_isLowStorage_freeBytes가threshold미만이면_true() {
+        let sut = StorageInfo(totalBytes: 1000, freeBytes: 50, appUsedBytes: 100)
+        XCTAssertTrue(sut.isLowStorage(threshold: 100))
+    }
+
+    func test_isLowStorage_freeBytes가threshold와같으면_false() {
+        let sut = StorageInfo(totalBytes: 1000, freeBytes: 100, appUsedBytes: 100)
+        XCTAssertFalse(sut.isLowStorage(threshold: 100))
+    }
+
+    func test_isLowStorage_freeBytes가threshold초과면_false() {
+        let sut = StorageInfo(totalBytes: 1000, freeBytes: 200, appUsedBytes: 100)
+        XCTAssertFalse(sut.isLowStorage(threshold: 100))
+    }
+
+    func test_isLowStorage_Boundary_threshold가0일때_freeBytes가0이면_false() {
+        let sut = StorageInfo(totalBytes: 100, freeBytes: 0, appUsedBytes: 100)
+        XCTAssertFalse(sut.isLowStorage(threshold: 0))
+    }
+
+    func test_isLowStorage_Boundary_threshold가0일때_freeBytes가양수면_false() {
+        let sut = StorageInfo(totalBytes: 100, freeBytes: 1, appUsedBytes: 50)
+        XCTAssertFalse(sut.isLowStorage(threshold: 0))
+    }
+}

--- a/ChaGok/Domain/Tests/Repository/MockStorageRepository.swift
+++ b/ChaGok/Domain/Tests/Repository/MockStorageRepository.swift
@@ -1,0 +1,42 @@
+import Foundation
+@testable import Domain
+
+/// StorageRepository 프로토콜 계약 검증 및 호출부 테스트용 Mock.
+final class MockStorageRepository: StorageRepository {
+
+    var storageInfoResult: Result<StorageInfo, Error> = .success(
+        StorageInfo(totalBytes: 1000, freeBytes: 500, appUsedBytes: 100)
+    )
+    var recordingFilesResult: Result<[RecordingFile], Error> = .success([])
+    var deleteFilesResult: Result<Int, Error> = .success(0)
+
+    var fetchStorageInfoCallCount = 0
+    var fetchRecordingFilesCallCount = 0
+    var deleteFilesCallCount = 0
+    var deleteFilesReceivedIds: [UUID] = []
+
+    func fetchStorageInfo() async throws -> StorageInfo {
+        fetchStorageInfoCallCount += 1
+        switch storageInfoResult {
+        case .success(let value): return value
+        case .failure(let error): throw error
+        }
+    }
+
+    func fetchRecordingFiles() async throws -> [RecordingFile] {
+        fetchRecordingFilesCallCount += 1
+        switch recordingFilesResult {
+        case .success(let value): return value
+        case .failure(let error): throw error
+        }
+    }
+
+    func deleteFiles(ids: [UUID]) async throws -> Int {
+        deleteFilesCallCount += 1
+        deleteFilesReceivedIds = ids
+        switch deleteFilesResult {
+        case .success(let value): return value
+        case .failure(let error): throw error
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Repository/StorageRepositoryTests.swift
+++ b/ChaGok/Domain/Tests/Repository/StorageRepositoryTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import XCTest
+@testable import Domain
+
+final class StorageRepositoryTests: XCTestCase {
+
+    // MARK: - Interface (계약): 반환 타입 및 정상 동작
+
+    func test_MockStorageRepository_fetchStorageInfo_StorageInfo를반환한다() async throws {
+        let expected = StorageInfo(totalBytes: 2000, freeBytes: 800, appUsedBytes: 200)
+        let mock = MockStorageRepository()
+        mock.storageInfoResult = .success(expected)
+
+        let result = try await mock.fetchStorageInfo()
+
+        XCTAssertEqual(result.totalBytes, expected.totalBytes)
+        XCTAssertEqual(result.freeBytes, expected.freeBytes)
+        XCTAssertEqual(result.appUsedBytes, expected.appUsedBytes)
+        XCTAssertEqual(mock.fetchStorageInfoCallCount, 1)
+    }
+
+    func test_MockStorageRepository_fetchRecordingFiles_RecordingFile배열을반환한다() async throws {
+        let url = URL(fileURLWithPath: "/tmp/rec.m4a")
+        let file = RecordingFile(
+            id: UUID(),
+            fileURL: url,
+            createdAt: Date(),
+            updatedAt: Date(),
+            duration: 60,
+            fileFormat: .m4a,
+            fileSize: 1024,
+            fileName: "rec.m4a",
+            title: "T",
+            description: "D",
+            tags: []
+        )
+        let mock = MockStorageRepository()
+        mock.recordingFilesResult = .success([file])
+
+        let result = try await mock.fetchRecordingFiles()
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].id, file.id)
+        XCTAssertEqual(result[0].fileURL, url)
+        XCTAssertEqual(mock.fetchRecordingFilesCallCount, 1)
+    }
+
+    func test_MockStorageRepository_deleteFiles_삭제된개수를반환한다() async throws {
+        let mock = MockStorageRepository()
+        mock.deleteFilesResult = .success(2)
+        let ids = [UUID(), UUID()]
+
+        let result = try await mock.deleteFiles(ids: ids)
+
+        XCTAssertEqual(result, 2)
+        XCTAssertEqual(mock.deleteFilesCallCount, 1)
+        XCTAssertEqual(mock.deleteFilesReceivedIds, ids)
+    }
+
+    // MARK: - E: Error - 에러 전파
+
+    func test_MockStorageRepository_fetchStorageInfo_에러시_throw한다() async {
+        struct DummyError: Error {}
+        let mock = MockStorageRepository()
+        mock.storageInfoResult = .failure(DummyError())
+
+        do {
+            _ = try await mock.fetchStorageInfo()
+            XCTFail("Should throw")
+        } catch is DummyError {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_MockStorageRepository_fetchRecordingFiles_에러시_throw한다() async {
+        struct DummyError: Error {}
+        let mock = MockStorageRepository()
+        mock.recordingFilesResult = .failure(DummyError())
+
+        do {
+            _ = try await mock.fetchRecordingFiles()
+            XCTFail("Should throw")
+        } catch is DummyError {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_MockStorageRepository_deleteFiles_에러시_throw한다() async {
+        struct DummyError: Error {}
+        let mock = MockStorageRepository()
+        mock.deleteFilesResult = .failure(DummyError())
+
+        do {
+            _ = try await mock.deleteFiles(ids: [UUID()])
+            XCTFail("Should throw")
+        } catch is DummyError {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 기능 요약
> 한 줄로 무엇을 추가/변경했는지

저장소 정보·녹음 파일 도메인 엔티티 및 StorageRepository 프로토콜 추가

## 📋 구체적인 내용
- **추가/변경된 동작:**
  - `StorageInfo`: 기기 저장소 정보 엔티티 (전체/여유/앱 사용량, usageRatio, freeRatio, isLowStorage 등)
  - `FileFormat`: 녹음 파일 형식 열거형 (mp3, wav, aac, m4a, other)
  - `RecordingFile`: 녹음 파일 엔티티 (id, fileURL, 생성/수정일, 재생시간, 형식, 크기, 제목, 설명, 태그 등)
  - `StorageRepository`: 저장소 정보 조회·녹음 파일 조회·삭제를 정의하는 리포지토리 프로토콜

---

## 🔗 연관 이슈

- closed #8 

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점

- **선택한 방식**
  - `StorageInfo`에서 usageRatio, freeRatio, usedBytes, isLowStorage(threshold:)를 프로퍼티/메서드로 두어 도메인 규칙을 엔티티 안에 유지
  - `isLowStorage`는 threshold를 인자로 받아 호출부에서 정책(예: 100MB)을 주입하도록 설계
  - `FileFormat`에 `other(String)`을 두어 확장 가능한 형식 대응
  - `StorageRepository`는 프로토콜만 두고 구현체는 Data 레이어에서 주입하도록 의존성 역전

- **고려했다가 제외한 방식**
  - StorageInfo에 threshold를 넣는 방식 → “저장 공간 부족” 기준이 화면/유스케이스마다 다를 수 있어 호출부에서 넘기도록 함
  - FileFormat을 String만 쓰는 방식 → 타입 안전성과 문서화를 위해 enum으로 고정

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [ ] 정상 플로우 동작 확인
- [ ] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [ ] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [ ] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- StorageInfo의 totalBytes == 0일 때 ratio 0 반환 처리
- RecordingFile 필드 구성(제목/설명/태그 등)이 앱 요구사항과 맞는지
- StorageRepository 메서드 시그니처(특히 deleteFiles의 반환 타입 Int)가 사용처와 맞는지

---

## 📚 참고

- Domain 레이어는 프레임워크 의존 없이 순수 Swift 타입만 사용