### PR TITLE
저장 공간 정보 조회 유스케이스 및 단위 테스트 추가

### DIFF
--- a/ChaGok/Domain/Sources/Entities/StorageInfo.swift
+++ b/ChaGok/Domain/Sources/Entities/StorageInfo.swift
@@ -15,3 +15,6 @@ public struct StorageInfo {
         self.deviceUsedBytes = deviceUsedBytes
     }
 }
+
+extension StorageInfo: Sendable {}
+extension StorageInfo: Equatable {}

--- a/ChaGok/Domain/Sources/Repositories/StorageRepository.swift
+++ b/ChaGok/Domain/Sources/Repositories/StorageRepository.swift
@@ -6,15 +6,4 @@ public protocol StorageRepository: Sendable {
     /// - Returns: 앱·디바이스 저장 공간 정보 (`StorageInfo`)
     /// - Throws: 저장소 접근 실패 시
     func fetchStorageInfo() async throws -> StorageInfo
-
-    /// 녹음 파일 목록을 조회합니다.
-    /// - Returns: 녹음 파일 엔티티 목록 (생성일 등 정렬 방식은 구현체에 따름)
-    /// - Throws: 파일 목록 조회 실패 시
-    func fetchRecordingFiles() async throws -> [VoiceRecord]
-
-    /// 지정한 날짜보다 오래된 녹음 파일을 삭제하고, 삭제된 파일 개수를 반환합니다.
-    /// - Parameter date: 이 날짜보다 이전에 생성된 파일이 삭제됩니다.
-    /// - Returns: 실제로 삭제된 파일 개수
-    /// - Throws: 삭제 중 오류 발생 시
-    func deleteFiles(olderThan date: Date) async throws -> Int
 }

--- a/ChaGok/Domain/Sources/UseCases/FetchStorageInfoUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/FetchStorageInfoUseCase.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// 저장 공간 정보 조회 유스케이스 프로토콜.
+public protocol FetchStorageInfoUseCase: Sendable {
+    /// 저장 공간 정보를 조회합니다.
+    /// - Returns: 앱·디바이스 저장 공간 정보 (`StorageInfo`)
+    /// - Throws: 저장소 접근 실패 시
+    func execute() async throws -> StorageInfo
+}
+
+public struct DefaultFetchStorageInfoUseCase: FetchStorageInfoUseCase {
+    private let storageRepository: StorageRepository
+
+    public init(storageRepository: StorageRepository) {
+        self.storageRepository = storageRepository
+    }
+
+    public func execute() async throws -> StorageInfo {
+        try await storageRepository.fetchStorageInfo()
+    }
+}

--- a/ChaGok/Domain/Tests/Entities/StorageInfoTests.swift
+++ b/ChaGok/Domain/Tests/Entities/StorageInfoTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import Domain
+
+final class StorageInfoTests: XCTestCase {
+
+    // MARK: - 2.1 init으로 생성한 값이 프로퍼티에 그대로 반영된다
+
+    func test_초기화_값이_프로퍼티에_그대로_반영된다() {
+        // Given
+        let appUsedBytes: Int64 = 1_000_000
+        let deviceTotalBytes: Int64 = 128_000_000_000
+        let deviceUsedBytes: Int64 = 64_000_000_000
+
+        // When
+        let storageInfo = StorageInfo(
+            appUsedBytes: appUsedBytes,
+            deviceTotalBytes: deviceTotalBytes,
+            deviceUsedBytes: deviceUsedBytes
+        )
+
+        // Then
+        XCTAssertEqual(storageInfo.appUsedBytes, appUsedBytes)
+        XCTAssertEqual(storageInfo.deviceTotalBytes, deviceTotalBytes)
+        XCTAssertEqual(storageInfo.deviceUsedBytes, deviceUsedBytes)
+    }
+
+    // MARK: - 2.2 경계값으로 생성해도 크래시 없이 보관된다
+
+    func test_경계값_초기화_시_정상_보관된다() {
+        // Given & When & Then: 각 경계값 케이스 검증
+
+        // 케이스 1: appUsedBytes == 0
+        let zeroAppUsed = StorageInfo(
+            appUsedBytes: 0,
+            deviceTotalBytes: 100_000_000_000,
+            deviceUsedBytes: 50_000_000_000
+        )
+        XCTAssertEqual(zeroAppUsed.appUsedBytes, 0)
+
+        // 케이스 2: deviceUsedBytes == deviceTotalBytes (디스크 가득 참)
+        let fullDisk = StorageInfo(
+            appUsedBytes: 1_000_000,
+            deviceTotalBytes: 128_000_000_000,
+            deviceUsedBytes: 128_000_000_000
+        )
+        XCTAssertEqual(fullDisk.deviceUsedBytes, fullDisk.deviceTotalBytes)
+
+        // 케이스 3: 매우 큰 값 (Int64 최대값 근처)
+        let largeValue: Int64 = 9_000_000_000_000_000_000
+        let largeStorageInfo = StorageInfo(
+            appUsedBytes: largeValue,
+            deviceTotalBytes: largeValue,
+            deviceUsedBytes: largeValue
+        )
+        XCTAssertEqual(largeStorageInfo.appUsedBytes, largeValue)
+        XCTAssertEqual(largeStorageInfo.deviceTotalBytes, largeValue)
+        XCTAssertEqual(largeStorageInfo.deviceUsedBytes, largeValue)
+
+        // 케이스 4: Int64 최대값
+        let maxValue: Int64 = Int64.max
+        let maxStorageInfo = StorageInfo(
+            appUsedBytes: maxValue,
+            deviceTotalBytes: maxValue,
+            deviceUsedBytes: maxValue
+        )
+        XCTAssertEqual(maxStorageInfo.appUsedBytes, maxValue)
+        XCTAssertEqual(maxStorageInfo.deviceTotalBytes, maxValue)
+        XCTAssertEqual(maxStorageInfo.deviceUsedBytes, maxValue)
+    }
+}

--- a/ChaGok/Domain/Tests/Mocks/MockStorageRepository.swift
+++ b/ChaGok/Domain/Tests/Mocks/MockStorageRepository.swift
@@ -1,0 +1,28 @@
+import Foundation
+@testable import Domain
+
+/// 테스트 전용 Mock. 동시 접근하지 않으므로 Sendable 요구를 @unchecked로 충족.
+final class MockStorageRepository: StorageRepository, @unchecked Sendable {
+    /// fetchStorageInfo() 호출 시 반환할 결과
+    var storageInfoResult: Result<StorageInfo, Error> = .success(
+        StorageInfo(
+            appUsedBytes: 0,
+            deviceTotalBytes: 0,
+            deviceUsedBytes: 0
+        )
+    )
+
+    /// fetchStorageInfo() 호출 횟수
+    private(set) var fetchStorageInfoCallCount = 0
+
+    func fetchStorageInfo() async throws -> StorageInfo {
+        fetchStorageInfoCallCount += 1
+
+        switch storageInfoResult {
+        case .success(let storageInfo):
+            return storageInfo
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Mocks/MockStorageRepository.swift
+++ b/ChaGok/Domain/Tests/Mocks/MockStorageRepository.swift
@@ -1,8 +1,8 @@
 import Foundation
 @testable import Domain
 
-/// 테스트 전용 Mock. 동시 접근하지 않으므로 Sendable 요구를 @unchecked로 충족.
-final class MockStorageRepository: StorageRepository, @unchecked Sendable {
+/// 테스트 전용 Mock.
+actor MockStorageRepository: StorageRepository {
     /// fetchStorageInfo() 호출 시 반환할 결과
     var storageInfoResult: Result<StorageInfo, Error> = .success(
         StorageInfo(
@@ -13,16 +13,15 @@ final class MockStorageRepository: StorageRepository, @unchecked Sendable {
     )
 
     /// fetchStorageInfo() 호출 횟수
-    private(set) var fetchStorageInfoCallCount = 0
+    var fetchStorageInfoCallCount = 0
 
-    func fetchStorageInfo() async throws -> StorageInfo {
+    func putStorageInfo(_ result: Result<StorageInfo, Error>) {
+        storageInfoResult = result
+    }
+
+    func fetchStorageInfo() throws -> StorageInfo {
         fetchStorageInfoCallCount += 1
 
-        switch storageInfoResult {
-        case .success(let storageInfo):
-            return storageInfo
-        case .failure(let error):
-            throw error
-        }
+        return try storageInfoResult.get()
     }
 }

--- a/ChaGok/Domain/Tests/UseCases/FetchStorageInfoUseCaseTests.swift
+++ b/ChaGok/Domain/Tests/UseCases/FetchStorageInfoUseCaseTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import Domain
+
+final class FetchStorageInfoUseCaseTests: XCTestCase {
+    private var mockRepository: MockStorageRepository!
+    private var useCase: DefaultFetchStorageInfoUseCase!
+
+    override func setUp() {
+        super.setUp()
+        mockRepository = MockStorageRepository()
+        useCase = DefaultFetchStorageInfoUseCase(storageRepository: mockRepository)
+    }
+
+    override func tearDown() {
+        useCase = nil
+        mockRepository = nil
+        super.tearDown()
+    }
+
+    // MARK: - 1.1 성공 시 Repository가 반환한 StorageInfo가 그대로 반환된다
+
+    func test_실행_성공시_저장정보_그대로_반환한다() async throws {
+        // Given
+        let expectedStorageInfo = StorageInfo(
+            appUsedBytes: 1_000_000,
+            deviceTotalBytes: 128_000_000_000,
+            deviceUsedBytes: 64_000_000_000
+        )
+        mockRepository.storageInfoResult = .success(expectedStorageInfo)
+
+        // When
+        let result = try await useCase.execute()
+
+        // Then
+        XCTAssertEqual(result.appUsedBytes, expectedStorageInfo.appUsedBytes)
+        XCTAssertEqual(result.deviceTotalBytes, expectedStorageInfo.deviceTotalBytes)
+        XCTAssertEqual(result.deviceUsedBytes, expectedStorageInfo.deviceUsedBytes)
+    }
+
+    // MARK: - 1.2 실패 시 Repository가 던진 에러가 그대로 전파된다
+
+    func test_실행_실패시_에러가_그대로_전파된다() async {
+        // Given
+        struct TestError: Error, Equatable {}
+        let expectedError = TestError()
+        mockRepository.storageInfoResult = .failure(expectedError)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("에러가 전파되어야 합니다")
+        } catch {
+            XCTAssertTrue(error is TestError, "에러 타입이 일치해야 합니다")
+        }
+    }
+
+    // MARK: - 1.3 execute() 호출 시 fetchStorageInfo()가 정확히 1번 호출된다
+
+    func test_실행시_fetchStorageInfo_한_번만_호출된다() async throws {
+        // Given
+        let expectedStorageInfo = StorageInfo(
+            appUsedBytes: 500_000,
+            deviceTotalBytes: 64_000_000_000,
+            deviceUsedBytes: 32_000_000_000
+        )
+        mockRepository.storageInfoResult = .success(expectedStorageInfo)
+
+        // When
+        _ = try await useCase.execute()
+
+        // Then
+        XCTAssertEqual(mockRepository.fetchStorageInfoCallCount, 1, "fetchStorageInfo()가 정확히 1번 호출되어야 합니다")
+    }
+}

--- a/ChaGok/Domain/Tests/UseCases/FetchStorageInfoUseCaseTests.swift
+++ b/ChaGok/Domain/Tests/UseCases/FetchStorageInfoUseCaseTests.swift
@@ -26,15 +26,13 @@ final class FetchStorageInfoUseCaseTests: XCTestCase {
             deviceTotalBytes: 128_000_000_000,
             deviceUsedBytes: 64_000_000_000
         )
-        mockRepository.storageInfoResult = .success(expectedStorageInfo)
+        await mockRepository.putStorageInfo(.success(expectedStorageInfo))
 
         // When
         let result = try await useCase.execute()
 
         // Then
-        XCTAssertEqual(result.appUsedBytes, expectedStorageInfo.appUsedBytes)
-        XCTAssertEqual(result.deviceTotalBytes, expectedStorageInfo.deviceTotalBytes)
-        XCTAssertEqual(result.deviceUsedBytes, expectedStorageInfo.deviceUsedBytes)
+        XCTAssertEqual(result, expectedStorageInfo)
     }
 
     // MARK: - 1.2 실패 시 Repository가 던진 에러가 그대로 전파된다
@@ -43,7 +41,7 @@ final class FetchStorageInfoUseCaseTests: XCTestCase {
         // Given
         struct TestError: Error, Equatable {}
         let expectedError = TestError()
-        mockRepository.storageInfoResult = .failure(expectedError)
+        await mockRepository.putStorageInfo(.failure(expectedError))
 
         // When & Then
         do {
@@ -63,12 +61,13 @@ final class FetchStorageInfoUseCaseTests: XCTestCase {
             deviceTotalBytes: 64_000_000_000,
             deviceUsedBytes: 32_000_000_000
         )
-        mockRepository.storageInfoResult = .success(expectedStorageInfo)
+        await mockRepository.putStorageInfo(.success(expectedStorageInfo))
 
         // When
         _ = try await useCase.execute()
 
         // Then
-        XCTAssertEqual(mockRepository.fetchStorageInfoCallCount, 1, "fetchStorageInfo()가 정확히 1번 호출되어야 합니다")
+        let storageInfoCallCount = await mockRepository.fetchStorageInfoCallCount
+        XCTAssertEqual(storageInfoCallCount, 1, "fetchStorageInfo()가 정확히 1번 호출되어야 합니다")
     }
 }


### PR DESCRIPTION
## ✨ 기능 요약
> 한 줄로 무엇을 추가/변경했는지

- 저장 공간 정보 조회 유스케이스(FetchStorageInfoUseCase) 추가 및 단위 테스트·Mock 구현

## 📋 구체적인 내용

- 추가/변경된 동작:
  - `FetchStorageInfoUseCase` 프로토콜 및 `DefaultFetchStorageInfoUseCase` 구현
  - `StorageRepository`에서 `fetchStorageInfo()`만 유지 (녹음 파일 관련 메서드 제거)
  - `MockStorageRepository` 테스트용 Mock 추가
  - `FetchStorageInfoUseCaseTests`: 성공·실패·호출 횟수 검증
  - `StorageInfoTests`: 초기화·경계값 검증
- 영향 받는 화면/모듈:
  - ChaGok/Domain (Sources: UseCases, Repositories / Tests: UseCases, Entities, Mocks)

---

## 🔗 연관 이슈

- closed #9

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점

- **선택한 방식**
  - `StorageRepository`를 의존하여 `fetchStorageInfo()` 호출만 담당하는 단일 책임 유스케이스로 구성
  - 프로토콜 + 기본 구현체 패턴으로 테스트 시 Mock 주입 용이
  - Mock은 테스트에서 단일 스레드 사용 전제로 `@unchecked Sendable` 적용

- **고려했다가 제외한 방식**
  - Mock을 actor로 감싸서 Sendable 만족: 테스트 복잡도 증가로 제외

  - 녹음 파일 관련 메서드 제거: 이 모듈의 책임이 아니며, 다른 리포지토리의 책임이라 판단

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [ ] 정상 플로우 동작 확인
- [ ] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [x] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [ ] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- MockStorageRepository의 `@unchecked Sendable` 사용이 테스트 전용으로 타당한지

---

## 📚 참고