### PR TITLE
Feature/Folder의 도메인 Layer (Repository, UseCase) #29

### DIFF
--- a/ChaGok/Domain/Sources/Entities/Folder.swift
+++ b/ChaGok/Domain/Sources/Entities/Folder.swift
@@ -5,16 +5,19 @@ public struct Folder {
     public let path: URL
     public let name: String
     public let createdAt: Date
-
+    public let content: [VoiceNote]
+    
     public init(
         id: String,
         path: URL,
         name: String,
-        createdAt: Date
+        createdAt: Date,
+        content: [VoiceNote]
     ) {
         self.id = id
         self.path = path
         self.name = name
         self.createdAt = createdAt
+        self.content = content
     }
 }

--- a/ChaGok/Domain/Sources/Repositories/FolderRepository.swift
+++ b/ChaGok/Domain/Sources/Repositories/FolderRepository.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public protocol FolderRepository: Sendable {
+    /// 새로운 폴더를 생성합니다.
+    func create(name: String) async throws -> Folder
+
+    /// 모든 폴더 목록을 조회합니다.
+    func fetchAll() async throws -> [Folder]
+
+    /// 폴더 정보를 업데이트합니다. (이름 변경 등)
+    func update(_ folder: Folder) async throws -> Folder
+
+    /// 폴더를 삭제합니다.
+    func delete(byId id: String) async throws
+}

--- a/ChaGok/Domain/Sources/UseCases/CreateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/CreateFolderUseCase.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// 폴더 생성 유스케이스 프로토콜.
+/// FileManager를 통한 실제 디렉토리 생성과 CoreData 모델 저장을 요청합니다.
+public protocol CreateFolderUseCaseImpl {
+    /// 새로운 폴더를 생성합니다.
+    /// - Parameter name: 생성할 폴더의 이름
+    /// - Returns: 생성된 `Folder` 엔티티
+    /// - Throws: 폴더 생성 실패 시
+    func execute(name: String) async throws -> Folder
+}
+
+public struct CreateFolderUseCase: CreateFolderUseCaseImpl {
+
+    private let repository: FolderRepository
+
+    public init(repository: FolderRepository) {
+        self.repository = repository
+    }
+
+    public func execute(name: String) async throws -> Folder {
+        try await repository.create(name: name)
+    }
+}

--- a/ChaGok/Domain/Sources/UseCases/CreateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/CreateFolderUseCase.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// 폴더 생성 유스케이스 프로토콜.
 /// FileManager를 통한 실제 디렉토리 생성과 CoreData 모델 저장을 요청합니다.
-public protocol CreateFolderUseCaseImpl {
+public protocol CreateFolderUseCase {
     /// 새로운 폴더를 생성합니다.
     /// - Parameter name: 생성할 폴더의 이름
     /// - Returns: 생성된 `Folder` 엔티티
@@ -10,7 +10,7 @@ public protocol CreateFolderUseCaseImpl {
     func execute(name: String) async throws -> Folder
 }
 
-public struct CreateFolderUseCase: CreateFolderUseCaseImpl {
+public struct DefaultCreateFolderUseCase: CreateFolderUseCase {
 
     private let repository: FolderRepository
 

--- a/ChaGok/Domain/Sources/UseCases/DeleteFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/DeleteFolderUseCase.swift
@@ -2,14 +2,14 @@ import Foundation
 
 /// 폴더 삭제 유스케이스 프로토콜.
 /// 지정한 폴더의 실제 디렉토리와 CoreData 모델을 삭제합니다.
-public protocol DeleteFolderUseCaseImpl {
+public protocol DeleteFolderUseCase {
     /// ID로 특정 폴더를 삭제합니다.
     /// - Parameter id: 삭제할 폴더의 ID
     /// - Throws: 폴더 삭제 실패 시
     func execute(byId id: String) async throws
 }
 
-public struct DeleteFolderUseCase: DeleteFolderUseCaseImpl {
+public struct DefaultDeleteFolderUseCase: DeleteFolderUseCase {
 
     private let repository: FolderRepository
 

--- a/ChaGok/Domain/Sources/UseCases/DeleteFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/DeleteFolderUseCase.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// 폴더 삭제 유스케이스 프로토콜.
+/// 지정한 폴더의 실제 디렉토리와 CoreData 모델을 삭제합니다.
+public protocol DeleteFolderUseCaseImpl {
+    /// ID로 특정 폴더를 삭제합니다.
+    /// - Parameter id: 삭제할 폴더의 ID
+    /// - Throws: 폴더 삭제 실패 시
+    func execute(byId id: String) async throws
+}
+
+public struct DeleteFolderUseCase: DeleteFolderUseCaseImpl {
+
+    private let repository: FolderRepository
+
+    public init(repository: FolderRepository) {
+        self.repository = repository
+    }
+
+    public func execute(byId id: String) async throws {
+        try await repository.delete(byId: id)
+    }
+}

--- a/ChaGok/Domain/Sources/UseCases/ReadFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/ReadFolderUseCase.swift
@@ -2,14 +2,14 @@ import Foundation
 
 /// 폴더 목록 조회 유스케이스 프로토콜.
 /// CoreData에 저장된 모든 폴더 정보를 조회합니다.
-public protocol ReadFolderUseCaseImpl {
+public protocol ReadFolderUseCase {
     /// 모든 폴더 목록을 조회합니다.
     /// - Returns: 조회된 `Folder` 배열
     /// - Throws: 조회 실패 시
     func execute() async throws -> [Folder]
 }
 
-public struct ReadFolderUseCase: ReadFolderUseCaseImpl {
+public struct DefaultReadFolderUseCase: ReadFolderUseCase {
 
     private let repository: FolderRepository
 

--- a/ChaGok/Domain/Sources/UseCases/ReadFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/ReadFolderUseCase.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// 폴더 목록 조회 유스케이스 프로토콜.
+/// CoreData에 저장된 모든 폴더 정보를 조회합니다.
+public protocol ReadFolderUseCaseImpl {
+    /// 모든 폴더 목록을 조회합니다.
+    /// - Returns: 조회된 `Folder` 배열
+    /// - Throws: 조회 실패 시
+    func execute() async throws -> [Folder]
+}
+
+public struct ReadFolderUseCase: ReadFolderUseCaseImpl {
+
+    private let repository: FolderRepository
+
+    public init(repository: FolderRepository) {
+        self.repository = repository
+    }
+
+    public func execute() async throws -> [Folder] {
+        try await repository.fetchAll()
+    }
+}

--- a/ChaGok/Domain/Sources/UseCases/UpdateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/UpdateFolderUseCase.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// 폴더 정보 업데이트 유스케이스 프로토콜.
 /// 폴더 이름 변경 등 기존 폴더의 정보를 수정합니다.
-public protocol UpdateFolderUseCaseImpl {
+public protocol UpdateFolderUseCase {
     /// 폴더 정보를 업데이트합니다.
     /// - Parameter folder: 업데이트할 `Folder` 엔티티
     /// - Returns: 업데이트된 `Folder` 엔티티
@@ -10,7 +10,7 @@ public protocol UpdateFolderUseCaseImpl {
     func execute(_ folder: Folder) async throws -> Folder
 }
 
-public struct UpdateFolderUseCase: UpdateFolderUseCaseImpl {
+public struct DefaultUpdateFolderUseCase: UpdateFolderUseCase {
 
     private let repository: FolderRepository
     

--- a/ChaGok/Domain/Sources/UseCases/UpdateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/UpdateFolderUseCase.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// 폴더 정보 업데이트 유스케이스 프로토콜.
+/// 폴더 이름 변경 등 기존 폴더의 정보를 수정합니다.
+public protocol UpdateFolderUseCaseImpl {
+    /// 폴더 정보를 업데이트합니다.
+    /// - Parameter folder: 업데이트할 `Folder` 엔티티
+    /// - Returns: 업데이트된 `Folder` 엔티티
+    /// - Throws: 업데이트 실패 시
+    func execute(_ folder: Folder) async throws -> Folder
+}
+
+public struct UpdateFolderUseCase: UpdateFolderUseCaseImpl {
+
+    private let repository: FolderRepository
+    
+    public init(repository: FolderRepository) {
+        self.repository = repository
+    }
+    
+    public func execute(_ folder: Folder) async throws -> Folder {
+        try await repository.update(folder)
+    }
+}


### PR DESCRIPTION
## ✨ 기능 요약
> 한 줄로 무엇을 추가/변경했는지

Domain Layer의 FolderRepository 및 CRUD UseCase 정의

## 📋 구체적인 내용
- **추가/변경된 동작:**
  - `FolderRepository`: Folder 구현체 로직 Protocol 정의
  - `CreateFolderUseCase`: FolderRepository create 관련 비지니스 로직 정의
  - `ReadFolderUseCase`: FolderRepository fetchAll 관련 비지니스 로직 정의
  - `UpdateFolderUseCase`: FolderRepository update 관련 비지니스 로직 정의
  - `DeleteFolderUseCase`: FolderRepository delete 관련 비지니스 로직 정의
---

## 🔗 연관 이슈

-open #29

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점

- **선택한 방식**
   폴더를 만드는 과정에서는 async/await이 필요없지만 CoreData와 데이터의 일관성을 위해선 필요하다는 판단.
- **고려했다가 제외한 방식**
   FolderUseCase로 통합 할까도 했지만 향후 Folder에 추가 기능을 고려하여 CRUD 각가 UseCase로 분리
---

📌 Next Step (다음 단계)
 Data Layer: DefaultFolderRepository 구현 (FileManager 디렉토리 생성 + CoreData 모델 저장)
 CoreData: FolderEntity 모델 정의 (.xcdatamodeld)
 DI Container: UseCase ↔ Repository 의존성 조립

## 👀 리뷰 포인트

- [ ] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**
   우리 Project의 성공을 기원합니다.

- 통합 테스트 testInitializeFolderExists 함수 workFlow 

---

## 📚 참고

- 중복 폴더 생성 Case는 생성자에서 분기 처리를 통해 막고 있음
- root Directory path가 생성 되지 않는 Case -> 일단은 fatalError로 크래시 후 출력 
향 후 UI/UX 방향에 따른 예외처리 throw필요