### PR TITLE
Folder UseCase 및 Repository Typed Throws 도입합니다.

### DIFF
--- a/ChaGok/Domain/Sources/Errors/Folders/CreateFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/CreateFolderUseCaseError.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public enum CreateFolderUseCaseError: LocalizedError, Sendable {
+    /// 작업 취소의 경우
+    case cancelled
+    /// 동일한 이름의 폴더가 이미 존재하는 경우 (생성, 수정 시 발생)
+    case duplicateName
+    /// 폴더 생성이 실패한 경우
+    case createFailed
+    /// 기타 알 수 없는 에러
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+            case .cancelled:
+                nil
+            case .duplicateName:
+                "이미 동일한 이름의 폴더가 존재합니다."
+            case .createFailed:
+                "폴더 생성에 실패했습니다."
+            case .unknown(let error):
+                error.localizedDescription
+        }
+    }
+}

--- a/ChaGok/Domain/Sources/Errors/Folders/FolderRepositoryError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/FolderRepositoryError.swift
@@ -3,7 +3,7 @@ import Foundation
 public enum FolderRepositoryError: LocalizedError, Sendable {
     /// 작업 취소의 경우
     case cancelled
-    /// 폴더를 찾을 수 없는 경우 (조회, 수정, 삭제 시 발생)
+    /// 폴더를 찾을 수 없는 경우 (조회, 수정 시 발생)
     case notFound
     /// 동일한 이름의 폴더가 이미 존재하는 경우 (생성, 수정 시 발생)
     case duplicateName

--- a/ChaGok/Domain/Sources/Errors/Folders/FolderRepositoryError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/FolderRepositoryError.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public enum FolderRepositoryError: LocalizedError, Sendable {
+    /// 작업 취소의 경우
+    case cancelled
+    /// 폴더를 찾을 수 없는 경우 (조회, 수정, 삭제 시 발생)
+    case notFound
+    /// 동일한 이름의 폴더가 이미 존재하는 경우 (생성, 수정 시 발생)
+    case duplicateName
+    /// 폴더 생성이 실패한 경우
+    case createFailed
+    /// 폴더 조회가 실패한 경우
+    case fetchFailed
+    /// 폴더 업데이트가 실패한 경우
+    case updateFailed
+    /// 기타 알 수 없는 에러
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+            case .cancelled:
+                nil
+            case .notFound:
+                "해당 폴더를 찾을 수 없습니다."
+            case .duplicateName:
+                "이미 동일한 이름의 폴더가 존재합니다."
+            case .createFailed:
+                "폴더 생성에 실패했습니다."
+            case .fetchFailed:
+                "폴더 목록을 불러오는데 실패했습니다."
+            case .updateFailed:
+                "폴더 정보를 수정하는데 실패했습니다."
+            case .unknown(let error):
+                error.localizedDescription
+        }
+    }
+}

--- a/ChaGok/Domain/Sources/Errors/Folders/ReadFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/ReadFolderUseCaseError.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public enum ReadFolderUseCaseError: LocalizedError, Sendable {
+    /// 작업 취소의 경우
+    case cancelled
+    /// 폴더를 찾을 수 없는 경우 (조회, 수정 시 발생)
+    case notFound
+    /// 폴더 조회가 실패한 경우
+    case fetchFailed
+    /// 기타 알 수 없는 에러
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+            case .cancelled:
+                nil
+            case .notFound:
+                "해당 폴더를 찾을 수 없습니다."
+            case .fetchFailed:
+                "폴더 목록을 불러오는데 실패했습니다."
+            case .unknown(let error):
+                error.localizedDescription
+        }
+    }
+}

--- a/ChaGok/Domain/Sources/Errors/Folders/UpdateFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/UpdateFolderUseCaseError.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public enum UpdateFolderUseCaseError: LocalizedError, Sendable {
+    /// 작업 취소의 경우
+    case cancelled
+    /// 폴더를 찾을 수 없는 경우 (조회, 수정 시 발생)
+    case notFound
+    /// 동일한 이름의 폴더가 이미 존재하는 경우 (생성, 수정 시 발생)
+    case duplicateName
+    /// 폴더 업데이트가 실패한 경우
+    case updateFailed
+    /// 기타 알 수 없는 에러
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+            case .cancelled:
+                nil
+            case .notFound:
+                "해당 폴더를 찾을 수 없습니다."
+            case .duplicateName:
+                "이미 동일한 이름의 폴더가 존재합니다."
+            case .updateFailed:
+                "폴더 정보를 수정하는데 실패했습니다."
+            case .unknown(let error):
+                error.localizedDescription
+        }
+    }
+}

--- a/ChaGok/Domain/Sources/Repositories/FolderRepository.swift
+++ b/ChaGok/Domain/Sources/Repositories/FolderRepository.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// 폴더(Folder) 엔티티의 CRUD를 담당하는 리포지토리 프로토콜.
+/// 폴더(Folder) 엔티티의 CRU 를 담당하는 리포지토리 프로토콜.
 public protocol FolderRepository: Sendable {
     /// 새로운 폴더를 생성합니다.
     /// - Parameter name: 생성할 폴더의 이름

--- a/ChaGok/Domain/Sources/Repositories/FolderRepository.swift
+++ b/ChaGok/Domain/Sources/Repositories/FolderRepository.swift
@@ -5,22 +5,18 @@ public protocol FolderRepository: Sendable {
     /// 새로운 폴더를 생성합니다.
     /// - Parameter name: 생성할 폴더의 이름
     /// - Returns: 생성된 폴더 엔티티
-    /// - Throws: 폴더 생성 실패 시
-    func create(name: String) async throws -> Folder
+    /// - Throws: `FolderRepositoryError.createFailed`, `.duplicateName` 등
+    func create(name: String) async throws(FolderRepositoryError) -> Folder
 
     /// 모든 폴더 목록을 조회합니다.
     /// - Returns: 조회된 폴더 목록
-    /// - Throws: 조회 실패 시
-    func fetchAll() async throws -> [Folder]
+    /// - Throws: `FolderRepositoryError.fetchFailed` 등
+    func fetchAll() async throws(FolderRepositoryError) -> [Folder]
 
     /// 폴더 정보를 업데이트합니다. (이름 변경 등)
     /// - Parameter folder: 업데이트할 폴더 엔티티
     /// - Returns: 업데이트된 폴더 엔티티
-    /// - Throws: 업데이트 실패 시
-    func update(_ folder: Folder) async throws -> Folder
+    /// - Throws: `FolderRepositoryError.updateFailed`, `.notFound`, `.duplicateName` 등
+    func update(_ folder: Folder) async throws(FolderRepositoryError) -> Folder
 
-    /// 특정 폴더를 삭제합니다.
-    /// - Parameter id: 삭제할 폴더의 ID
-    /// - Throws: 삭제 실패 시
-    func delete(byId id: UUID) async throws
 }

--- a/ChaGok/Domain/Sources/UseCases/Folders/CreateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/CreateFolderUseCase.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Core
 
 /// 폴더 생성 유스케이스 프로토콜.
 /// FileManager를 통한 실제 디렉토리 생성과 CoreData 모델 저장을 요청합니다.
@@ -7,7 +8,7 @@ public protocol CreateFolderUseCase: Sendable {
     /// - Parameter name: 생성할 폴더의 이름
     /// - Returns: 생성된 `Folder` 엔티티
     /// - Throws: 폴더 생성 실패 시
-    func execute(name: String) async throws -> Folder
+    func execute(name: String) async throws(CreateFolderUseCaseError) -> Folder
 }
 
 public struct DefaultCreateFolderUseCase: CreateFolderUseCase {
@@ -18,7 +19,23 @@ public struct DefaultCreateFolderUseCase: CreateFolderUseCase {
         self.repository = repository
     }
 
-    public func execute(name: String) async throws -> Folder {
-        try await repository.create(name: name)
+    public func execute(name: String) async throws(CreateFolderUseCaseError) -> Folder {
+        typealias UseCaseError = CreateFolderUseCaseError
+        if Task.isCancelled { throw UseCaseError.cancelled }
+        do {
+            return try await repository.create(name: name)
+        } catch {
+            AppLogger.error(error)
+            switch error {
+                case .cancelled:
+                    throw UseCaseError.cancelled
+                case .duplicateName:
+                    throw UseCaseError.duplicateName
+                case .createFailed:
+                    throw UseCaseError.createFailed
+                case .unknown, .notFound, .fetchFailed, .updateFailed:
+                    throw UseCaseError.unknown(error)
+            }
+        }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/Folders/ReadFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/ReadFolderUseCase.swift
@@ -3,7 +3,7 @@ import Core
 
 /// 폴더 목록 조회 유스케이스 프로토콜.
 /// CoreData에 저장된 모든 폴더 정보를 조회합니다.
-public protocol ReadFolderUseCase {
+public protocol ReadFolderUseCase: Sendable {
     /// 모든 폴더 목록을 조회합니다.
     /// - Returns: 조회된 `Folder` 배열
     /// - Throws: 조회 실패 시

--- a/ChaGok/Domain/Sources/UseCases/Folders/ReadFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/ReadFolderUseCase.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Core
 
 /// 폴더 목록 조회 유스케이스 프로토콜.
 /// CoreData에 저장된 모든 폴더 정보를 조회합니다.
@@ -6,7 +7,7 @@ public protocol ReadFolderUseCase {
     /// 모든 폴더 목록을 조회합니다.
     /// - Returns: 조회된 `Folder` 배열
     /// - Throws: 조회 실패 시
-    func execute() async throws -> [Folder]
+    func execute() async throws(ReadFolderUseCaseError) -> [Folder]
 }
 
 public struct DefaultReadFolderUseCase: ReadFolderUseCase {
@@ -17,7 +18,20 @@ public struct DefaultReadFolderUseCase: ReadFolderUseCase {
         self.repository = repository
     }
 
-    public func execute() async throws -> [Folder] {
-        try await repository.fetchAll()
+    public func execute() async throws(ReadFolderUseCaseError) -> [Folder] {
+        typealias UseCaseError = ReadFolderUseCaseError
+        if Task.isCancelled { throw UseCaseError.cancelled }
+        do {
+            return try await repository.fetchAll()
+        } catch {
+            AppLogger.error(error)
+            switch error {
+                case .cancelled: throw UseCaseError.cancelled
+                case .notFound: throw UseCaseError.notFound
+                case .fetchFailed: throw UseCaseError.fetchFailed
+                case .unknown, .updateFailed, .createFailed, .duplicateName:
+                    throw UseCaseError.unknown(error)
+            }
+        }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/Folders/UpdateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/UpdateFolderUseCase.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Core
 
 /// 폴더 정보 업데이트 유스케이스 프로토콜.
 /// 폴더 이름 변경 등 기존 폴더의 정보를 수정합니다.
@@ -7,7 +8,7 @@ public protocol UpdateFolderUseCase: Sendable {
     /// - Parameter folder: 업데이트할 `Folder` 엔티티
     /// - Returns: 업데이트된 `Folder` 엔티티
     /// - Throws: 업데이트 실패 시
-    func execute(_ folder: Folder) async throws -> Folder
+    func execute(_ folder: Folder) async throws(UpdateFolderUseCaseError) -> Folder
 }
 
 public struct DefaultUpdateFolderUseCase: UpdateFolderUseCase {
@@ -18,7 +19,21 @@ public struct DefaultUpdateFolderUseCase: UpdateFolderUseCase {
         self.repository = repository
     }
 
-    public func execute(_ folder: Folder) async throws -> Folder {
-        try await repository.update(folder)
+    public func execute(_ folder: Folder) async throws(UpdateFolderUseCaseError) -> Folder {
+        typealias UseCaseError = UpdateFolderUseCaseError
+        if Task.isCancelled { throw UseCaseError.cancelled }
+        do {
+            return try await repository.update(folder)
+        } catch {
+            AppLogger.error(error)
+            switch error {
+                case .cancelled: throw UseCaseError.cancelled
+                case .duplicateName: throw UseCaseError.duplicateName
+                case .notFound: throw UseCaseError.notFound
+                case .updateFailed: throw UseCaseError.updateFailed
+                case .unknown, .fetchFailed, .createFailed:
+                    throw UseCaseError.unknown(error)
+            }
+        }
     }
 }


### PR DESCRIPTION
## ✨ 작업 요약
> 한 줄로 무엇을 추가/변경했는지

- 폴더 관련 도메인 레이어(UseCase, Repository)에 `Typed Throws`를 적용하여 에러 핸들링의 타입 안정성과 가독성을 개선했습니다.
 또한 delete 관련 함수를 제거했습니다.

## 📋 구체적인 내용
- 추가/변경된 동작:
  - **Typed Throws 적용**: 
    - `CreateFolderUseCase`, `ReadFolderUseCase`, `UpdateFolderUseCase`, `FolderRepository` 전반에 Typed Throws를 도입하여 발생 가능한 에러를 명시적으로 처리했습니다.
  - **세분화된 에러 정의**:
    - 각 기능별 전용 에러 타입(`CreateFolderUseCaseError`, `ReadFolderUseCaseError` 등)을 정의하고 상세 에러 케이스를 추가했습니다.
    - 각 에러에 `description`을 추가하여 에러 메시지 관리를 용이하게 했습니다.
- 영향 받는 화면/모듈: Domain Layer

---

## 🔗 연관 이슈

- open #63 

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
  - **Typed Throws 도입**: 호출부에서 발생 가능한 에러를 컴파일 타임에 확정하여 안정성 강화
  - **기능별 에러 분리**: 각 기능에 최적화된 에러 케이스만 노출하여 SRP(단일 책임 원칙) 준수
  - **영구 삭제 제거**: 비즈니스 정책(휴지통 우선)을 코드 레벨에서 강제

- **고려했다가 제외한 방식**
  - **통합 에러 사용**: 불필요한 에러 분기 처리를 피하기 위해 기능별 분리 방식 채택
---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [x] 정상 플로우 동작 확인
- [x] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [ ] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [ ] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- Typed Throw 적용 Error Case 목록 및 Error do-Catch 연결 부분

---

## 📚 참고

- 없음
