### PR TITLE
(폴더/워크스페이스, 기본 폴더) UseCase, Repository Unit Test 검증 및 예외 처리를 리펙토링 합니다. 

### DIFF
--- a/ChaGok/Domain/Sources/Errors/Folders/CreateFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/CreateFolderUseCaseError.swift
@@ -3,6 +3,8 @@ import Foundation
 public enum CreateFolderUseCaseError: LocalizedError, Sendable {
     /// 작업 취소의 경우
     case cancelled
+    /// 유효하지 않은 이름의 경우
+    case invalidName
     /// 동일한 이름의 폴더가 이미 존재하는 경우 (생성, 수정 시 발생)
     case duplicateName
     /// 폴더 생성이 실패한 경우
@@ -14,6 +16,8 @@ public enum CreateFolderUseCaseError: LocalizedError, Sendable {
         switch self {
             case .cancelled:
                 nil
+            case .invalidName:
+                "폴더 이름을 한 글자 이상 입력해 주세요."
             case .duplicateName:
                 "이미 동일한 이름의 폴더가 존재합니다."
             case .createFailed:
@@ -22,4 +26,18 @@ public enum CreateFolderUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: FolderRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .duplicateName:
+                self = .duplicateName
+            case .createFailed:
+                self = .createFailed
+            default:
+                self = .unknown(error)
+        }
+    }
+
 }

--- a/ChaGok/Domain/Sources/Errors/Folders/FetchBasicFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/FetchBasicFolderUseCaseError.swift
@@ -22,4 +22,18 @@ public enum FetchBasicFolderUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: WorkSpaceBasicFolderRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .notFound:
+                self = .notFound
+            case .createFailed:
+                self = .createFailed
+            case .unknown(let err):
+                self = .unknown(err)
+        }
+    }
+
 }

--- a/ChaGok/Domain/Sources/Errors/Folders/ReadFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/ReadFolderUseCaseError.swift
@@ -22,4 +22,18 @@ public enum ReadFolderUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: FolderRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .notFound:
+                self = .notFound
+            case .fetchFailed:
+                self = .fetchFailed
+            default:
+                self = .unknown(error)
+        }
+    }
+
 }

--- a/ChaGok/Domain/Sources/Errors/Folders/UpdateFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/UpdateFolderUseCaseError.swift
@@ -3,6 +3,8 @@ import Foundation
 public enum UpdateFolderUseCaseError: LocalizedError, Sendable {
     /// 작업 취소의 경우
     case cancelled
+    /// 유효하지 않음 이름의 경우
+    case invalidName
     /// 폴더를 찾을 수 없는 경우 (조회, 수정 시 발생)
     case notFound
     /// 동일한 이름의 폴더가 이미 존재하는 경우 (생성, 수정 시 발생)
@@ -16,6 +18,8 @@ public enum UpdateFolderUseCaseError: LocalizedError, Sendable {
         switch self {
             case .cancelled:
                 nil
+            case .invalidName:
+                "폴더 이름을 한 글자 이상 입력해 주세요."
             case .notFound:
                 "해당 폴더를 찾을 수 없습니다."
             case .duplicateName:
@@ -26,4 +30,20 @@ public enum UpdateFolderUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: FolderRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .duplicateName:
+                self = .duplicateName
+            case .notFound:
+                self = .notFound
+            case .updateFailed:
+                self = .updateFailed
+            default:
+                self = .unknown(error)
+        }
+    }
+
 }

--- a/ChaGok/Domain/Sources/Errors/WorkSpace/FetchRootUrlUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/WorkSpace/FetchRootUrlUseCaseError.swift
@@ -14,4 +14,14 @@ public enum FetchRootUrlUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: WorkSpaceRootURLRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .unknown(let error):
+                self = .unknown(error)
+        }
+    }
+
 }

--- a/ChaGok/Domain/Sources/UseCases/Folders/CreateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/CreateFolderUseCase.swift
@@ -22,20 +22,17 @@ public struct DefaultCreateFolderUseCase: CreateFolderUseCase {
     public func execute(name: String) async throws(CreateFolderUseCaseError) -> Folder {
         typealias UseCaseError = CreateFolderUseCaseError
         if Task.isCancelled { throw UseCaseError.cancelled }
+
+        // invalidName 유효성 검증
+        guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw UseCaseError.invalidName
+        }
+
         do {
             return try await repository.create(name: name)
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled:
-                    throw UseCaseError.cancelled
-                case .duplicateName:
-                    throw UseCaseError.duplicateName
-                case .createFailed:
-                    throw UseCaseError.createFailed
-                case .unknown, .notFound, .fetchFailed, .updateFailed:
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/Folders/FetchBasicFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/FetchBasicFolderUseCase.swift
@@ -28,16 +28,7 @@ public struct DefaultFetchBasicFolderUseCase: FetchBasicFolderUseCase {
             return try await repository.fetchOrCreateBasicFolder()
         } catch let error {
             AppLogger.error(error)
-            switch error {
-                case .cancelled:
-                    throw UseCaseError.cancelled
-                case .createFailed:
-                    throw UseCaseError.createFailed
-                case .notFound:
-                    throw UseCaseError.notFound
-                case .unknown(let error):
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/Folders/FetchBasicFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/FetchBasicFolderUseCase.swift
@@ -22,7 +22,7 @@ public struct DefaultFetchBasicFolderUseCase: FetchBasicFolderUseCase {
     @discardableResult
     public func execute() async throws(FetchBasicFolderUseCaseError) -> Folder {
         typealias UseCaseError = FetchBasicFolderUseCaseError
-        if Task.isCancelled { throw FetchBasicFolderUseCaseError.cancelled }
+        if Task.isCancelled { throw UseCaseError.cancelled }
         do {
             // 기본 폴더 생성/확인
             return try await repository.fetchOrCreateBasicFolder()

--- a/ChaGok/Domain/Sources/UseCases/Folders/ReadFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/ReadFolderUseCase.swift
@@ -25,13 +25,8 @@ public struct DefaultReadFolderUseCase: ReadFolderUseCase {
             return try await repository.fetchAll()
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled: throw UseCaseError.cancelled
-                case .notFound: throw UseCaseError.notFound
-                case .fetchFailed: throw UseCaseError.fetchFailed
-                case .unknown, .updateFailed, .createFailed, .duplicateName:
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
+
 }

--- a/ChaGok/Domain/Sources/UseCases/Folders/UpdateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/UpdateFolderUseCase.swift
@@ -22,18 +22,18 @@ public struct DefaultUpdateFolderUseCase: UpdateFolderUseCase {
     public func execute(_ folder: Folder) async throws(UpdateFolderUseCaseError) -> Folder {
         typealias UseCaseError = UpdateFolderUseCaseError
         if Task.isCancelled { throw UseCaseError.cancelled }
+
+        // invalidName 유효성 검증
+        guard !folder.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw UseCaseError.invalidName
+        }
+
         do {
             return try await repository.update(folder)
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled: throw UseCaseError.cancelled
-                case .duplicateName: throw UseCaseError.duplicateName
-                case .notFound: throw UseCaseError.notFound
-                case .updateFailed: throw UseCaseError.updateFailed
-                case .unknown, .fetchFailed, .createFailed:
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
+
 }

--- a/ChaGok/Domain/Sources/UseCases/WorkSpace/FetchRootUrlUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/WorkSpace/FetchRootUrlUseCase.swift
@@ -20,18 +20,12 @@ public struct DefaultFetchRootUrlUseCase: FetchRootUrlUseCase {
 
     public func execute() async throws(FetchRootUrlUseCaseError) -> URL {
         typealias UseCaseError = FetchRootUrlUseCaseError
-        if Task.isCancelled { throw FetchRootUrlUseCaseError.cancelled }
+        if Task.isCancelled { throw UseCaseError.cancelled }
         do {
-            // root URL 가져오기
             return try await repository.fetchRootURL()
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled:
-                    throw UseCaseError.cancelled
-                case .unknown(let error):
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
 }

--- a/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
@@ -1,0 +1,291 @@
+import XCTest
+@testable import Domain
+
+final class CreateFolderUseCaseTest: XCTestCase {
+    typealias UseCaseError = CreateFolderUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension CreateFolderUseCaseTest {
+    /// 성공 Case: Repository가 정상적으로 Folder를 반환할 때
+    func test_execute_returnsFolder_whenRepositorySucceeds() async throws {
+        // Given
+        let expectedName = "New Folder"
+        let expectedFolder = Folder(path: URL(fileURLWithPath: "/test"), name: expectedName)
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .success(expectedFolder)
+            )
+        )
+
+        // When
+        let folder = try await useCase.execute(name: expectedName)
+
+        // Then
+        XCTAssertEqual(folder.name, expectedName)
+        XCTAssertEqual(folder.id, expectedFolder.id)
+    }
+}
+
+// MARK: - Error Cases
+
+extension CreateFolderUseCaseTest {
+    /// 유효하지 않은 이름 Case: 폴더 이름이 비어있거나 공백일 때 .invalidName 확인
+    func test_execute_throwsInvalidName_whenNameIsEmpty() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository()
+        )
+        let invalidNames = ["", " ", "  \n  "]
+
+        // When & Then
+        await withTaskGroup(of: Void.self) { group in
+            for name in invalidNames {
+                group.addTask {
+                    do {
+                        _ = try await useCase.execute(name: name)
+                        XCTFail("이름이 비어있는 경우 .invalidName 에러가 발생해야 합니다. (input: '\(name)')")
+                    } catch UseCaseError.invalidName {
+                        // Success
+                    } catch {
+                        XCTFail("Expected .invalidName, got \(error) for name: '\(name)'")
+                    }
+                }
+            }
+        }
+    }
+
+    /// 이름 중복 Case: 이미 같은 이름의 폴더가 존재할 때 .duplicateName 대칭 확인
+    func test_execute_throwsDuplicateName_whenRepositoryReturnsDuplicateName() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .duplicateName
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "Existing Folder")
+            XCTFail("중복 이름인 경우 .duplicateName 에러가 발생해야 합니다.")
+        } catch UseCaseError.duplicateName {
+            // Success
+        } catch {
+            XCTFail("Expected .duplicateName, got \(error)")
+        }
+    }
+
+    /// 생성 실패 Case: repository가 .createFailed를 반환할 때
+    func test_execute_throwsCreateFailed_whenRepositoryReturnsCreateFailed() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .createFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "New Folder")
+            XCTFail("생성 실패의 경우 .createFailed 에러가 발생해야 합니다.")
+        } catch UseCaseError.createFailed {
+            // Success
+        } catch {
+            XCTFail("Expected .createFailed, got \(error)")
+        }
+    }
+
+    /// 찾을 수 없는 경우 Case: Repository에서 .notFound를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsNotFound() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .notFound
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "Existing Folder")
+            XCTFail("찾을 수 없을 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .notFound:
+                    break // Success
+                default:
+                    XCTFail("Expected .notFound, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 수정 실패 Case: Repository에서 .updateFailed를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsUpdateFailed() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .updateFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "Existing Folder")
+            XCTFail("찾을 수 없을 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .updateFailed:
+                    break // Success
+                default:
+                    XCTFail("Expected .updateFailed, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 조회 실패 Case: Repository에서 .fetchFailed를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsFetchFailed() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .fetchFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "Existing Folder")
+            XCTFail("찾을 수 없을 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .fetchFailed:
+                    break // Success
+                default:
+                    XCTFail("Expected .fetchFailed, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+        // Given
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .unknown(dummyError)
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "Unknown Test")
+            XCTFail("알 수 없는 에러 발생 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부에는 FolderRepositoryError가 포함되어야 합니다.")
+            }
+
+            switch repoError {
+                case .unknown(let underlyingError):
+                    XCTAssertTrue(underlyingError is Dummy)
+                default:
+                    XCTFail("Expected .unknown underlying error, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+}
+
+// MARK: - Error Cases ( Cancelled )
+
+extension CreateFolderUseCaseTest {
+
+    /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
+    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .cancelled
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "Existing Folder")
+            XCTFail("작업 취소의 경우 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case: 작업이 즉시 취소된 경우 execute 함수 내부 isCancelled를 검증한다
+    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .success(Folder(path: URL.applicationSupportDirectory, name: "test"))
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute(name: "Cancel Test") }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업이 즉시 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case (During Execution): 작업 도중 Task가 취소된 경우
+    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .success(Folder(path: URL(fileURLWithPath: "/"), name: "test")),
+                delay: 100_000_000 // 0.1초 지연
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute(name: "Cancel Test") }
+
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기 후 취소
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+}

--- a/ChaGok/Domain/Tests/Folders/MockFolderRepository.swift
+++ b/ChaGok/Domain/Tests/Folders/MockFolderRepository.swift
@@ -1,0 +1,78 @@
+import Foundation
+@testable import Domain
+
+struct MockFolderRepository: FolderRepository {
+
+    enum Behavior<T: Sendable>: Sendable {
+        case success(T)         // 성공한 경우
+        case cancelled          // 작업 취소의 경우
+        case notFound           // 폴더를 찾을 수 없는 경우
+        case duplicateName      // 이름이 중복된 경우
+        case createFailed       // 생성에 실패한 경우
+        case fetchFailed        // 조회에 실패한 경우
+        case updateFailed       // 수정에 실패한 경우
+        case unknown(Error)     // 알 수 없는 오류의 경우
+    }
+
+    var createBehavior: Behavior<Folder>?
+    var fetchAllBehavior: Behavior<[Folder]>?
+    var updateBehavior: Behavior<Folder>?
+
+    var delay: UInt64 = 0
+
+    init(
+        createBehavior: Behavior<Folder>? = nil,
+        fetchAllBehavior: Behavior<[Folder]>? = nil,
+        updateBehavior: Behavior<Folder>? = nil,
+        delay: UInt64 = 0
+    ) {
+        self.createBehavior = createBehavior
+        self.fetchAllBehavior = fetchAllBehavior
+        self.updateBehavior = updateBehavior
+        self.delay = delay
+    }
+
+    func create(name: String) async throws(FolderRepositoryError) -> Folder {
+        try await handleBehavior(createBehavior, methodName: "create")
+    }
+
+    func fetchAll() async throws(FolderRepositoryError) -> [Folder] {
+        try await handleBehavior(fetchAllBehavior, methodName: "fetchAll")
+    }
+
+    func update(_ folder: Folder) async throws(FolderRepositoryError) -> Folder {
+        try await handleBehavior(updateBehavior, methodName: "update")
+    }
+}
+
+// MARK: - Helper Function
+
+extension MockFolderRepository {
+    private func handleBehavior<T>(
+        _ behavior: Behavior<T>?,
+        methodName: String
+    ) async throws(FolderRepositoryError) -> T {
+        if delay > 0 {
+            try? await Task.sleep(nanoseconds: delay)
+        }
+
+        if Task.isCancelled {
+            throw .cancelled
+        }
+
+        guard let behavior = behavior else {
+            fatalError("\(methodName)의 Behavior가 설정되지 않았습니다.")
+        }
+
+        switch behavior {
+            case .success(let value): return value
+            case .cancelled: throw .cancelled
+            case .notFound: throw .notFound
+            case .duplicateName: throw .duplicateName
+            case .createFailed: throw .createFailed
+            case .fetchFailed: throw .fetchFailed
+            case .updateFailed: throw .updateFailed
+            case .unknown(let error): throw .unknown(error)
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Folders/ReadFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/ReadFolderUseCaseTest.swift
@@ -1,0 +1,242 @@
+import XCTest
+@testable import Domain
+
+final class ReadFolderUseCaseTest: XCTestCase {
+    typealias UseCaseError = ReadFolderUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension ReadFolderUseCaseTest {
+    /// 성공 Case: 모든 폴더 목록을 정상적으로 반환할 때
+    func test_execute_returnsFolders_whenRepositorySucceeds() async throws {
+        // Given
+        let expectedFolders = [
+            Folder(path: URL(fileURLWithPath: "/1"), name: "Folder 1"),
+            Folder(path: URL(fileURLWithPath: "/2"), name: "Folder 2")
+        ]
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .success(expectedFolders)
+            )
+        )
+
+        // When
+        let folders = try await useCase.execute()
+
+        // Then
+        XCTAssertEqual(folders.count, 2)
+        XCTAssertEqual(folders[0].name, "Folder 1")
+        XCTAssertEqual(folders[0].id, expectedFolders[0].id)
+        XCTAssertEqual(folders[1].name, "Folder 2")
+        XCTAssertEqual(folders[1].id, expectedFolders[1].id)
+    }
+}
+
+// MARK: - Error Cases
+
+extension ReadFolderUseCaseTest {
+
+    /// 조회 실패 Case: fetchFailed 에러 전파 확인
+    func test_execute_throwsFetchFailed_whenRepositoryReturnsFetchFailed() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .fetchFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("조회 실패 시 .fetchFailed 에러가 발생해야 합니다.")
+        } catch UseCaseError.fetchFailed {
+            // Success
+        } catch {
+            XCTFail("Expected .fetchFailed, got \(error)")
+        }
+    }
+
+    /// 찾을 수 없는 경우 Case: Repository에서 .notFound를 반환할 때 동일하게 전파되는지 확인
+    func test_execute_throwsNotFound_whenRepositoryReturnsNotFound() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .notFound
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("찾을 수 없을 시 .notFound 에러가 발생해야 합니다.")
+        } catch UseCaseError.notFound {
+            // Success
+        } catch {
+            XCTFail("Expected .notFound, got \(error)")
+        }
+    }
+
+    /// 매핑 확인 Case: Repository에서 .createFailed를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsCreateFailed() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .createFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("생성 실패 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .createFailed:
+                    break // Success
+                default:
+                    XCTFail("Expected .createFailed, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 매핑 확인 Case: Repository에서 .updateFailed를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsUpdateFailed() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .updateFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("수정 실패 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .updateFailed:
+                    break // Success
+                default:
+                    XCTFail("Expected .updateFailed, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+        // Given
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .unknown(dummyError)
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("알 수 없는 에러 발생 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부에는 FolderRepositoryError가 포함되어야 합니다.")
+            }
+
+            switch repoError {
+                case .unknown(let underlyingError):
+                    XCTAssertTrue(underlyingError is Dummy)
+                default:
+                    XCTFail("Expected .unknown underlying error, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+}
+
+// MARK: - Error Cases ( Cancelled )
+
+extension ReadFolderUseCaseTest {
+
+    /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
+    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .cancelled
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("작업 취소의 경우 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case: 작업이 즉시 취소된 경우 execute 함수 내부 isCancelled를 검증한다
+    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .success([])
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute() }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업이 즉시 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case (During Execution): 작업 도중 Task가 취소된 경우
+    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .success([]),
+                delay: 100_000_000 // 0.1초 지연
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute() }
+
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기 후 취소
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
@@ -1,0 +1,298 @@
+import XCTest
+@testable import Domain
+
+final class UpdateFolderUseCaseTest: XCTestCase {
+    typealias UseCaseError = UpdateFolderUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension UpdateFolderUseCaseTest {
+    /// 성공 Case: 폴더 정보 업데이트가 정상적으로 완료될 때
+    func test_execute_returnsUpdatedFolder_whenRepositorySucceeds() async throws {
+        // Given
+        let originalFolder = Folder(path: URL(fileURLWithPath: "/test"), name: "Old Name")
+        let updatedFolder = Folder(
+            id: originalFolder.id,
+            path: originalFolder.path,
+            name: "New Name",
+            createdAt: originalFolder.createdAt
+        )
+
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .success(updatedFolder)
+            )
+        )
+
+        // When
+        let result = try await useCase.execute(originalFolder)
+
+        // Then
+        XCTAssertEqual(result.name, "New Name")
+        XCTAssertEqual(result.id, originalFolder.id)
+        XCTAssertEqual(result.path, originalFolder.path)
+        XCTAssertEqual(result.createdAt, originalFolder.createdAt)
+    }
+}
+
+// MARK: - Error Cases
+
+extension UpdateFolderUseCaseTest {
+    /// 유효하지 않은 이름 Case: 폴더 이름이 비어있거나 공백일 때 .invalidName 확인
+    func test_execute_throwsInvalidName_whenNameIsEmpty() async {
+        // Given
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository()
+        )
+        let invalidNames = ["", " ", "  \n  "]
+
+        // When & Then
+        await withTaskGroup(of: Void.self) { group in
+            for name in invalidNames {
+                group.addTask {
+                    let folder = Folder(path: URL(fileURLWithPath: "/"), name: name)
+                    do {
+                        _ = try await useCase.execute(folder)
+                        XCTFail("이름이 비어있는 경우 .invalidName 에러가 발생해야 합니다. (input: '\(name)')")
+                    } catch UseCaseError.invalidName {
+                        // Success
+                    } catch {
+                        XCTFail("Expected .invalidName, got \(error) for name: '\(name)'")
+                    }
+                }
+            }
+        }
+    }
+
+    /// 찾을 수 없음 Case: 수정하려는 폴더가 존재하지 않을 때 .notFound 전파 확인
+    func test_execute_throwsNotFound_whenRepositoryReturnsNotFound() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .notFound
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("폴더를 찾을 수 없는 경우 .notFound 에러가 발생해야 합니다.")
+        } catch UseCaseError.notFound {
+            // Success
+        } catch {
+            XCTFail("Expected .notFound, got \(error)")
+        }
+    }
+
+    /// 이름 중복 Case: 수정하려는 이름이 이미 존재할 때 .duplicateName 전파 확인
+    func test_execute_throwsDuplicateName_whenRepositoryReturnsDuplicateName() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "New Name")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .duplicateName
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("이름이 중복된 경우 .duplicateName 에러가 발생해야 합니다.")
+        } catch UseCaseError.duplicateName {
+            // Success
+        } catch {
+            XCTFail("Expected .duplicateName, got \(error)")
+        }
+    }
+
+    /// 수정 실패 Case: Repository에서 .updateFailed를 반환할 때 동일하게 전파되는지 확인
+    func test_execute_throwsUpdateFailed_whenRepositoryReturnsUpdateFailed() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .updateFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("수정 실패 시 .updateFailed 에러가 발생해야 합니다.")
+        } catch UseCaseError.updateFailed {
+            // Success
+        } catch {
+            XCTFail("Expected .updateFailed, got \(error)")
+        }
+    }
+
+    /// 매핑 확인 Case: Repository에서 .createFailed를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsCreateFailed() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .createFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("생성 실패 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .createFailed:
+                    break // Success
+                default:
+                    XCTFail("Expected .createFailed, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 매핑 확인 Case: Repository에서 .fetchFailed를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsFetchFailed() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .fetchFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("조회 실패 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .fetchFailed:
+                    break // Success
+                default:
+                    XCTFail("Expected .fetchFailed, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .unknown(dummyError)
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("알 수 없는 에러 발생 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부에는 FolderRepositoryError가 포함되어야 합니다.")
+            }
+
+            switch repoError {
+                case .unknown(let underlyingError):
+                    XCTAssertTrue(underlyingError is Dummy)
+                default:
+                    XCTFail("Expected .unknown underlying error, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+}
+
+// MARK: - Error Cases ( Cancelled )
+
+extension UpdateFolderUseCaseTest {
+    /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
+    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .cancelled
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("작업 취소의 경우 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case: 작업이 즉시 취소된 경우 execute 함수 내부 isCancelled를 검증한다
+    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .success(folder)
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute(folder) }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업이 즉시 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case (During Execution): 작업 도중 Task가 취소된 경우
+    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .success(folder),
+                delay: 100_000_000 // 0.1초 지연
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute(folder) }
+
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기 후 취소
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/WorkSpace/FetchBasicFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/FetchBasicFolderUseCaseTest.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import Domain
+
+final class FetchBasicFolderUseCaseTest: XCTestCase {
+    typealias UseCaseError = FetchBasicFolderUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension FetchBasicFolderUseCaseTest {
+    /// 성공 Case: Repository가 정상적으로 Folder를 반환할 때
+    func test_execute_returnsFolder_whenRepositorySucceeds() async throws {
+        // Given
+        let expectedFolder = Folder(path: URL(fileURLWithPath: "/test"), name: "Basic Folder")
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .success(expectedFolder)
+            )
+        )
+
+        // When
+        let folder = try await useCase.execute()
+
+        // Then
+        XCTAssertEqual(folder.id, expectedFolder.id)
+        XCTAssertEqual(folder.name, expectedFolder.name)
+    }
+}
+
+// MARK: - Error Cases
+
+extension FetchBasicFolderUseCaseTest {
+    /// 찾을 수 없음 Case: Repo에서 .notFound를 반환할 때 대칭 확인
+    func test_execute_throwsNotFound_whenRepositoryReturnsNotFound() async {
+        // Given
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .notFound
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("기본 폴더가 없는 경우 .notFound 에러가 발생해야 합니다.")
+        } catch UseCaseError.notFound {
+            // Success
+        } catch {
+            XCTFail("Expected .notFound, got \(error)")
+        }
+    }
+
+    /// 생성 실패 Case: Repo에서 .createFailed를 반환할 때 대칭 확인
+    func test_execute_throwsCreateFailed_whenRepositoryReturnsCreateFailed() async {
+        // Given
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .createFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("생성 실패 시 .createFailed 에러가 발생해야 합니다.")
+        } catch UseCaseError.createFailed {
+            // Success
+        } catch {
+            XCTFail("Expected .createFailed, got \(error)")
+        }
+    }
+
+    /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+        // Given
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .unknown(dummyError)
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("알 수 없는 에러 발생 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            // RepoError.unknown 내부의 Dummy 에러가 유지되어야 함
+            XCTAssertTrue(error is Dummy)
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+}
+
+// MARK: - Error Cases ( Cancelled )
+
+extension FetchBasicFolderUseCaseTest {
+    /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
+    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+        // Given
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .cancelled
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("작업 취소의 경우 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case: 작업이 즉시 취소된 경우
+    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+        // Given
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .success(Folder(path: URL(fileURLWithPath: "/"), name: "test"))
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute() }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업이 즉시 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case (During Execution): 작업 도중 Task가 취소된 경우
+    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
+        // Given
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .success(Folder(path: URL(fileURLWithPath: "/"), name: "test")),
+                rootUrlDelay: 100_000_000 // 0.1초 지연
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute() }
+
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기 후 취소
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/WorkSpace/FetchRootUrlUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/FetchRootUrlUseCaseTest.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import Domain
+
+final class FetchRootUrlUseCaseTest: XCTestCase {
+    typealias UseCaseError = FetchRootUrlUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension FetchRootUrlUseCaseTest {
+    /// 성공 Case: Repository가 정상적으로 URL을 반환할 때
+    /// UseCase도 해당 URL을 반환하는지 확인
+    func test_execute_returnsURL_whenRepositorySucceeds() async throws {
+        // Given
+        let expectedURL = URL.applicationSupportDirectory
+        let useCase = DefaultFetchRootUrlUseCase(
+            repository: MockWorkSpaceRepository(
+                rootUrlBehavior: .success(expectedURL)
+            )
+        )
+
+        // When
+        let url = try await useCase.execute()
+
+        // Then
+        XCTAssertEqual(url, expectedURL)
+    }
+}
+
+// MARK: - Error Cases
+
+extension FetchRootUrlUseCaseTest {
+
+    /// 취소 Case (Repository): Repository 단계에서 cancelled 에러가 발생한 경우
+    /// UseCase가 .cancelled 에러를 던지는지 확인
+    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+        // Given
+        let useCase = DefaultFetchRootUrlUseCase(
+            repository: MockWorkSpaceRepository(
+                rootUrlBehavior: .cancelled
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("Repository가 cancelled 에러를 던지면 UseCase도 cancelled 에러를 던져야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+        // Given
+        let testURL: URL = .applicationSupportDirectory
+        let useCase = DefaultFetchRootUrlUseCase(
+            repository: MockWorkSpaceRepository(
+                rootUrlBehavior: .success(testURL)
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute() }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("이미 취소된 Task이므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected FetchRootUrlUseCaseError.cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case (During Execution): Repository가 작업 중일 때 Task가 취소된 경우
+    /// Repository 또는 UseCase에서 .cancelled 에러를 올바르게 전파하는지 확인
+    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
+        // Given
+        let testURL: URL = .applicationSupportDirectory
+        let useCase = DefaultFetchRootUrlUseCase(
+            repository: MockWorkSpaceRepository(
+                rootUrlBehavior: .success(testURL),
+                rootUrlDelay: 100_000_000 // 0.1초 지연
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute() }
+
+        // 작업을 시작할 시간을 조금 준 뒤 취소
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected FetchRootUrlUseCaseError.cancelled, got \(error)")
+        }
+    }
+
+    /// 알 수 없는 에러 Case: Repository에서 정의되지 않은 에러를 던졌을 때
+    /// UseCase가 이를 .unknown 케이스로 래핑하여 던지는지 확인
+    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+        // Given
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let useCase = DefaultFetchRootUrlUseCase(
+            repository: MockWorkSpaceRepository(
+                rootUrlBehavior: .unknown(dummyError)
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("Repository가 unknown 에러를 던지면 UseCase도 .unknown 에러를 던져야 합니다.")
+        } catch let error {
+            switch error {
+                case .unknown(let repoError):
+                    XCTAssertTrue(repoError is Dummy)
+                default:
+                    XCTFail("Expected .unknown, got \(error)")
+            }
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/WorkSpace/MockWorkSpaceRepository.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/MockWorkSpaceRepository.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Domain
+
+struct MockWorkSpaceRepository: WorkSpaceRepository {
+
+    enum RootURLBehavior: Sendable {
+        case success(URL)       // 성공한 경우
+        case cancelled          // 작업 취소의 경우
+        case unknown(Error)     // 알수 없는 오류
+    }
+
+    enum BasicFolderBehavior: Sendable {
+        case success(Folder)    // 성공한 경우
+        case cancelled          // 작업 취소 경우
+        case notFound           // 기본 폴더를 찾을 수 없는 경우
+        case createFailed       // 기본 폴더 Entity 생성 실패의 경우
+        case unknown(Error)     // 알수 없는 오류
+    }
+
+    var rootUrlBehavior: RootURLBehavior?
+    var basicFolderBehavior: BasicFolderBehavior?
+    var rootUrlDelay: UInt64 = 0
+
+    typealias RootURLError = Domain.WorkSpaceRootURLRepositoryError
+    typealias BasicFolderError = Domain.WorkSpaceBasicFolderRepositoryError
+
+    init(
+        rootUrlBehavior: RootURLBehavior? = nil,
+        basicFolderBehavior: BasicFolderBehavior? = nil,
+        rootUrlDelay: UInt64 = 0
+    ) {
+        self.rootUrlBehavior = rootUrlBehavior
+        self.basicFolderBehavior = basicFolderBehavior
+        self.rootUrlDelay = rootUrlDelay
+    }
+
+    func fetchRootURL() async throws(RootURLError) -> URL {
+        if rootUrlDelay > 0 {
+            try? await Task.sleep(nanoseconds: rootUrlDelay)
+        }
+
+        if Task.isCancelled {
+            throw RootURLError.cancelled
+        }
+
+        switch rootUrlBehavior {
+            case .success(let url):
+                return url
+            case .cancelled:
+                throw RootURLError.cancelled
+            case .unknown(let error):
+                throw RootURLError.unknown(error)
+            case .none:
+                fatalError("RootURLBehavior가 없습니다.")
+        }
+    }
+
+    func fetchOrCreateBasicFolder() async throws(BasicFolderError) -> Domain.Folder {
+        if rootUrlDelay > 0 {
+            try? await Task.sleep(nanoseconds: rootUrlDelay)
+        }
+
+        if Task.isCancelled {
+            throw BasicFolderError.cancelled
+        }
+
+        switch basicFolderBehavior {
+            case .success(let folder):
+                return folder
+            case .cancelled:
+                throw BasicFolderError.cancelled
+            case .notFound:
+                throw BasicFolderError.notFound
+            case .createFailed:
+                throw BasicFolderError.createFailed
+            case .unknown(let error):
+                throw BasicFolderError.unknown(error)
+            case .none:
+                fatalError("BasicFolderBehavior가 없습니다.")
+        }
+    }
+
+}


### PR DESCRIPTION
## ✨ 작업 요약
> 한 줄로 무엇을 추가/변경했는지

- 도메인 레이어 유즈케이스 테스트 코드 고도화 및 에러 핸들링 구조 표준화

## 📋 구체적인 내용
- 추가/변경된 동작:
    - 에러 매핑 표준화: 각 UseCaseError에 init(_ repositoryError:) 생성자를 도입하여, 유즈케이스 내부의 복잡한 switch-case 매핑 로직을 에러 정의부로 캡슐화하고 코드를 간소화했습니다.
    
    - 유효성 검증(Validation) 추가: CreateFolder, UpdateFolder 유즈케이스에서 공백 이름을 검증하는 invalidName 로직과 전용 에러 케이스를 추가했습니다. ( Unit Test 덕분에 깨달았습니다. 👍 )
    
    - 고품질 테스트 스위트 완성: 아래 5개 유즈케이스에 대해 성공, 상세 에러 매핑, 취소(3개) 시나리오를 포함한 종합 테스트를 작성했습니다.
    
    - 취소 케이스:
       - isCancelled가 UseCaseError로 잘 변환 되는지.
       - execute 내부 isCancelled가 정의되어 있는지
       - repository 내부 isCancelled가 정의되어 있는지
       
   - 테스트 효율화: TaskGroup을 활용하여 여러 입력값(공백, 줄바꿈 등)에 대한 유효성 검사를 병렬로 처리하도록 개선했습니다.
  
- 영향 받는 화면/모듈:
   - domain-test-WorkSpace 폴더, domain-test-Folders 폴더, CreateFolderUseCase, ReadFolderUseCase, UpdateFolderUseCase, FetchBasicFolderUseCase, FetchRootUrlUseCase
---

## 🔗 연관 이슈

- closed #59 

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
   - 에러 Enum 내부 매핑 패턴
       - 유즈케이스의 catch 블록이 비대해지는 것을 막기 위해 Typed Throws 내부에서 리포지토리 에러를 유즈케이스 에러로 변환하는 생성자를 구현했습니다. 이를 통해 비즈니스 로직과 에러 변환 정책을 명확히 분리했습니다.
   - 도메인별 명확한 에러 분리:
       - FolderRepository (C, R, U): 공통된 FolderRepositoryError를 통해 일관된 폴더 작업 에러를 관리
       - WorkSpaceRepository: 루트 경로는 WorkSpaceRootURLRepositoryError, 기본 폴더는 WorkSpaceBasicFolderRepositoryError로 세분화하여 각 문맥에 맞는 에러 응답을 보장
       
- **고려했다가 제외한 방식**
   - Generic Unknown Handling
       - 모든 에러를 단순히 .unknown(Error)로 던지는 방식도 고려했으나, UI 레벨에서 사용자에게 정확한 피드백(예: "중복된 이름입니다", "이름을 입력하세요")을 주기 위해 도메인 문맥에 맞는 구체적인 케이스를 유지하는 방식을 선택했습니다. 
       - 모든 에러를 단순히 .unknown(Error)로 던지다 Unit Test에서 Block 당했습니다. 👍 

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [ ] 정상 플로우 동작 확인
- [ ] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [ ] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [ ] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- Typed Throws Switch문 캡슐화
- task.cancel에 대한 총 3가지 시나리오

---

## 📚 참고

-
