### PR TITLE
Domain(UseCaseError, RepositoryError) Typed Throws 변환 과정을 캡슐화 합니다.

### DIFF
--- a/ChaGok/Domain/Sources/Errors/Authority/CheckOnBoardingMicrophonePermissionUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Authority/CheckOnBoardingMicrophonePermissionUseCaseError.swift
@@ -14,4 +14,13 @@ public enum CheckOnBoardingMicrophonePermissionUseCaseError: LocalizedError, Sen
                 error.localizedDescription
         }
     }
+
+    public init(_ error: VoiceRecordPermissionRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            default:
+                self = .unknown(error)
+        }
+    }
 }

--- a/ChaGok/Domain/Sources/Errors/Authority/CheckOnBoardingMicrophonePermissionUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Authority/CheckOnBoardingMicrophonePermissionUseCaseError.swift
@@ -15,7 +15,7 @@ public enum CheckOnBoardingMicrophonePermissionUseCaseError: LocalizedError, Sen
         }
     }
 
-    public init(_ error: VoiceRecordPermissionRepositoryError) {
+    init(_ error: VoiceRecordPermissionRepositoryError) {
         switch error {
             case .cancelled:
                 self = .cancelled

--- a/ChaGok/Domain/Sources/Errors/Folders/CreateFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/CreateFolderUseCaseError.swift
@@ -27,7 +27,7 @@ public enum CreateFolderUseCaseError: LocalizedError, Sendable {
         }
     }
 
-    public init(_ error: FolderRepositoryError) {
+    init(_ error: FolderRepositoryError) {
         switch error {
             case .cancelled:
                 self = .cancelled

--- a/ChaGok/Domain/Sources/Errors/Folders/CreateFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/CreateFolderUseCaseError.swift
@@ -3,6 +3,8 @@ import Foundation
 public enum CreateFolderUseCaseError: LocalizedError, Sendable {
     /// 작업 취소의 경우
     case cancelled
+    /// 유효하지 않은 이름의 경우
+    case invalidName
     /// 동일한 이름의 폴더가 이미 존재하는 경우 (생성, 수정 시 발생)
     case duplicateName
     /// 폴더 생성이 실패한 경우
@@ -14,6 +16,8 @@ public enum CreateFolderUseCaseError: LocalizedError, Sendable {
         switch self {
             case .cancelled:
                 nil
+            case .invalidName:
+                "폴더 이름을 한 글자 이상 입력해 주세요."
             case .duplicateName:
                 "이미 동일한 이름의 폴더가 존재합니다."
             case .createFailed:
@@ -22,4 +26,18 @@ public enum CreateFolderUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: FolderRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .duplicateName:
+                self = .duplicateName
+            case .createFailed:
+                self = .createFailed
+            default:
+                self = .unknown(error)
+        }
+    }
+
 }

--- a/ChaGok/Domain/Sources/Errors/Folders/FetchBasicFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/FetchBasicFolderUseCaseError.swift
@@ -23,7 +23,7 @@ public enum FetchBasicFolderUseCaseError: LocalizedError, Sendable {
         }
     }
 
-    public init(_ error: WorkSpaceBasicFolderRepositoryError) {
+    init(_ error: WorkSpaceBasicFolderRepositoryError) {
         switch error {
             case .cancelled:
                 self = .cancelled

--- a/ChaGok/Domain/Sources/Errors/Folders/FetchBasicFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/FetchBasicFolderUseCaseError.swift
@@ -22,4 +22,18 @@ public enum FetchBasicFolderUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: WorkSpaceBasicFolderRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .notFound:
+                self = .notFound
+            case .createFailed:
+                self = .createFailed
+            case .unknown(let err):
+                self = .unknown(err)
+        }
+    }
+
 }

--- a/ChaGok/Domain/Sources/Errors/Folders/ReadFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/ReadFolderUseCaseError.swift
@@ -22,4 +22,18 @@ public enum ReadFolderUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: FolderRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .notFound:
+                self = .notFound
+            case .fetchFailed:
+                self = .fetchFailed
+            default:
+                self = .unknown(error)
+        }
+    }
+
 }

--- a/ChaGok/Domain/Sources/Errors/Folders/ReadFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/ReadFolderUseCaseError.swift
@@ -23,7 +23,7 @@ public enum ReadFolderUseCaseError: LocalizedError, Sendable {
         }
     }
 
-    public init(_ error: FolderRepositoryError) {
+    init(_ error: FolderRepositoryError) {
         switch error {
             case .cancelled:
                 self = .cancelled

--- a/ChaGok/Domain/Sources/Errors/Folders/UpdateFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/UpdateFolderUseCaseError.swift
@@ -3,6 +3,8 @@ import Foundation
 public enum UpdateFolderUseCaseError: LocalizedError, Sendable {
     /// 작업 취소의 경우
     case cancelled
+    /// 유효하지 않음 이름의 경우
+    case invalidName
     /// 폴더를 찾을 수 없는 경우 (조회, 수정 시 발생)
     case notFound
     /// 동일한 이름의 폴더가 이미 존재하는 경우 (생성, 수정 시 발생)
@@ -16,6 +18,8 @@ public enum UpdateFolderUseCaseError: LocalizedError, Sendable {
         switch self {
             case .cancelled:
                 nil
+            case .invalidName:
+                "폴더 이름을 한 글자 이상 입력해 주세요."
             case .notFound:
                 "해당 폴더를 찾을 수 없습니다."
             case .duplicateName:
@@ -26,4 +30,20 @@ public enum UpdateFolderUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: FolderRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .duplicateName:
+                self = .duplicateName
+            case .notFound:
+                self = .notFound
+            case .updateFailed:
+                self = .updateFailed
+            default:
+                self = .unknown(error)
+        }
+    }
+
 }

--- a/ChaGok/Domain/Sources/Errors/Folders/UpdateFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/UpdateFolderUseCaseError.swift
@@ -31,7 +31,7 @@ public enum UpdateFolderUseCaseError: LocalizedError, Sendable {
         }
     }
 
-    public init(_ error: FolderRepositoryError) {
+    init(_ error: FolderRepositoryError) {
         switch error {
             case .cancelled:
                 self = .cancelled

--- a/ChaGok/Domain/Sources/Errors/Languages/FetchLanguagesUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Languages/FetchLanguagesUseCaseError.swift
@@ -18,4 +18,15 @@ public enum FetchLanguagesUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: FetchLanguagesRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .notFound:
+                self = .notFound
+            case .unknown(let error):
+                self = .unknown(error)
+        }
+    }
 }

--- a/ChaGok/Domain/Sources/Errors/Languages/FetchLanguagesUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Languages/FetchLanguagesUseCaseError.swift
@@ -19,7 +19,7 @@ public enum FetchLanguagesUseCaseError: LocalizedError, Sendable {
         }
     }
 
-    public init(_ error: FetchLanguagesRepositoryError) {
+    init(_ error: FetchLanguagesRepositoryError) {
         switch error {
             case .cancelled:
                 self = .cancelled

--- a/ChaGok/Domain/Sources/Errors/Languages/SetLanguagesUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Languages/SetLanguagesUseCaseError.swift
@@ -19,7 +19,7 @@ public enum SetLanguagesUseCaseError: LocalizedError, Sendable {
         }
     }
 
-    public init(_ error: SetLanguagesRepositoryError) {
+    init(_ error: SetLanguagesRepositoryError) {
         switch error {
             case .cancelled:
                 self = .cancelled

--- a/ChaGok/Domain/Sources/Errors/Languages/SetLanguagesUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Languages/SetLanguagesUseCaseError.swift
@@ -18,4 +18,15 @@ public enum SetLanguagesUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: SetLanguagesRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .saveFailed:
+                self = .saveFailed
+            case .unknown(let error):
+                self = .unknown(error)
+        }
+    }
 }

--- a/ChaGok/Domain/Sources/Errors/WasteBasket/UseCases/DeleteWasteBasketUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/WasteBasket/UseCases/DeleteWasteBasketUseCaseError.swift
@@ -20,7 +20,7 @@ public enum DeleteWasteBasketUseCaseError: LocalizedError, Sendable {
         }
     }
 
-    public init(_ error: DeleteWasteBasketRepositoryError) {
+    init(_ error: DeleteWasteBasketRepositoryError) {
         switch error {
             case .cancelled:
                 self = .cancelled

--- a/ChaGok/Domain/Sources/Errors/WasteBasket/UseCases/DeleteWasteBasketUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/WasteBasket/UseCases/DeleteWasteBasketUseCaseError.swift
@@ -19,4 +19,15 @@ public enum DeleteWasteBasketUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: DeleteWasteBasketRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .deleteFailed(let method):
+                self = .deleteFailed(method)
+            case .unknown(let error):
+                self = .unknown(error)
+        }
+    }
 }

--- a/ChaGok/Domain/Sources/Errors/WasteBasket/UseCases/FetchWasteBasketFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/WasteBasket/UseCases/FetchWasteBasketFolderUseCaseError.swift
@@ -20,7 +20,7 @@ public enum FetchWasteBasketFolderUseCaseError: LocalizedError, Sendable {
         }
     }
 
-    public init(_ error: FetchWasteBasketRepositoryError) {
+    init(_ error: FetchWasteBasketRepositoryError) {
         switch error {
             case .cancelled:
                 self = .cancelled

--- a/ChaGok/Domain/Sources/Errors/WasteBasket/UseCases/FetchWasteBasketFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/WasteBasket/UseCases/FetchWasteBasketFolderUseCaseError.swift
@@ -19,4 +19,15 @@ public enum FetchWasteBasketFolderUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: FetchWasteBasketRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .fetchFailed:
+                self = .fetchFailed
+            case .unknown(let error):
+                self = .unknown(error)
+        }
+    }
 }

--- a/ChaGok/Domain/Sources/Errors/WasteBasket/UseCases/MoveWasteBasketUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/WasteBasket/UseCases/MoveWasteBasketUseCaseError.swift
@@ -19,4 +19,15 @@ public enum MoveWasteBasketUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: MoveWasteBasketRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .moveFailed(let method):
+                self = .moveFailed(method)
+            case .unknown(let error):
+                self = .unknown(error)
+        }
+    }
 }

--- a/ChaGok/Domain/Sources/Errors/WasteBasket/UseCases/MoveWasteBasketUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/WasteBasket/UseCases/MoveWasteBasketUseCaseError.swift
@@ -20,7 +20,7 @@ public enum MoveWasteBasketUseCaseError: LocalizedError, Sendable {
         }
     }
 
-    public init(_ error: MoveWasteBasketRepositoryError) {
+    init(_ error: MoveWasteBasketRepositoryError) {
         switch error {
             case .cancelled:
                 self = .cancelled

--- a/ChaGok/Domain/Sources/Errors/WorkSpace/FetchRootUrlUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/WorkSpace/FetchRootUrlUseCaseError.swift
@@ -14,4 +14,14 @@ public enum FetchRootUrlUseCaseError: LocalizedError, Sendable {
                 error.localizedDescription
         }
     }
+
+    public init(_ error: WorkSpaceRootURLRepositoryError) {
+        switch error {
+            case .cancelled:
+                self = .cancelled
+            case .unknown(let error):
+                self = .unknown(error)
+        }
+    }
+
 }

--- a/ChaGok/Domain/Sources/Errors/WorkSpace/FetchRootUrlUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/WorkSpace/FetchRootUrlUseCaseError.swift
@@ -15,7 +15,7 @@ public enum FetchRootUrlUseCaseError: LocalizedError, Sendable {
         }
     }
 
-    public init(_ error: WorkSpaceRootURLRepositoryError) {
+    init(_ error: WorkSpaceRootURLRepositoryError) {
         switch error {
             case .cancelled:
                 self = .cancelled

--- a/ChaGok/Domain/Sources/UseCases/Authority/CheckOnBoardingMicrophonePermissionUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Authority/CheckOnBoardingMicrophonePermissionUseCase.swift
@@ -19,16 +19,17 @@ public struct DefaultCheckOnBoardingMicrophonePermissionUseCase: CheckOnBoarding
 
     public func execute() async throws(CheckOnBoardingMicrophonePermissionUseCaseError) -> MicrophonePermissionStatus {
         typealias UseCaseError = CheckOnBoardingMicrophonePermissionUseCaseError
-        if Task.isCancelled {
-            throw .cancelled
-        }
+        if Task.isCancelled { throw UseCaseError.cancelled }
 
         do {
             try await repository.checkRecordingPermission()
             return .authorized
         } catch {
             AppLogger.error(error)
-            throw UseCaseError(error)
+            switch error {
+                case .permissionDenied: return .denied // 권한 없음을 denied
+                default: throw UseCaseError(error)
+            }
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/Authority/CheckOnBoardingMicrophonePermissionUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Authority/CheckOnBoardingMicrophonePermissionUseCase.swift
@@ -18,6 +18,7 @@ public struct DefaultCheckOnBoardingMicrophonePermissionUseCase: CheckOnBoarding
     }
 
     public func execute() async throws(CheckOnBoardingMicrophonePermissionUseCaseError) -> MicrophonePermissionStatus {
+        typealias UseCaseError = CheckOnBoardingMicrophonePermissionUseCaseError
         if Task.isCancelled {
             throw .cancelled
         }
@@ -27,15 +28,7 @@ public struct DefaultCheckOnBoardingMicrophonePermissionUseCase: CheckOnBoarding
             return .authorized
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .permissionDenied:
-                    // 온보딩에서는 거부되어도 다음 단계로 넘어갈 수 있도록 상태만 반환
-                    return .denied
-                case .cancelled:
-                    throw .cancelled
-                case .unknown(let error):
-                    throw .unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/Folders/CreateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/CreateFolderUseCase.swift
@@ -22,20 +22,17 @@ public struct DefaultCreateFolderUseCase: CreateFolderUseCase {
     public func execute(name: String) async throws(CreateFolderUseCaseError) -> Folder {
         typealias UseCaseError = CreateFolderUseCaseError
         if Task.isCancelled { throw UseCaseError.cancelled }
+
+        // invalidName 유효성 검증
+        guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw UseCaseError.invalidName
+        }
+
         do {
             return try await repository.create(name: name)
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled:
-                    throw UseCaseError.cancelled
-                case .duplicateName:
-                    throw UseCaseError.duplicateName
-                case .createFailed:
-                    throw UseCaseError.createFailed
-                case .unknown, .notFound, .fetchFailed, .updateFailed:
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/Folders/FetchBasicFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/FetchBasicFolderUseCase.swift
@@ -22,22 +22,13 @@ public struct DefaultFetchBasicFolderUseCase: FetchBasicFolderUseCase {
     @discardableResult
     public func execute() async throws(FetchBasicFolderUseCaseError) -> Folder {
         typealias UseCaseError = FetchBasicFolderUseCaseError
-        if Task.isCancelled { throw FetchBasicFolderUseCaseError.cancelled }
+        if Task.isCancelled { throw UseCaseError.cancelled }
         do {
             // 기본 폴더 생성/확인
             return try await repository.fetchOrCreateBasicFolder()
         } catch let error {
             AppLogger.error(error)
-            switch error {
-                case .cancelled:
-                    throw UseCaseError.cancelled
-                case .createFailed:
-                    throw UseCaseError.createFailed
-                case .notFound:
-                    throw UseCaseError.notFound
-                case .unknown(let error):
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/Folders/ReadFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/ReadFolderUseCase.swift
@@ -25,13 +25,8 @@ public struct DefaultReadFolderUseCase: ReadFolderUseCase {
             return try await repository.fetchAll()
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled: throw UseCaseError.cancelled
-                case .notFound: throw UseCaseError.notFound
-                case .fetchFailed: throw UseCaseError.fetchFailed
-                case .unknown, .updateFailed, .createFailed, .duplicateName:
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
+
 }

--- a/ChaGok/Domain/Sources/UseCases/Folders/UpdateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/UpdateFolderUseCase.swift
@@ -22,18 +22,18 @@ public struct DefaultUpdateFolderUseCase: UpdateFolderUseCase {
     public func execute(_ folder: Folder) async throws(UpdateFolderUseCaseError) -> Folder {
         typealias UseCaseError = UpdateFolderUseCaseError
         if Task.isCancelled { throw UseCaseError.cancelled }
+
+        // invalidName 유효성 검증
+        guard !folder.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw UseCaseError.invalidName
+        }
+
         do {
             return try await repository.update(folder)
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled: throw UseCaseError.cancelled
-                case .duplicateName: throw UseCaseError.duplicateName
-                case .notFound: throw UseCaseError.notFound
-                case .updateFailed: throw UseCaseError.updateFailed
-                case .unknown, .fetchFailed, .createFailed:
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
+
 }

--- a/ChaGok/Domain/Sources/UseCases/Languages/FetchLanguageUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Languages/FetchLanguageUseCase.swift
@@ -23,11 +23,7 @@ public struct DefaultFetchLanguageUseCase: FetchLanguageUseCase {
             return try await repository.fetchLanguage()
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled: throw UseCaseError.cancelled
-                case .notFound: throw UseCaseError.notFound
-                case .unknown(let error): throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/Languages/SelectLanguageUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Languages/SelectLanguageUseCase.swift
@@ -24,11 +24,7 @@ public struct DefaultSelectLanguageUseCase: SelectLanguageUseCase {
             return try await repository.saveLanguage(lang)
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled: throw UseCaseError.cancelled
-                case .saveFailed: throw UseCaseError.saveFailed
-                case .unknown(let error): throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/WasteBaskets/DeleteWasteBasketUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/WasteBaskets/DeleteWasteBasketUseCase.swift
@@ -31,14 +31,7 @@ public struct DefaultDeleteWasteBasketUseCase: DeleteWasteBasketUseCase {
             }
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled:
-                    throw UseCaseError.cancelled
-                case .deleteFailed(let method):
-                    throw UseCaseError.deleteFailed(method)
-                case .unknown(let error):
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/WasteBaskets/FetchWasteBasketFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/WasteBaskets/FetchWasteBasketFolderUseCase.swift
@@ -25,14 +25,7 @@ public struct DefaultFetchWasteBasketFolderUseCase: FetchWasteBasketFolderUseCas
             return try await repository.fetchAll()
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled:
-                    throw UseCaseError.cancelled
-                case .fetchFailed:
-                    throw UseCaseError.fetchFailed
-                case .unknown(let error):
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/WasteBaskets/MoveWasteBasketUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/WasteBaskets/MoveWasteBasketUseCase.swift
@@ -28,14 +28,7 @@ public struct DefaultMoveWasteBasketUseCase: MoveWasteBasketUseCase {
             }
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled:
-                    throw UseCaseError.cancelled
-                case .moveFailed(let method):
-                    throw UseCaseError.moveFailed(method)
-                case .unknown(let error):
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/WorkSpace/FetchRootUrlUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/WorkSpace/FetchRootUrlUseCase.swift
@@ -20,18 +20,12 @@ public struct DefaultFetchRootUrlUseCase: FetchRootUrlUseCase {
 
     public func execute() async throws(FetchRootUrlUseCaseError) -> URL {
         typealias UseCaseError = FetchRootUrlUseCaseError
-        if Task.isCancelled { throw FetchRootUrlUseCaseError.cancelled }
+        if Task.isCancelled { throw UseCaseError.cancelled }
         do {
-            // root URL 가져오기
             return try await repository.fetchRootURL()
         } catch {
             AppLogger.error(error)
-            switch error {
-                case .cancelled:
-                    throw UseCaseError.cancelled
-                case .unknown(let error):
-                    throw UseCaseError.unknown(error)
-            }
+            throw UseCaseError(error)
         }
     }
 }


### PR DESCRIPTION
## ✨ 작업 요약
> UseCase에서 `UseCaseError(error)` 형식을 통해 Repository 에러를 UseCase 에러로 변환할 수 있도록 내부 캡슐화 및 구조 표준화를 진행했습니다.

## 📋 구체적인 내용
- **추가/변경된 동작**:
    - **에러 매핑 캡슐화**: 각 `UseCaseError` 열거형에 `init(_ repositoryError:)` 생성자를 도입하여, 유즈케이스 내부의 복잡한 매핑 로직을 에러 정의부로 이동 및 은닉했습니다.
    - **유효성 검증(Validation) 로직 추가**: `CreateFolder`, `UpdateFolder` 유즈케이스에서 공백 이름을 사전에 차단하는 `invalidName` 에러 케이스 및 검증 로직을 추가했습니다.
    - **에러 응답 표준화**: `FetchBasicFolder`, `FetchRootUrl` 등 워크스페이스 관련 유즈케이스에도 동일한 에러 핸들링 패턴을 적용했습니다.
- **영향 받는 화면/모듈**:
    - `Domain` 모듈 (UseCases, Errors)

---

## 🔗 연관 이슈
- closed #69

---

## 🧩 설계·구현 노트

- **선택한 방식: Error Extension Mapping & Typed Throws 활용**
    - **이유**: 유즈케이스의 `catch` 블록이 비대해지는 것을 막고, 에러 변환 정책을 한곳에서 관리하기 위함입니다.
    - **이점**: Swift의 `Typed Throws`를 활용하여 리포지토리별로 세분화된 에러 타입을 정의함으로써, 컴파일 타임에 에러 호환성을 보장하고 테스트 코드의 가독성을 높였습니다.
- **고려했다가 제외한 방식: Manual Switch-Case in UseCase**
    - 유즈케이스 내부에서 수동으로 매핑할 경우 코드 중복이 발생하고, 향후 리포지토리에 에러 케이스가 추가될 때 누락될 위험이 있어 제외했습니다.

---

## ✅ 확인 사항
- [x] 정상 플로우 동작 확인
- [ ] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부 (해당 없음)
- [ ] (로직 추가 시) 테스트 추가 여부 (별도 PR/커밋으로 연계 확인 가능)

---

## 👀 리뷰 포인트
- [ ] 설계·구조 적절성: `UseCaseError(error)` 초기화 패턴의 일관성 및 캡슐화 수준
- [ ] 로직·엣지 케이스: `invalidName` 등 새로 추가된 도메인 규칙 준수 여부
- [ ] 예외/에러 핸들링: 명시적으로 매핑되지 않은 리포지토리 에러가 `.unknown`으로 안전하게 래핑되는지

**특히 봐줬으면 하는 부분**
- 리포지토리 에러를 유즈케이스 에러로 변환할 때, 각 유즈케이스의 비즈니스 목적에 맞게 에러 케이스가 적절히 사상되었는지(Mapping accuracy) 확인 부탁드립니다.

---

## 📚 참고
- Swift 6.0 Typed Throws Guideline
