### PR TITLE
음성 메모 생성 및 조회 유스케이스를 구현하고 단위 테스트를 추가합니다.

### DIFF
--- a/ChaGok/Domain/Sources/Entities/AudioFileFormat.swift
+++ b/ChaGok/Domain/Sources/Entities/AudioFileFormat.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// 지원하는 오디오 파일 형식 열거형.
+public enum AudioFileFormat: String, CaseIterable, Sendable {
+    case m4a
+    case wav
+    case mp3
+    case caf
+    case aac
+    case aiff
+    case aif
+
+    /// 파일 확장자 문자열로부터 AudioFileFormat을 생성합니다. (대소문자 구분 없음)
+    public init?(extension: String) {
+        self.init(rawValue: `extension`.lowercased())
+    }
+}

--- a/ChaGok/Domain/Sources/Errors/VoiceNotes/UseCases/CreateVoiceNoteUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/VoiceNotes/UseCases/CreateVoiceNoteUseCaseError.swift
@@ -3,11 +3,17 @@ import Foundation
 /// 음성 메모 생성 유스케이스에서 발생할 수 있는 에러.
 public enum CreateVoiceNoteUseCaseError: LocalizedError, Sendable {
 
-    /// 검증 실패: 녹음 길이가 유효하지 않음 (0 미만).
+    /// 검증 실패: 녹음 길이가 유효하지 않음 (0 이하).
     case invalidDuration(duration: Double)
 
     /// 검증 실패: 오디오 파일 경로가 유효하지 않음.
     case invalidAudioFilePath(URL)
+
+    /// 검증 실패: 파일명이 비어있음.
+    case emptyFileName
+
+    /// 검증 실패: 지원하지 않는 파일 확장자.
+    case unsupportedExtension(String)
 
     /// 음성 메모 생성 실패 (저장/디스크/권한 등).
     case createFailed
@@ -24,6 +30,10 @@ public enum CreateVoiceNoteUseCaseError: LocalizedError, Sendable {
             return "녹음 길이가 올바르지 않습니다."
         case .invalidAudioFilePath:
             return "오디오 파일 경로가 올바르지 않습니다."
+        case .emptyFileName:
+            return "파일 이름이 비어있습니다."
+        case .unsupportedExtension(let ext):
+            return "지원하지 않는 파일 확장자입니다: \(ext)"
         case .createFailed:
             return "음성 메모 생성에 실패했습니다."
         case .cancelled:

--- a/ChaGok/Domain/Sources/Errors/VoiceNotes/UseCases/FetchVoiceNoteUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/VoiceNotes/UseCases/FetchVoiceNoteUseCaseError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// 음성 메모 조회 유스케이스에서 발생할 수 있는 에러.
-public enum ReadVoiceNoteUseCaseError: LocalizedError, Sendable {
+public enum FetchVoiceNoteUseCaseError: LocalizedError, Sendable {
 
     /// 폴더별 목록 조회 실패.
     case fetchAllFailed(folderID: UUID)

--- a/ChaGok/Domain/Sources/UseCases/VoiceNotes/CreateVoiceNoteUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/VoiceNotes/CreateVoiceNoteUseCase.swift
@@ -13,6 +13,7 @@ public protocol CreateVoiceNoteUseCase: Sendable {
 public struct DefaultCreateVoiceNoteUseCase: CreateVoiceNoteUseCase {
 
     private let repository: VoiceNoteCreateRepository
+    private let allowedExtensions: Set<String> = ["m4a", "wav", "mp3", "caf", "aac", "aiff", "aif"]
 
     public init(repository: VoiceNoteCreateRepository) {
         self.repository = repository
@@ -22,13 +23,29 @@ public struct DefaultCreateVoiceNoteUseCase: CreateVoiceNoteUseCase {
         -> VoiceNote {
         if Task.isCancelled { throw .cancelled }
 
-        if voiceRecord.duration < 0 {
+        if !voiceRecord.duration.isFinite || voiceRecord.duration <= 0 {
             let error = CreateVoiceNoteUseCaseError.invalidDuration(duration: voiceRecord.duration)
             AppLogger.error(error)
             throw error
         }
-        if !voiceRecord.audioFilePath.isFileURL || voiceRecord.audioFilePath.path.isEmpty {
+
+        if !voiceRecord.audioFilePath.isFileURL {
             let error = CreateVoiceNoteUseCaseError.invalidAudioFilePath(voiceRecord.audioFilePath)
+            AppLogger.error(error)
+            throw error
+        }
+
+        let fileName = voiceRecord.audioFilePath.lastPathComponent
+        if fileName.isEmpty {
+            let error = CreateVoiceNoteUseCaseError.emptyFileName
+            AppLogger.error(error)
+            throw error
+        }
+
+        let pathExtension = voiceRecord.audioFilePath.pathExtension.lowercased()
+
+        guard allowedExtensions.contains(pathExtension) else {
+            let error = CreateVoiceNoteUseCaseError.unsupportedExtension(pathExtension)
             AppLogger.error(error)
             throw error
         }
@@ -43,7 +60,7 @@ public struct DefaultCreateVoiceNoteUseCase: CreateVoiceNoteUseCase {
 }
 
 extension CreateVoiceNoteUseCaseError {
-    public init(_ error: VoiceNoteCreateRepositoryError) {
+    fileprivate init(_ error: VoiceNoteCreateRepositoryError) {
         switch error {
         case .createFailed:
             self = .createFailed

--- a/ChaGok/Domain/Sources/UseCases/VoiceNotes/CreateVoiceNoteUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/VoiceNotes/CreateVoiceNoteUseCase.swift
@@ -13,7 +13,6 @@ public protocol CreateVoiceNoteUseCase: Sendable {
 public struct DefaultCreateVoiceNoteUseCase: CreateVoiceNoteUseCase {
 
     private let repository: VoiceNoteCreateRepository
-    private let allowedExtensions: Set<String> = ["m4a", "wav", "mp3", "caf", "aac", "aiff", "aif"]
 
     public init(repository: VoiceNoteCreateRepository) {
         self.repository = repository
@@ -42,9 +41,8 @@ public struct DefaultCreateVoiceNoteUseCase: CreateVoiceNoteUseCase {
             throw error
         }
 
-        let pathExtension = voiceRecord.audioFilePath.pathExtension.lowercased()
-
-        guard allowedExtensions.contains(pathExtension) else {
+        let pathExtension = voiceRecord.audioFilePath.pathExtension
+        guard let _ = AudioFileFormat(extension: pathExtension) else {
             let error = CreateVoiceNoteUseCaseError.unsupportedExtension(pathExtension)
             AppLogger.error(error)
             throw error

--- a/ChaGok/Domain/Sources/UseCases/VoiceNotes/FetchVoiceNoteUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/VoiceNotes/FetchVoiceNoteUseCase.swift
@@ -2,21 +2,21 @@ import Core
 import Foundation
 
 /// 음성 메모 조회 유스케이스 프로토콜.
-public protocol ReadVoiceNoteUseCase: Sendable {
+public protocol FetchVoiceNoteUseCase: Sendable {
     /// 특정 폴더의 모든 음성 메모를 조회합니다.
     /// - Parameter folderID: 조회할 폴더의 ID
     /// - Returns: 조회된 `VoiceNote` 배열
-    /// - Throws: `ReadVoiceNoteUseCaseError` (목록 조회 실패)
-    func execute(folderID: UUID) async throws(ReadVoiceNoteUseCaseError) -> [VoiceNote]
+    /// - Throws: `FetchVoiceNoteUseCaseError` (목록 조회 실패)
+    func execute(folderID: UUID) async throws(FetchVoiceNoteUseCaseError) -> [VoiceNote]
 
     /// 특정 음성 메모를 조회합니다.
     /// - Parameter id: 조회할 음성 메모의 ID
     /// - Returns: 조회된 `VoiceNote` 엔티티
-    /// - Throws: `ReadVoiceNoteUseCaseError` (레코드 없음, 단건 조회 실패)
-    func execute(byId id: UUID) async throws(ReadVoiceNoteUseCaseError) -> VoiceNote
+    /// - Throws: `FetchVoiceNoteUseCaseError` (레코드 없음, 단건 조회 실패)
+    func execute(byId id: UUID) async throws(FetchVoiceNoteUseCaseError) -> VoiceNote
 }
 
-public struct DefaultReadVoiceNoteUseCase: ReadVoiceNoteUseCase {
+public struct DefaultFetchVoiceNoteUseCase: FetchVoiceNoteUseCase {
 
     private let repository: VoiceNoteFetchRepository
 
@@ -24,29 +24,35 @@ public struct DefaultReadVoiceNoteUseCase: ReadVoiceNoteUseCase {
         self.repository = repository
     }
 
-    public func execute(folderID: UUID) async throws(ReadVoiceNoteUseCaseError) -> [VoiceNote] {
+    public func execute(folderID: UUID) async throws(FetchVoiceNoteUseCaseError) -> [VoiceNote] {
         if Task.isCancelled { throw .cancelled }
+        let voiceNotes: [VoiceNote]
         do {
-            return try await repository.fetchAll(folderID: folderID)
+            voiceNotes = try await repository.fetchAll(folderID: folderID)
         } catch {
             AppLogger.error(error)
-            throw ReadVoiceNoteUseCaseError(error)
+            throw FetchVoiceNoteUseCaseError(error)
         }
+        if Task.isCancelled { throw .cancelled }
+        return voiceNotes
     }
 
-    public func execute(byId id: UUID) async throws(ReadVoiceNoteUseCaseError) -> VoiceNote {
+    public func execute(byId id: UUID) async throws(FetchVoiceNoteUseCaseError) -> VoiceNote {
         if Task.isCancelled { throw .cancelled }
+        let voiceNote: VoiceNote
         do {
-            return try await repository.fetch(byId: id)
+            voiceNote = try await repository.fetch(byId: id)
         } catch {
             AppLogger.error(error)
-            throw ReadVoiceNoteUseCaseError(error)
+            throw FetchVoiceNoteUseCaseError(error)
         }
+        if Task.isCancelled { throw .cancelled }
+        return voiceNote
     }
 }
 
-extension ReadVoiceNoteUseCaseError {
-    public init(_ error: VoiceNoteFetchRepositoryError) {
+extension FetchVoiceNoteUseCaseError {
+    fileprivate init(_ error: VoiceNoteFetchRepositoryError) {
         switch error {
         case .fetchAllFailed(let folderID):
             self = .fetchAllFailed(folderID: folderID)

--- a/ChaGok/Domain/Tests/DomainTests.swift
+++ b/ChaGok/Domain/Tests/DomainTests.swift
@@ -1,4 +1,0 @@
-import Testing
-@testable import Domain
-
-@Test func placeholder() {}

--- a/ChaGok/Domain/Tests/Mocks/Entities/VoiceNote+Stub.swift
+++ b/ChaGok/Domain/Tests/Mocks/Entities/VoiceNote+Stub.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+@testable import Domain
+
+extension VoiceNote {
+    static func stub(
+        id: UUID = UUID(),
+        title: String = "Test Voice Note",
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        folderID: UUID = UUID(),
+        voiceRecord: VoiceRecord = .stub(),
+        keywords: [Keyword] = [],
+        transcript: Transcript? = nil,
+        summary: Summary? = nil,
+        deletedAt: Date? = nil
+    ) -> VoiceNote {
+        VoiceNote(
+            id: id,
+            title: title,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            folderID: folderID,
+            voiceRecord: voiceRecord,
+            keywords: keywords,
+            transcript: transcript,
+            summary: summary,
+            deletedAt: deletedAt
+        )
+    }
+}

--- a/ChaGok/Domain/Tests/Mocks/Repositories/VoiceNote/MockVoiceNoteCreateRepository.swift
+++ b/ChaGok/Domain/Tests/Mocks/Repositories/VoiceNote/MockVoiceNoteCreateRepository.swift
@@ -1,0 +1,61 @@
+import Foundation
+import XCTest
+
+@testable import Domain
+
+actor MockVoiceNoteCreateRepository: VoiceNoteCreateRepository {
+
+    private var result: Result<VoiceNote, VoiceNoteCreateRepositoryError>?
+
+    private(set) var createCallCount = 0
+    private(set) var actualVoiceRecord: VoiceRecord?
+
+    private var expectedCreateCallCount: Int?
+    private var expectedVoiceRecordID: UUID?
+
+    func setResult(_ result: Result<VoiceNote, VoiceNoteCreateRepositoryError>) {
+        self.result = result
+    }
+
+    func expectCreate(callCount: Int, voiceRecordID: UUID? = nil) {
+        expectedCreateCallCount = callCount
+        expectedVoiceRecordID = voiceRecordID
+    }
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedCreateCallCount {
+            XCTAssertEqual(
+                createCallCount,
+                expected,
+                "create call count mismatch",
+                file: file,
+                line: line
+            )
+        }
+        if let expectedID = expectedVoiceRecordID {
+            XCTAssertEqual(
+                actualVoiceRecord?.id,
+                expectedID,
+                "voiceRecord ID mismatch",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func create(_ voiceRecord: VoiceRecord) async throws(VoiceNoteCreateRepositoryError)
+        -> VoiceNote {
+        createCallCount += 1
+        actualVoiceRecord = voiceRecord
+
+        switch result {
+        case .success(let success):
+            return success
+        case .failure(let failure):
+            throw failure
+        case .none:
+            XCTFail("MockVoiceNoteCreateRepository.result 가 설정되지 않았습니다.")
+            throw .unknown(NSError(domain: "MockVoiceNoteCreateRepository", code: -1))
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Mocks/Repositories/VoiceNote/MockVoiceNoteFetchRepository.swift
+++ b/ChaGok/Domain/Tests/Mocks/Repositories/VoiceNote/MockVoiceNoteFetchRepository.swift
@@ -1,0 +1,109 @@
+import Foundation
+import XCTest
+
+@testable import Domain
+
+actor MockVoiceNoteFetchRepository: VoiceNoteFetchRepository {
+
+    private var fetchAllResult: Result<[VoiceNote], VoiceNoteFetchRepositoryError>?
+    private var fetchByIdResult: Result<VoiceNote, VoiceNoteFetchRepositoryError>?
+
+    private(set) var fetchAllCallCount = 0
+    private(set) var actualFetchAllFolderID: UUID?
+    private(set) var fetchByIdCallCount = 0
+    private(set) var actualFetchByIdID: UUID?
+
+    private var expectedFetchAllCallCount: Int?
+    private var expectedFetchAllFolderID: UUID?
+    private var expectedFetchByIdCallCount: Int?
+    private var expectedFetchByIdID: UUID?
+
+    func setFetchAllResult(_ result: Result<[VoiceNote], VoiceNoteFetchRepositoryError>) {
+        fetchAllResult = result
+    }
+
+    func setFetchByIdResult(_ result: Result<VoiceNote, VoiceNoteFetchRepositoryError>) {
+        fetchByIdResult = result
+    }
+
+    func expectFetchAll(callCount: Int, folderID: UUID? = nil) {
+        expectedFetchAllCallCount = callCount
+        expectedFetchAllFolderID = folderID
+    }
+
+    func expectFetchById(callCount: Int, id: UUID? = nil) {
+        expectedFetchByIdCallCount = callCount
+        expectedFetchByIdID = id
+    }
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedFetchAllCallCount {
+            XCTAssertEqual(
+                fetchAllCallCount,
+                expected,
+                "fetchAll call count mismatch",
+                file: file,
+                line: line
+            )
+        }
+        if let expectedFolderID = expectedFetchAllFolderID {
+            XCTAssertEqual(
+                actualFetchAllFolderID,
+                expectedFolderID,
+                "fetchAll folderID mismatch",
+                file: file,
+                line: line
+            )
+        }
+        if let expected = expectedFetchByIdCallCount {
+            XCTAssertEqual(
+                fetchByIdCallCount,
+                expected,
+                "fetch(byId:) call count mismatch",
+                file: file,
+                line: line
+            )
+        }
+        if let expectedID = expectedFetchByIdID {
+            XCTAssertEqual(
+                actualFetchByIdID,
+                expectedID,
+                "fetch(byId:) id mismatch",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func fetchAll(folderID: UUID) async throws(VoiceNoteFetchRepositoryError) -> [VoiceNote] {
+        fetchAllCallCount += 1
+        actualFetchAllFolderID = folderID
+
+        switch fetchAllResult {
+        case .success(let success):
+            return success
+        case .failure(let failure):
+            throw failure
+        case .none:
+            XCTFail("MockVoiceNoteFetchRepository.fetchAllResult 가 설정되지 않았습니다.")
+            throw .unknown(NSError(domain: "MockVoiceNoteFetchRepository.fetchAllResult", code: -1))
+        }
+    }
+
+    func fetch(byId id: UUID) async throws(VoiceNoteFetchRepositoryError) -> VoiceNote {
+        fetchByIdCallCount += 1
+        actualFetchByIdID = id
+
+        switch fetchByIdResult {
+        case .success(let success):
+            return success
+        case .failure(let failure):
+            throw failure
+        case .none:
+            XCTFail("MockVoiceNoteFetchRepository.fetchByIdResult 가 설정되지 않았습니다.")
+            throw .unknown(
+                NSError(domain: "MockVoiceNoteFetchRepository.fetchByIdResult", code: -1)
+            )
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/UseCases/VoiceNotes/CreateVoiceNoteUseCaseTests.swift
+++ b/ChaGok/Domain/Tests/UseCases/VoiceNotes/CreateVoiceNoteUseCaseTests.swift
@@ -26,7 +26,7 @@ extension CreateVoiceNoteUseCaseTests {
 
     func test_execute_유효한입력을넣으면_생성된보이스노트를반환한다() async throws {
         // Given
-        let voiceRecord = VoiceRecord(
+        let voiceRecord = VoiceRecord.stub(
             audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
             duration: 1.0
         )
@@ -46,11 +46,11 @@ extension CreateVoiceNoteUseCaseTests {
 
     func test_execute_대문자확장자여도_정상적으로생성한다() async throws {
         // Given
-        let voiceRecord = VoiceRecord(
+        let voiceRecord = VoiceRecord.stub(
             audioFilePath: URL(fileURLWithPath: "/tmp/TEST.M4A"),
             duration: 1.0
         )
-        let expected = VoiceNote.stub(title: "Created", voiceRecord: voiceRecord)
+        let expected = VoiceNote.stub(voiceRecord: voiceRecord)
         await repository.setResult(.success(expected))
         await repository.expectCreate(callCount: 1, voiceRecordID: voiceRecord.id)
 
@@ -68,10 +68,7 @@ extension CreateVoiceNoteUseCaseTests {
 
     func test_execute_재생시간이0이면_invalidDuration에러를던진다() async {
         // Given
-        let voiceRecord = VoiceRecord(
-            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
-            duration: 0.0
-        )
+        let voiceRecord = VoiceRecord.stub(duration: 0.0)
         await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
         await repository.expectCreate(callCount: 0)
 
@@ -92,10 +89,7 @@ extension CreateVoiceNoteUseCaseTests {
 
     func test_execute_재생시간이NaN이면_invalidDuration에러를던진다() async {
         // Given
-        let voiceRecord = VoiceRecord(
-            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
-            duration: Double.nan
-        )
+        let voiceRecord = VoiceRecord.stub(duration: Double.nan)
         await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
         await repository.expectCreate(callCount: 0)
 
@@ -115,10 +109,7 @@ extension CreateVoiceNoteUseCaseTests {
 
     func test_execute_재생시간이무한이면_invalidDuration에러를던진다() async {
         // Given
-        let voiceRecord = VoiceRecord(
-            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
-            duration: Double.infinity
-        )
+        let voiceRecord = VoiceRecord.stub(duration: Double.infinity)
         await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
         await repository.expectCreate(callCount: 0)
 
@@ -138,10 +129,8 @@ extension CreateVoiceNoteUseCaseTests {
 
     func test_execute_오디오경로가파일URL이아니면_invalidAudioFilePath에러를던진다() async {
         // Given
-        let voiceRecord = VoiceRecord(
-            audioFilePath: URL(string: "https://example.com/test.m4a")!,
-            duration: 1.0
-        )
+        let url = URL(string: "https://example.com/test.m4a")!
+        let voiceRecord = VoiceRecord.stub(audioFilePath: url)
         await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
         await repository.expectCreate(callCount: 0)
 
@@ -151,10 +140,10 @@ extension CreateVoiceNoteUseCaseTests {
             XCTFail("에러를 throw 해야 합니다.")
         } catch {
             // Then
-            guard case .invalidAudioFilePath(let url) = error else {
+            guard case .invalidAudioFilePath(let mappedUrl) = error else {
                 return XCTFail("expected .invalidAudioFilePath, got \(error)")
             }
-            XCTAssertEqual(url, voiceRecord.audioFilePath)
+            XCTAssertEqual(mappedUrl, url)
         }
 
         await repository.verify()
@@ -163,10 +152,8 @@ extension CreateVoiceNoteUseCaseTests {
     func test_execute_파일명이비어있으면_emptyFileName에러를던진다() async {
         // Given
         // "file://" 는 lastPathComponent가 빈 문자열이 됨
-        let voiceRecord = VoiceRecord(
-            audioFilePath: URL(string: "file://")!,
-            duration: 1.0
-        )
+        let url = URL(string: "file://")!
+        let voiceRecord = VoiceRecord.stub(audioFilePath: url)
         await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
         await repository.expectCreate(callCount: 0)
 
@@ -186,10 +173,7 @@ extension CreateVoiceNoteUseCaseTests {
 
     func test_execute_지원하지않는확장자이면_unsupportedExtension에러를던진다() async {
         // Given
-        let voiceRecord = VoiceRecord(
-            audioFilePath: URL(fileURLWithPath: "/tmp/test.txt"),
-            duration: 1.0
-        )
+        let voiceRecord = VoiceRecord.stub(audioFilePath: URL(fileURLWithPath: "/tmp/test.txt"))
         await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
         await repository.expectCreate(callCount: 0)
 
@@ -210,10 +194,7 @@ extension CreateVoiceNoteUseCaseTests {
 
     func test_execute_리포지토리가생성실패를반환하면_createFailed에러를던진다() async {
         // Given
-        let voiceRecord = VoiceRecord(
-            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
-            duration: 1.0
-        )
+        let voiceRecord = VoiceRecord.stub()
         await repository.setResult(.failure(.createFailed))
         await repository.expectCreate(callCount: 1, voiceRecordID: voiceRecord.id)
 
@@ -233,10 +214,7 @@ extension CreateVoiceNoteUseCaseTests {
 
     func test_execute_리포지토리가취소를반환하면_cancelled에러를던진다() async {
         // Given
-        let voiceRecord = VoiceRecord(
-            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
-            duration: 1.0
-        )
+        let voiceRecord = VoiceRecord.stub()
         await repository.setResult(.failure(.cancelled))
         await repository.expectCreate(callCount: 1, voiceRecordID: voiceRecord.id)
 
@@ -258,10 +236,7 @@ extension CreateVoiceNoteUseCaseTests {
         // Given
         struct DummyError: Error {}
 
-        let voiceRecord = VoiceRecord(
-            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
-            duration: 1.0
-        )
+        let voiceRecord = VoiceRecord.stub()
         await repository.setResult(.failure(.unknown(DummyError())))
         await repository.expectCreate(callCount: 1, voiceRecordID: voiceRecord.id)
 
@@ -291,10 +266,7 @@ extension CreateVoiceNoteUseCaseTests {
         }
 
         // Given
-        let voiceRecord = VoiceRecord(
-            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
-            duration: 1.0
-        )
+        let voiceRecord = VoiceRecord.stub()
         await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
         await repository.expectCreate(callCount: 0)
 

--- a/ChaGok/Domain/Tests/UseCases/VoiceNotes/CreateVoiceNoteUseCaseTests.swift
+++ b/ChaGok/Domain/Tests/UseCases/VoiceNotes/CreateVoiceNoteUseCaseTests.swift
@@ -1,0 +1,319 @@
+import XCTest
+
+@testable import Domain
+
+final class CreateVoiceNoteUseCaseTests: XCTestCase {
+
+    private var repository: MockVoiceNoteCreateRepository!
+    private var sut: DefaultCreateVoiceNoteUseCase!
+
+    override func setUp() {
+        super.setUp()
+        repository = MockVoiceNoteCreateRepository()
+        sut = DefaultCreateVoiceNoteUseCase(repository: repository)
+    }
+
+    override func tearDown() {
+        sut = nil
+        repository = nil
+        super.tearDown()
+    }
+}
+
+// MARK: - 성공
+
+extension CreateVoiceNoteUseCaseTests {
+
+    func test_execute_유효한입력을넣으면_생성된보이스노트를반환한다() async throws {
+        // Given
+        let voiceRecord = VoiceRecord(
+            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
+            duration: 1.0
+        )
+        let expected = VoiceNote.stub(title: "Created", voiceRecord: voiceRecord)
+        await repository.setResult(.success(expected))
+        await repository.expectCreate(callCount: 1, voiceRecordID: voiceRecord.id)
+
+        // When
+        let result = try await sut.execute(voiceRecord)
+
+        // Then
+        XCTAssertEqual(result.id, expected.id)
+        XCTAssertEqual(result.title, "Created")
+        XCTAssertEqual(result.voiceRecord.id, voiceRecord.id)
+        await repository.verify()
+    }
+
+    func test_execute_대문자확장자여도_정상적으로생성한다() async throws {
+        // Given
+        let voiceRecord = VoiceRecord(
+            audioFilePath: URL(fileURLWithPath: "/tmp/TEST.M4A"),
+            duration: 1.0
+        )
+        let expected = VoiceNote.stub(title: "Created", voiceRecord: voiceRecord)
+        await repository.setResult(.success(expected))
+        await repository.expectCreate(callCount: 1, voiceRecordID: voiceRecord.id)
+
+        // When
+        let result = try await sut.execute(voiceRecord)
+
+        // Then
+        XCTAssertEqual(result.id, expected.id)
+        await repository.verify()
+    }
+}
+
+// MARK: - 실패 / 에러 매핑
+extension CreateVoiceNoteUseCaseTests {
+
+    func test_execute_재생시간이0이면_invalidDuration에러를던진다() async {
+        // Given
+        let voiceRecord = VoiceRecord(
+            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
+            duration: 0.0
+        )
+        await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
+        await repository.expectCreate(callCount: 0)
+
+        // When
+        do {
+            _ = try await sut.execute(voiceRecord)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .invalidDuration(let duration) = error else {
+                return XCTFail("expected .invalidDuration, got \(error)")
+            }
+            XCTAssertEqual(duration, 0.0)
+        }
+
+        await repository.verify()
+    }
+
+    func test_execute_재생시간이NaN이면_invalidDuration에러를던진다() async {
+        // Given
+        let voiceRecord = VoiceRecord(
+            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
+            duration: Double.nan
+        )
+        await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
+        await repository.expectCreate(callCount: 0)
+
+        // When
+        do {
+            _ = try await sut.execute(voiceRecord)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            guard case .invalidDuration(let duration) = error else {
+                return XCTFail("expected .invalidDuration, got \(error)")
+            }
+            XCTAssertTrue(duration.isNaN)
+        }
+
+        await repository.verify()
+    }
+
+    func test_execute_재생시간이무한이면_invalidDuration에러를던진다() async {
+        // Given
+        let voiceRecord = VoiceRecord(
+            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
+            duration: Double.infinity
+        )
+        await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
+        await repository.expectCreate(callCount: 0)
+
+        // When
+        do {
+            _ = try await sut.execute(voiceRecord)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            guard case .invalidDuration(let duration) = error else {
+                return XCTFail("expected .invalidDuration, got \(error)")
+            }
+            XCTAssertTrue(duration.isInfinite)
+        }
+
+        await repository.verify()
+    }
+
+    func test_execute_오디오경로가파일URL이아니면_invalidAudioFilePath에러를던진다() async {
+        // Given
+        let voiceRecord = VoiceRecord(
+            audioFilePath: URL(string: "https://example.com/test.m4a")!,
+            duration: 1.0
+        )
+        await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
+        await repository.expectCreate(callCount: 0)
+
+        // When
+        do {
+            _ = try await sut.execute(voiceRecord)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .invalidAudioFilePath(let url) = error else {
+                return XCTFail("expected .invalidAudioFilePath, got \(error)")
+            }
+            XCTAssertEqual(url, voiceRecord.audioFilePath)
+        }
+
+        await repository.verify()
+    }
+
+    func test_execute_파일명이비어있으면_emptyFileName에러를던진다() async {
+        // Given
+        // "file://" 는 lastPathComponent가 빈 문자열이 됨
+        let voiceRecord = VoiceRecord(
+            audioFilePath: URL(string: "file://")!,
+            duration: 1.0
+        )
+        await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
+        await repository.expectCreate(callCount: 0)
+
+        // When
+        do {
+            _ = try await sut.execute(voiceRecord)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .emptyFileName = error else {
+                return XCTFail("expected .emptyFileName, got \(error)")
+            }
+        }
+
+        await repository.verify()
+    }
+
+    func test_execute_지원하지않는확장자이면_unsupportedExtension에러를던진다() async {
+        // Given
+        let voiceRecord = VoiceRecord(
+            audioFilePath: URL(fileURLWithPath: "/tmp/test.txt"),
+            duration: 1.0
+        )
+        await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
+        await repository.expectCreate(callCount: 0)
+
+        // When
+        do {
+            _ = try await sut.execute(voiceRecord)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .unsupportedExtension(let ext) = error else {
+                return XCTFail("expected .unsupportedExtension, got \(error)")
+            }
+            XCTAssertEqual(ext, "txt")
+        }
+
+        await repository.verify()
+    }
+
+    func test_execute_리포지토리가생성실패를반환하면_createFailed에러를던진다() async {
+        // Given
+        let voiceRecord = VoiceRecord(
+            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
+            duration: 1.0
+        )
+        await repository.setResult(.failure(.createFailed))
+        await repository.expectCreate(callCount: 1, voiceRecordID: voiceRecord.id)
+
+        // When
+        do {
+            _ = try await sut.execute(voiceRecord)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .createFailed = error else {
+                return XCTFail("expected .createFailed, got \(error)")
+            }
+        }
+
+        await repository.verify()
+    }
+
+    func test_execute_리포지토리가취소를반환하면_cancelled에러를던진다() async {
+        // Given
+        let voiceRecord = VoiceRecord(
+            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
+            duration: 1.0
+        )
+        await repository.setResult(.failure(.cancelled))
+        await repository.expectCreate(callCount: 1, voiceRecordID: voiceRecord.id)
+
+        // When
+        do {
+            _ = try await sut.execute(voiceRecord)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .cancelled = error else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+        }
+
+        await repository.verify()
+    }
+
+    func test_execute_리포지토리가알수없는에러를반환하면_unknown에러를던진다() async {
+        // Given
+        struct DummyError: Error {}
+
+        let voiceRecord = VoiceRecord(
+            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
+            duration: 1.0
+        )
+        await repository.setResult(.failure(.unknown(DummyError())))
+        await repository.expectCreate(callCount: 1, voiceRecordID: voiceRecord.id)
+
+        // When
+        do {
+            _ = try await sut.execute(voiceRecord)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .unknown(let underlying) = error else {
+                return XCTFail("expected .unknown, got \(error)")
+            }
+            XCTAssertTrue(underlying is DummyError)
+        }
+
+        await repository.verify()
+    }
+}
+
+// MARK: - Task 취소
+
+extension CreateVoiceNoteUseCaseTests {
+
+    func test_execute_실행전에태스크가취소되면_리포지토리호출없이cancelled에러를던진다() async {
+        guard let sut else {
+            return XCTFail("sut should be initialized in setUp")
+        }
+
+        // Given
+        let voiceRecord = VoiceRecord(
+            audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"),
+            duration: 1.0
+        )
+        await repository.setResult(.success(VoiceNote.stub(voiceRecord: voiceRecord)))
+        await repository.expectCreate(callCount: 0)
+
+        // When
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await sut.execute(voiceRecord)
+        }
+
+        // Then
+        do {
+            _ = try await task.value
+            XCTFail("취소 에러를 throw 해야 합니다.")
+        } catch {
+            guard case .cancelled = error as? CreateVoiceNoteUseCaseError else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+        }
+
+        await repository.verify()
+    }
+}

--- a/ChaGok/Domain/Tests/UseCases/VoiceNotes/FetchVoiceNoteUseCaseTests.swift
+++ b/ChaGok/Domain/Tests/UseCases/VoiceNotes/FetchVoiceNoteUseCaseTests.swift
@@ -1,0 +1,322 @@
+import XCTest
+
+@testable import Domain
+
+final class FetchVoiceNoteUseCaseTests: XCTestCase {
+
+    private var repository: MockVoiceNoteFetchRepository!
+    private var sut: DefaultFetchVoiceNoteUseCase!
+
+    override func setUp() {
+        super.setUp()
+        repository = MockVoiceNoteFetchRepository()
+        sut = DefaultFetchVoiceNoteUseCase(repository: repository)
+    }
+
+    override func tearDown() {
+        sut = nil
+        repository = nil
+        super.tearDown()
+    }
+}
+
+// MARK: - 성공
+
+extension FetchVoiceNoteUseCaseTests {
+
+    func test_execute_전체조회에성공하면_보이스노트목록을반환한다() async throws {
+        // Given
+        let folderID = UUID()
+        let expectedNotes = [
+            VoiceNote.stub(title: "Title 1"),
+            VoiceNote.stub(title: "Title 2"),
+        ]
+        await repository.setFetchAllResult(.success(expectedNotes))
+        await repository.expectFetchAll(callCount: 1, folderID: folderID)
+
+        // When
+        let result = try await sut.execute(folderID: folderID)
+
+        // Then
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.first?.title, "Title 1")
+        XCTAssertEqual(result.last?.title, "Title 2")
+        await repository.verify()
+    }
+
+    func test_executeById_ID조회에성공하면_보이스노트를반환한다() async throws {
+        // Given
+        let id = UUID()
+        let expectedNote = VoiceNote.stub(id: id, title: "Title")
+        await repository.setFetchByIdResult(.success(expectedNote))
+        await repository.expectFetchById(callCount: 1, id: id)
+
+        // When
+        let result = try await sut.execute(byId: id)
+
+        // Then
+        XCTAssertEqual(result.id, id)
+        XCTAssertEqual(result.title, "Title")
+        await repository.verify()
+    }
+}
+
+// MARK: - 실패 / 에러 매핑
+
+extension FetchVoiceNoteUseCaseTests {
+
+    func test_execute_전체조회가실패하면_fetchAllFailed에러를던진다() async {
+        // Given
+        let folderID = UUID()
+        await repository.setFetchAllResult(.failure(.fetchAllFailed(folderID: folderID)))
+        await repository.expectFetchAll(callCount: 1, folderID: folderID)
+
+        // When
+        do {
+            _ = try await sut.execute(folderID: folderID)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .fetchAllFailed(let mappedFolderID) = error else {
+                return XCTFail("expected .fetchAllFailed, got \(error)")
+            }
+            XCTAssertEqual(mappedFolderID, folderID)
+        }
+
+        await repository.verify()
+    }
+
+    func test_executeById_레코드를찾을수없으면_recordNotFound에러를던진다() async {
+        // Given
+        let id = UUID()
+        await repository.setFetchByIdResult(.failure(.recordNotFound(id: id)))
+        await repository.expectFetchById(callCount: 1, id: id)
+
+        // When
+        do {
+            _ = try await sut.execute(byId: id)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .recordNotFound(let mappedID) = error else {
+                return XCTFail("expected .recordNotFound, got \(error)")
+            }
+            XCTAssertEqual(mappedID, id)
+        }
+
+        await repository.verify()
+    }
+
+    func test_execute_리포지토리가조회실패를반환하면_fetchFailed에러를던진다() async {
+        // Given
+        let folderID = UUID()
+        let targetID = UUID()
+        await repository.setFetchAllResult(.failure(.fetchFailed(id: targetID)))
+        await repository.expectFetchAll(callCount: 1, folderID: folderID)
+
+        // When
+        do {
+            _ = try await sut.execute(folderID: folderID)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .fetchFailed(let mappedID) = error else {
+                return XCTFail("expected .fetchFailed, got \(error)")
+            }
+            XCTAssertEqual(mappedID, targetID)
+        }
+
+        await repository.verify()
+    }
+
+    func test_execute_리포지토리가취소를반환하면_cancelled에러를던진다() async {
+        // Given
+        let folderID = UUID()
+        await repository.setFetchAllResult(.failure(.cancelled))
+        await repository.expectFetchAll(callCount: 1, folderID: folderID)
+
+        // When
+        do {
+            _ = try await sut.execute(folderID: folderID)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .cancelled = error else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+        }
+
+        await repository.verify()
+    }
+
+    func test_execute_리포지토리가알수없는에러를반환하면_unknown에러를던진다() async {
+        // Given
+        let folderID = UUID()
+        struct DummyError: Error {}
+        await repository.setFetchAllResult(.failure(.unknown(DummyError())))
+        await repository.expectFetchAll(callCount: 1, folderID: folderID)
+
+        // When
+        do {
+            _ = try await sut.execute(folderID: folderID)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .unknown(let underlying) = error else {
+                return XCTFail("expected .unknown, got \(error)")
+            }
+            XCTAssertTrue(underlying is DummyError)
+        }
+
+        await repository.verify()
+    }
+
+    func test_executeById_리포지토리가전체조회실패를반환하면_fetchAllFailed에러를던진다() async {
+        // Given
+        let id = UUID()
+        let folderID = UUID()
+        await repository.setFetchByIdResult(.failure(.fetchAllFailed(folderID: folderID)))
+        await repository.expectFetchById(callCount: 1, id: id)
+
+        // When
+        do {
+            _ = try await sut.execute(byId: id)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .fetchAllFailed(let mappedFolderID) = error else {
+                return XCTFail("expected .fetchAllFailed, got \(error)")
+            }
+            XCTAssertEqual(mappedFolderID, folderID)
+        }
+
+        await repository.verify()
+    }
+
+    func test_executeById_리포지토리가조회실패를반환하면_fetchFailed에러를던진다() async {
+        // Given
+        let id = UUID()
+        await repository.setFetchByIdResult(.failure(.fetchFailed(id: id)))
+        await repository.expectFetchById(callCount: 1, id: id)
+
+        // When
+        do {
+            _ = try await sut.execute(byId: id)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .fetchFailed(let mappedID) = error else {
+                return XCTFail("expected .fetchFailed, got \(error)")
+            }
+            XCTAssertEqual(mappedID, id)
+        }
+
+        await repository.verify()
+    }
+
+    func test_executeById_리포지토리가취소를반환하면_cancelled에러를던진다() async {
+        // Given
+        let id = UUID()
+        await repository.setFetchByIdResult(.failure(.cancelled))
+        await repository.expectFetchById(callCount: 1, id: id)
+
+        // When
+        do {
+            _ = try await sut.execute(byId: id)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .cancelled = error else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+        }
+
+        await repository.verify()
+    }
+
+    func test_executeById_리포지토리가알수없는에러를반환하면_unknown에러를던진다() async {
+        // Given
+        struct DummyError: Error {}
+
+        let id = UUID()
+        await repository.setFetchByIdResult(.failure(.unknown(DummyError())))
+        await repository.expectFetchById(callCount: 1, id: id)
+
+        // When
+        do {
+            _ = try await sut.execute(byId: id)
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .unknown(let underlying) = error else {
+                return XCTFail("expected .unknown, got \(error)")
+            }
+            XCTAssertTrue(underlying is DummyError)
+        }
+
+        await repository.verify()
+    }
+}
+
+// MARK: - Task 취소
+
+extension FetchVoiceNoteUseCaseTests {
+
+    func test_execute_태스크가취소되면_리포지토리호출없이cancelled에러를던진다() async {
+        guard let sut else {
+            return XCTFail("sut should be initialized in setUp")
+        }
+
+        // Given
+        let folderID = UUID()
+        await repository.setFetchAllResult(.success([]))
+        await repository.expectFetchAll(callCount: 0)
+
+        // When
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await sut.execute(folderID: folderID)
+        }
+
+        // Then
+        do {
+            _ = try await task.value
+            XCTFail("취소 에러를 throw 해야 합니다.")
+        } catch {
+            guard case .cancelled = error as? FetchVoiceNoteUseCaseError else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+        }
+
+        await repository.verify()
+    }
+
+    func test_executeById_태스크가취소되면_리포지토리호출없이cancelled에러를던진다() async {
+        guard let sut else {
+            return XCTFail("sut should be initialized in setUp")
+        }
+
+        // Given
+        let id = UUID()
+        await repository.setFetchByIdResult(.success(VoiceNote.stub(id: id)))
+        await repository.expectFetchById(callCount: 0)
+
+        // When
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await sut.execute(byId: id)
+        }
+
+        // Then
+        do {
+            _ = try await task.value
+            XCTFail("취소 에러를 throw 해야 합니다.")
+        } catch {
+            guard case .cancelled = error as? FetchVoiceNoteUseCaseError else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+        }
+
+        await repository.verify()
+    }
+}


### PR DESCRIPTION
## ✨ 작업 요약
음성 메모 생성(`CreateVoiceNoteUseCase`) 및 조회(`FetchVoiceNoteUseCase`) 기능을 구현하고, 이에 대한 단위 테스트를 추가합니다.

## 📋 구체적인 내용
- **CreateVoiceNoteUseCase 구현**: 음성 메모 생성을 위한 비즈니스 로직 구현 및 오디오 파일 확장자 검증(`Set<String>` 기반) 추가
- **FetchVoiceNoteUseCase 구현**: 특정 ID 또는 폴더 단위의 음성 메모 조회를 위한 유스케이스 구현
- **도메인 에러 정의**: 각 유스케이스별 전용 에러(`CreateVoiceNoteUseCaseError`, `FetchVoiceNoteUseCaseError`) 정의 및 에러 매핑
- **테스트 기반 구축**: `VoiceNote`, `VoiceRecord` 테스트용 `Stub` 및 `Mock Repository` 구현으로 테스트 효율성 향상
- **단위 테스트 작성**: 성공/실패 시나리오, 엣지 케이스(재생 시간 0, 지원하지 않는 확장자 등), 작업 취소(Cancellation)에 대한 검증 완료

## 🔗 연관 이슈
- closed #73 

## 🧩 설계·구현 노트
- **도메인 레이어 순수성 유지**: Apple 전용 프레임워크인 `UniformTypeIdentifiers` 대신 `Set<String>`을 사용하여 오디오 파일 확장자를 검증함으로써 플랫폼 의존성을 제거했습니다.
- **네이밍 컨벤션 통일**: 기존의 `ReadVoiceNote`를 `FetchVoiceNote`로 리네이밍하여 프로젝트 내의 조회 작업 명명 규칙을 일관성 있게 맞추었습니다.
- **테스트 가독성 개선**: 테스트 코드에서 `Stub`을 적극적으로 활용하여 불필요한 엔티티 초기화 로직을 제거하고, 테스트의 핵심 의도가 잘 드러나도록 리팩토링했습니다.

## ✅ 확인 사항
- [x] 정상 플로우 동작 확인
- [x] 엣지 케이스 / 빈 값·에러 처리 확인
- [x] (로직 추가 시) 테스트 추가 여부

## 👀 리뷰 포인트
- 유스케이스에서의 확장자 검증 로직이 도메인 규칙으로서 적절한지 확인 부탁드립니다.
- 에러 매핑 구조가 다른 유스케이스들과 일관성을 유지하고 있는지 검토 부탁드립니다.
- 단위 테스트의 커버리지와 `Stub` 활용 방식이 적절한지 의견 주시면 감사하겠습니다.