### PR TITLE
WorkSpace(기본 폴더, 루트 URL) UseCase 단위 테스트를 추가합니다.

### DIFF
--- a/ChaGok/Domain/Tests/WorkSpace/FetchBasicFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/FetchBasicFolderUseCaseTest.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import Domain
+
+final class FetchBasicFolderUseCaseTest: XCTestCase {
+    typealias UseCaseError = FetchBasicFolderUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension FetchBasicFolderUseCaseTest {
+    /// 성공 Case: Repository가 정상적으로 Folder를 반환할 때
+    func test_execute_returnsFolder_whenRepositorySucceeds() async throws {
+        // Given
+        let expectedFolder = Folder(path: URL(fileURLWithPath: "/test"), name: "Basic Folder")
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .success(expectedFolder)
+            )
+        )
+
+        // When
+        let folder = try await useCase.execute()
+
+        // Then
+        XCTAssertEqual(folder.id, expectedFolder.id)
+        XCTAssertEqual(folder.name, expectedFolder.name)
+    }
+}
+
+// MARK: - Error Cases
+
+extension FetchBasicFolderUseCaseTest {
+    /// 찾을 수 없음 Case: Repo에서 .notFound를 반환할 때 대칭 확인
+    func test_execute_throwsNotFound_whenRepositoryReturnsNotFound() async {
+        // Given
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .notFound
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("기본 폴더가 없는 경우 .notFound 에러가 발생해야 합니다.")
+        } catch UseCaseError.notFound {
+            // Success
+        } catch {
+            XCTFail("Expected .notFound, got \(error)")
+        }
+    }
+
+    /// 생성 실패 Case: Repo에서 .createFailed를 반환할 때 대칭 확인
+    func test_execute_throwsCreateFailed_whenRepositoryReturnsCreateFailed() async {
+        // Given
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .createFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("생성 실패 시 .createFailed 에러가 발생해야 합니다.")
+        } catch UseCaseError.createFailed {
+            // Success
+        } catch {
+            XCTFail("Expected .createFailed, got \(error)")
+        }
+    }
+
+    /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+        // Given
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .unknown(dummyError)
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("알 수 없는 에러 발생 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            // RepoError.unknown 내부의 Dummy 에러가 유지되어야 함
+            XCTAssertTrue(error is Dummy)
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+}
+
+// MARK: - Error Cases ( Cancelled )
+
+extension FetchBasicFolderUseCaseTest {
+    /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
+    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+        // Given
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .cancelled
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("작업 취소의 경우 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case: 작업이 즉시 취소된 경우
+    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+        // Given
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .success(Folder(path: URL(fileURLWithPath: "/"), name: "test"))
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute() }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업이 즉시 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case (During Execution): 작업 도중 Task가 취소된 경우
+    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
+        // Given
+        let useCase = DefaultFetchBasicFolderUseCase(
+            repository: MockWorkSpaceRepository(
+                basicFolderBehavior: .success(Folder(path: URL(fileURLWithPath: "/"), name: "test")),
+                rootUrlDelay: 100_000_000 // 0.1초 지연
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute() }
+
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기 후 취소
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/WorkSpace/FetchBasicFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/FetchBasicFolderUseCaseTest.swift
@@ -8,13 +8,14 @@ final class FetchBasicFolderUseCaseTest: XCTestCase {
 // MARK: - Success Cases
 
 extension FetchBasicFolderUseCaseTest {
-    /// 성공 Case: Repository가 정상적으로 Folder를 반환할 때
-    func test_execute_returnsFolder_whenRepositorySucceeds() async throws {
+
+    func test_execute_리포지토리가성공했을때_Folder를반환한다() async throws {
         // Given
         let expectedFolder = Folder(path: URL(fileURLWithPath: "/test"), name: "Basic Folder")
-        let repository = MockWorkSpaceRepository(
-            basicFolderBehavior: .success(expectedFolder)
-        )
+        let repository = MockWorkSpaceRepository()
+        await repository.setBasicFolderResult(.success(expectedFolder))
+        await repository.expectFetchOrCreateBasicFolder(callCount: 1)
+
         let useCase = DefaultFetchBasicFolderUseCase(repository: repository)
 
         // When
@@ -23,18 +24,20 @@ extension FetchBasicFolderUseCaseTest {
         // Then
         XCTAssertEqual(folder.id, expectedFolder.id)
         XCTAssertEqual(folder.name, expectedFolder.name)
-        let callCount = await repository.fetchOrCreateBasicFolderCallCount
-        XCTAssertEqual(callCount, 1, "성공 시 Repository가 한 번 호출되어야 합니다.")
+        await repository.verify()
     }
 }
 
 // MARK: - Error Cases
 
 extension FetchBasicFolderUseCaseTest {
-    /// 찾을 수 없음 Case: Repo에서 .notFound를 반환할 때 대칭 확인
-    func test_execute_throwsNotFound_whenRepositoryReturnsNotFound() async {
+
+    func test_execute_리포지토리에서찾을수없을때_notFound에러를던진다() async {
         // Given
-        let repository = MockWorkSpaceRepository(basicFolderBehavior: .notFound)
+        let repository = MockWorkSpaceRepository()
+        await repository.setBasicFolderResult(.failure(.notFound))
+        await repository.expectFetchOrCreateBasicFolder(callCount: 1)
+
         let useCase = DefaultFetchBasicFolderUseCase(repository: repository)
 
         // When & Then
@@ -43,17 +46,18 @@ extension FetchBasicFolderUseCaseTest {
             XCTFail("기본 폴더가 없는 경우 .notFound 에러가 발생해야 합니다.")
         } catch UseCaseError.notFound {
             // Success
-            let callCount = await repository.fetchOrCreateBasicFolderCallCount
-            XCTAssertEqual(callCount, 1, "검색 실패 시에도 Repository 호출은 1회 발생해야 합니다.")
+            await repository.verify()
         } catch {
             XCTFail("Expected .notFound, got \(error)")
         }
     }
 
-    /// 생성 실패 Case: Repo에서 .createFailed를 반환할 때 대칭 확인
-    func test_execute_throwsCreateFailed_whenRepositoryReturnsCreateFailed() async {
+    func test_execute_리포지토리에서생성실패했을때_createFailed에러를던진다() async {
         // Given
-        let repository = MockWorkSpaceRepository(basicFolderBehavior: .createFailed)
+        let repository = MockWorkSpaceRepository()
+        await repository.setBasicFolderResult(.failure(.createFailed))
+        await repository.expectFetchOrCreateBasicFolder(callCount: 1)
+
         let useCase = DefaultFetchBasicFolderUseCase(repository: repository)
 
         // When & Then
@@ -62,19 +66,20 @@ extension FetchBasicFolderUseCaseTest {
             XCTFail("생성 실패 시 .createFailed 에러가 발생해야 합니다.")
         } catch UseCaseError.createFailed {
             // Success
-            let callCount = await repository.fetchOrCreateBasicFolderCallCount
-            XCTAssertEqual(callCount, 1, "생성 실패 시에도 Repository 호출은 1회 발생해야 합니다.")
+            await repository.verify()
         } catch {
             XCTFail("Expected .createFailed, got \(error)")
         }
     }
 
-    /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
-    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+    func test_execute_리포지토리에서알수없는에러가발생했을때_unknown에러를던진다() async {
         // Given
         struct Dummy: Error {}
         let dummyError = Dummy()
-        let repository = MockWorkSpaceRepository(basicFolderBehavior: .unknown(dummyError))
+        let repository = MockWorkSpaceRepository()
+        await repository.setBasicFolderResult(.failure(.unknown(dummyError)))
+        await repository.expectFetchOrCreateBasicFolder(callCount: 1)
+
         let useCase = DefaultFetchBasicFolderUseCase(repository: repository)
 
         // When & Then
@@ -84,8 +89,7 @@ extension FetchBasicFolderUseCaseTest {
         } catch UseCaseError.unknown(let error) {
             // RepoError.unknown 내부의 Dummy 에러가 유지되어야 함
             XCTAssertTrue(error is Dummy)
-            let callCount = await repository.fetchOrCreateBasicFolderCallCount
-            XCTAssertEqual(callCount, 1, "에러 발생 시에도 Repository 호출은 1회 발생해야 합니다.")
+            await repository.verify()
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
@@ -95,10 +99,13 @@ extension FetchBasicFolderUseCaseTest {
 // MARK: - Error Cases ( Cancelled )
 
 extension FetchBasicFolderUseCaseTest {
-    /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
-    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+
+    func test_execute_리포지토리에서취소되었을때_cancelled에러를던진다() async {
         // Given
-        let repository = MockWorkSpaceRepository(basicFolderBehavior: .cancelled)
+        let repository = MockWorkSpaceRepository()
+        await repository.setBasicFolderResult(.failure(.cancelled))
+        await repository.expectFetchOrCreateBasicFolder(callCount: 1)
+
         let useCase = DefaultFetchBasicFolderUseCase(repository: repository)
 
         // When & Then
@@ -107,32 +114,32 @@ extension FetchBasicFolderUseCaseTest {
             XCTFail("작업 취소의 경우 .cancelled 에러가 발생해야 합니다.")
         } catch UseCaseError.cancelled {
             // Success
-            let callCount = await repository.fetchOrCreateBasicFolderCallCount
-            XCTAssertEqual(callCount, 1, "Repository 진입 후 취소된 경우 호출 횟수는 1회여야 합니다.")
+            await repository.verify()
         } catch {
             XCTFail("Expected .cancelled, got \(error)")
         }
     }
 
-    /// 취소 Case: 작업이 즉시 취소된 경우
-    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+    func test_execute_작업이이미취소되었을때_cancelled에러를던진다() async {
         // Given
-        let repository = MockWorkSpaceRepository(
-            basicFolderBehavior: .success(Folder(path: URL(fileURLWithPath: "/"), name: "test"))
-        )
+        let repository = MockWorkSpaceRepository()
+        await repository.setBasicFolderResult(.success(Folder(path: URL(fileURLWithPath: "/"), name: "test")))
+        await repository.expectFetchOrCreateBasicFolder(callCount: 0)
+
         let useCase = DefaultFetchBasicFolderUseCase(repository: repository)
 
         // When & Then
-        let task = Task { try await useCase.execute() }
-        task.cancel()
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            _ = try await useCase.execute()
+        }
 
         do {
             _ = try await task.value
             XCTFail("작업이 즉시 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
         } catch UseCaseError.cancelled {
             // Success
-            let callCount = await repository.fetchOrCreateBasicFolderCallCount
-            XCTAssertEqual(callCount, 0, "선제적 취소 시 Repository는 단 한 번도 호출되지 않아야 합니다.")
+            await repository.verify()
         } catch {
             XCTFail("Expected .cancelled, got \(error)")
         }

--- a/ChaGok/Domain/Tests/WorkSpace/FetchBasicFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/FetchBasicFolderUseCaseTest.swift
@@ -12,11 +12,10 @@ extension FetchBasicFolderUseCaseTest {
     func test_execute_returnsFolder_whenRepositorySucceeds() async throws {
         // Given
         let expectedFolder = Folder(path: URL(fileURLWithPath: "/test"), name: "Basic Folder")
-        let useCase = DefaultFetchBasicFolderUseCase(
-            repository: MockWorkSpaceRepository(
-                basicFolderBehavior: .success(expectedFolder)
-            )
+        let repository = MockWorkSpaceRepository(
+            basicFolderBehavior: .success(expectedFolder)
         )
+        let useCase = DefaultFetchBasicFolderUseCase(repository: repository)
 
         // When
         let folder = try await useCase.execute()
@@ -24,6 +23,8 @@ extension FetchBasicFolderUseCaseTest {
         // Then
         XCTAssertEqual(folder.id, expectedFolder.id)
         XCTAssertEqual(folder.name, expectedFolder.name)
+        let callCount = await repository.fetchOrCreateBasicFolderCallCount
+        XCTAssertEqual(callCount, 1, "성공 시 Repository가 한 번 호출되어야 합니다.")
     }
 }
 
@@ -33,11 +34,8 @@ extension FetchBasicFolderUseCaseTest {
     /// 찾을 수 없음 Case: Repo에서 .notFound를 반환할 때 대칭 확인
     func test_execute_throwsNotFound_whenRepositoryReturnsNotFound() async {
         // Given
-        let useCase = DefaultFetchBasicFolderUseCase(
-            repository: MockWorkSpaceRepository(
-                basicFolderBehavior: .notFound
-            )
-        )
+        let repository = MockWorkSpaceRepository(basicFolderBehavior: .notFound)
+        let useCase = DefaultFetchBasicFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -45,6 +43,8 @@ extension FetchBasicFolderUseCaseTest {
             XCTFail("기본 폴더가 없는 경우 .notFound 에러가 발생해야 합니다.")
         } catch UseCaseError.notFound {
             // Success
+            let callCount = await repository.fetchOrCreateBasicFolderCallCount
+            XCTAssertEqual(callCount, 1, "검색 실패 시에도 Repository 호출은 1회 발생해야 합니다.")
         } catch {
             XCTFail("Expected .notFound, got \(error)")
         }
@@ -53,11 +53,8 @@ extension FetchBasicFolderUseCaseTest {
     /// 생성 실패 Case: Repo에서 .createFailed를 반환할 때 대칭 확인
     func test_execute_throwsCreateFailed_whenRepositoryReturnsCreateFailed() async {
         // Given
-        let useCase = DefaultFetchBasicFolderUseCase(
-            repository: MockWorkSpaceRepository(
-                basicFolderBehavior: .createFailed
-            )
-        )
+        let repository = MockWorkSpaceRepository(basicFolderBehavior: .createFailed)
+        let useCase = DefaultFetchBasicFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -65,6 +62,8 @@ extension FetchBasicFolderUseCaseTest {
             XCTFail("생성 실패 시 .createFailed 에러가 발생해야 합니다.")
         } catch UseCaseError.createFailed {
             // Success
+            let callCount = await repository.fetchOrCreateBasicFolderCallCount
+            XCTAssertEqual(callCount, 1, "생성 실패 시에도 Repository 호출은 1회 발생해야 합니다.")
         } catch {
             XCTFail("Expected .createFailed, got \(error)")
         }
@@ -75,11 +74,8 @@ extension FetchBasicFolderUseCaseTest {
         // Given
         struct Dummy: Error {}
         let dummyError = Dummy()
-        let useCase = DefaultFetchBasicFolderUseCase(
-            repository: MockWorkSpaceRepository(
-                basicFolderBehavior: .unknown(dummyError)
-            )
-        )
+        let repository = MockWorkSpaceRepository(basicFolderBehavior: .unknown(dummyError))
+        let useCase = DefaultFetchBasicFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -88,6 +84,8 @@ extension FetchBasicFolderUseCaseTest {
         } catch UseCaseError.unknown(let error) {
             // RepoError.unknown 내부의 Dummy 에러가 유지되어야 함
             XCTAssertTrue(error is Dummy)
+            let callCount = await repository.fetchOrCreateBasicFolderCallCount
+            XCTAssertEqual(callCount, 1, "에러 발생 시에도 Repository 호출은 1회 발생해야 합니다.")
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
@@ -100,11 +98,8 @@ extension FetchBasicFolderUseCaseTest {
     /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
     func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
         // Given
-        let useCase = DefaultFetchBasicFolderUseCase(
-            repository: MockWorkSpaceRepository(
-                basicFolderBehavior: .cancelled
-            )
-        )
+        let repository = MockWorkSpaceRepository(basicFolderBehavior: .cancelled)
+        let useCase = DefaultFetchBasicFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -112,6 +107,8 @@ extension FetchBasicFolderUseCaseTest {
             XCTFail("작업 취소의 경우 .cancelled 에러가 발생해야 합니다.")
         } catch UseCaseError.cancelled {
             // Success
+            let callCount = await repository.fetchOrCreateBasicFolderCallCount
+            XCTAssertEqual(callCount, 1, "Repository 진입 후 취소된 경우 호출 횟수는 1회여야 합니다.")
         } catch {
             XCTFail("Expected .cancelled, got \(error)")
         }
@@ -120,11 +117,10 @@ extension FetchBasicFolderUseCaseTest {
     /// 취소 Case: 작업이 즉시 취소된 경우
     func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
         // Given
-        let useCase = DefaultFetchBasicFolderUseCase(
-            repository: MockWorkSpaceRepository(
-                basicFolderBehavior: .success(Folder(path: URL(fileURLWithPath: "/"), name: "test"))
-            )
+        let repository = MockWorkSpaceRepository(
+            basicFolderBehavior: .success(Folder(path: URL(fileURLWithPath: "/"), name: "test"))
         )
+        let useCase = DefaultFetchBasicFolderUseCase(repository: repository)
 
         // When & Then
         let task = Task { try await useCase.execute() }
@@ -135,32 +131,8 @@ extension FetchBasicFolderUseCaseTest {
             XCTFail("작업이 즉시 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
         } catch UseCaseError.cancelled {
             // Success
-        } catch {
-            XCTFail("Expected .cancelled, got \(error)")
-        }
-    }
-
-    /// 취소 Case (During Execution): 작업 도중 Task가 취소된 경우
-    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
-        // Given
-        let useCase = DefaultFetchBasicFolderUseCase(
-            repository: MockWorkSpaceRepository(
-                basicFolderBehavior: .success(Folder(path: URL(fileURLWithPath: "/"), name: "test")),
-                rootUrlDelay: 100_000_000 // 0.1초 지연
-            )
-        )
-
-        // When & Then
-        let task = Task { try await useCase.execute() }
-
-        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기 후 취소
-        task.cancel()
-
-        do {
-            _ = try await task.value
-            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
-        } catch UseCaseError.cancelled {
-            // Success
+            let callCount = await repository.fetchOrCreateBasicFolderCallCount
+            XCTAssertEqual(callCount, 0, "선제적 취소 시 Repository는 단 한 번도 호출되지 않아야 합니다.")
         } catch {
             XCTFail("Expected .cancelled, got \(error)")
         }

--- a/ChaGok/Domain/Tests/WorkSpace/FetchBasicFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/FetchBasicFolderUseCaseTest.swift
@@ -9,7 +9,7 @@ final class FetchBasicFolderUseCaseTest: XCTestCase {
 
 extension FetchBasicFolderUseCaseTest {
 
-    func test_execute_리포지토리가성공했을때_Folder를반환한다() async throws {
+    func test_execute_기본폴더조회에성공하면_Folder를반환한다() async throws {
         // Given
         let expectedFolder = Folder(path: URL(fileURLWithPath: "/test"), name: "Basic Folder")
         let repository = MockWorkSpaceRepository()
@@ -32,7 +32,7 @@ extension FetchBasicFolderUseCaseTest {
 
 extension FetchBasicFolderUseCaseTest {
 
-    func test_execute_리포지토리에서찾을수없을때_notFound에러를던진다() async {
+    func test_execute_기본폴더를찾을수없으면_notFound에러를던진다() async {
         // Given
         let repository = MockWorkSpaceRepository()
         await repository.setBasicFolderResult(.failure(.notFound))
@@ -52,7 +52,7 @@ extension FetchBasicFolderUseCaseTest {
         }
     }
 
-    func test_execute_리포지토리에서생성실패했을때_createFailed에러를던진다() async {
+    func test_execute_기본폴더생성에실패하면_createFailed에러를던진다() async {
         // Given
         let repository = MockWorkSpaceRepository()
         await repository.setBasicFolderResult(.failure(.createFailed))
@@ -72,7 +72,7 @@ extension FetchBasicFolderUseCaseTest {
         }
     }
 
-    func test_execute_리포지토리에서알수없는에러가발생했을때_unknown에러를던진다() async {
+    func test_execute_기본폴더조회중알수없는에러가발생하면_unknown에러를던진다() async {
         // Given
         struct Dummy: Error {}
         let dummyError = Dummy()
@@ -100,7 +100,7 @@ extension FetchBasicFolderUseCaseTest {
 
 extension FetchBasicFolderUseCaseTest {
 
-    func test_execute_리포지토리에서취소되었을때_cancelled에러를던진다() async {
+    func test_execute_기본폴더조회중취소되면_cancelled에러를던진다() async {
         // Given
         let repository = MockWorkSpaceRepository()
         await repository.setBasicFolderResult(.failure(.cancelled))
@@ -120,7 +120,7 @@ extension FetchBasicFolderUseCaseTest {
         }
     }
 
-    func test_execute_작업이이미취소되었을때_cancelled에러를던진다() async {
+    func test_execute_기본폴더조회작업이취소되었으면_즉시cancelled에러를던진다() async {
         // Given
         let repository = MockWorkSpaceRepository()
         await repository.setBasicFolderResult(.success(Folder(path: URL(fileURLWithPath: "/"), name: "test")))

--- a/ChaGok/Domain/Tests/WorkSpace/FetchRootUrlUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/FetchRootUrlUseCaseTest.swift
@@ -13,17 +13,18 @@ extension FetchRootUrlUseCaseTest {
     func test_execute_returnsURL_whenRepositorySucceeds() async throws {
         // Given
         let expectedURL = URL.applicationSupportDirectory
-        let useCase = DefaultFetchRootUrlUseCase(
-            repository: MockWorkSpaceRepository(
-                rootUrlBehavior: .success(expectedURL)
-            )
+        let repository = MockWorkSpaceRepository(
+            rootUrlBehavior: .success(expectedURL)
         )
+        let useCase = DefaultFetchRootUrlUseCase(repository: repository)
 
         // When
         let url = try await useCase.execute()
 
         // Then
         XCTAssertEqual(url, expectedURL)
+        let callCount = await repository.fetchRootURLCallCount
+        XCTAssertEqual(callCount, 1, "성공 시 Repository가 한 번 호출되어야 합니다.")
     }
 }
 
@@ -35,11 +36,8 @@ extension FetchRootUrlUseCaseTest {
     /// UseCase가 .cancelled 에러를 던지는지 확인
     func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
         // Given
-        let useCase = DefaultFetchRootUrlUseCase(
-            repository: MockWorkSpaceRepository(
-                rootUrlBehavior: .cancelled
-            )
-        )
+        let repository = MockWorkSpaceRepository(rootUrlBehavior: .cancelled)
+        let useCase = DefaultFetchRootUrlUseCase(repository: repository)
 
         // When & Then
         do {
@@ -47,19 +45,20 @@ extension FetchRootUrlUseCaseTest {
             XCTFail("Repository가 cancelled 에러를 던지면 UseCase도 cancelled 에러를 던져야 합니다.")
         } catch UseCaseError.cancelled {
             // Success
+            let callCount = await repository.fetchRootURLCallCount
+            XCTAssertEqual(callCount, 1, "Repository까지 진입 후 취소된 경우 호출 횟수는 1회여야 합니다.")
         } catch {
             XCTFail("Expected .cancelled, got \(error)")
         }
     }
 
+    /// 취소 Case: 즉시 취소된경우
+    ///  UserCase의 isCancelled가 있는지 확인
     func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
         // Given
         let testURL: URL = .applicationSupportDirectory
-        let useCase = DefaultFetchRootUrlUseCase(
-            repository: MockWorkSpaceRepository(
-                rootUrlBehavior: .success(testURL)
-            )
-        )
+        let repository = MockWorkSpaceRepository(rootUrlBehavior: .success(testURL))
+        let useCase = DefaultFetchRootUrlUseCase(repository: repository)
 
         // When & Then
         let task = Task { try await useCase.execute() }
@@ -70,35 +69,8 @@ extension FetchRootUrlUseCaseTest {
             XCTFail("이미 취소된 Task이므로 .cancelled 에러가 발생해야 합니다.")
         } catch UseCaseError.cancelled {
             // Success
-        } catch {
-            XCTFail("Expected FetchRootUrlUseCaseError.cancelled, got \(error)")
-        }
-    }
-
-    /// 취소 Case (During Execution): Repository가 작업 중일 때 Task가 취소된 경우
-    /// Repository 또는 UseCase에서 .cancelled 에러를 올바르게 전파하는지 확인
-    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
-        // Given
-        let testURL: URL = .applicationSupportDirectory
-        let useCase = DefaultFetchRootUrlUseCase(
-            repository: MockWorkSpaceRepository(
-                rootUrlBehavior: .success(testURL),
-                rootUrlDelay: 100_000_000 // 0.1초 지연
-            )
-        )
-
-        // When & Then
-        let task = Task { try await useCase.execute() }
-
-        // 작업을 시작할 시간을 조금 준 뒤 취소
-        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기
-        task.cancel()
-
-        do {
-            _ = try await task.value
-            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
-        } catch UseCaseError.cancelled {
-            // Success
+            let callCount = await repository.fetchRootURLCallCount
+            XCTAssertEqual(callCount, 0, "선제적 취소 시 Repository는 단 한 번도 호출되지 않아야 합니다.")
         } catch {
             XCTFail("Expected FetchRootUrlUseCaseError.cancelled, got \(error)")
         }
@@ -110,11 +82,8 @@ extension FetchRootUrlUseCaseTest {
         // Given
         struct Dummy: Error {}
         let dummyError = Dummy()
-        let useCase = DefaultFetchRootUrlUseCase(
-            repository: MockWorkSpaceRepository(
-                rootUrlBehavior: .unknown(dummyError)
-            )
-        )
+        let repository = MockWorkSpaceRepository(rootUrlBehavior: .unknown(dummyError))
+        let useCase = DefaultFetchRootUrlUseCase(repository: repository)
 
         // When & Then
         do {
@@ -124,6 +93,8 @@ extension FetchRootUrlUseCaseTest {
             switch error {
                 case .unknown(let repoError):
                     XCTAssertTrue(repoError is Dummy)
+                    let callCount = await repository.fetchRootURLCallCount
+                    XCTAssertEqual(callCount, 1, "에러 발생 시에도 Repository 호출은 1회 발생해야 합니다.")
                 default:
                     XCTFail("Expected .unknown, got \(error)")
             }

--- a/ChaGok/Domain/Tests/WorkSpace/FetchRootUrlUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/FetchRootUrlUseCaseTest.swift
@@ -8,14 +8,14 @@ final class FetchRootUrlUseCaseTest: XCTestCase {
 // MARK: - Success Cases
 
 extension FetchRootUrlUseCaseTest {
-    /// 성공 Case: Repository가 정상적으로 URL을 반환할 때
-    /// UseCase도 해당 URL을 반환하는지 확인
-    func test_execute_returnsURL_whenRepositorySucceeds() async throws {
+
+    func test_execute_리포지토리가성공했을때_URL을반환한다() async throws {
         // Given
         let expectedURL = URL.applicationSupportDirectory
-        let repository = MockWorkSpaceRepository(
-            rootUrlBehavior: .success(expectedURL)
-        )
+        let repository = MockWorkSpaceRepository()
+        await repository.setRootURLResult(.success(expectedURL))
+        await repository.expectFetchRootURL(callCount: 1)
+
         let useCase = DefaultFetchRootUrlUseCase(repository: repository)
 
         // When
@@ -23,8 +23,7 @@ extension FetchRootUrlUseCaseTest {
 
         // Then
         XCTAssertEqual(url, expectedURL)
-        let callCount = await repository.fetchRootURLCallCount
-        XCTAssertEqual(callCount, 1, "성공 시 Repository가 한 번 호출되어야 합니다.")
+        await repository.verify()
     }
 }
 
@@ -32,11 +31,12 @@ extension FetchRootUrlUseCaseTest {
 
 extension FetchRootUrlUseCaseTest {
 
-    /// 취소 Case (Repository): Repository 단계에서 cancelled 에러가 발생한 경우
-    /// UseCase가 .cancelled 에러를 던지는지 확인
-    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+    func test_execute_리포지토리에서취소되었을때_cancelled에러를던진다() async {
         // Given
-        let repository = MockWorkSpaceRepository(rootUrlBehavior: .cancelled)
+        let repository = MockWorkSpaceRepository()
+        await repository.setRootURLResult(.failure(.cancelled))
+        await repository.expectFetchRootURL(callCount: 1)
+
         let useCase = DefaultFetchRootUrlUseCase(repository: repository)
 
         // When & Then
@@ -45,44 +45,46 @@ extension FetchRootUrlUseCaseTest {
             XCTFail("Repository가 cancelled 에러를 던지면 UseCase도 cancelled 에러를 던져야 합니다.")
         } catch UseCaseError.cancelled {
             // Success
-            let callCount = await repository.fetchRootURLCallCount
-            XCTAssertEqual(callCount, 1, "Repository까지 진입 후 취소된 경우 호출 횟수는 1회여야 합니다.")
+            await repository.verify()
         } catch {
             XCTFail("Expected .cancelled, got \(error)")
         }
     }
 
-    /// 취소 Case: 즉시 취소된경우
-    ///  UserCase의 isCancelled가 있는지 확인
-    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+    func test_execute_작업이이미취소되었을때_즉시cancelled에러를던진다() async {
         // Given
         let testURL: URL = .applicationSupportDirectory
-        let repository = MockWorkSpaceRepository(rootUrlBehavior: .success(testURL))
+        let repository = MockWorkSpaceRepository()
+        await repository.setRootURLResult(.success(testURL))
+        await repository.expectFetchRootURL(callCount: 0)
+
         let useCase = DefaultFetchRootUrlUseCase(repository: repository)
 
         // When & Then
-        let task = Task { try await useCase.execute() }
-        task.cancel()
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+             _ = try await useCase.execute()
+        }
 
         do {
             _ = try await task.value
             XCTFail("이미 취소된 Task이므로 .cancelled 에러가 발생해야 합니다.")
         } catch UseCaseError.cancelled {
             // Success
-            let callCount = await repository.fetchRootURLCallCount
-            XCTAssertEqual(callCount, 0, "선제적 취소 시 Repository는 단 한 번도 호출되지 않아야 합니다.")
+            await repository.verify()
         } catch {
             XCTFail("Expected FetchRootUrlUseCaseError.cancelled, got \(error)")
         }
     }
 
-    /// 알 수 없는 에러 Case: Repository에서 정의되지 않은 에러를 던졌을 때
-    /// UseCase가 이를 .unknown 케이스로 래핑하여 던지는지 확인
-    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+    func test_execute_리포지토리에서알수없는에러가발생했을때_unknown에러를던진다() async {
         // Given
         struct Dummy: Error {}
         let dummyError = Dummy()
-        let repository = MockWorkSpaceRepository(rootUrlBehavior: .unknown(dummyError))
+        let repository = MockWorkSpaceRepository()
+        await repository.setRootURLResult(.failure(.unknown(dummyError)))
+        await repository.expectFetchRootURL(callCount: 1)
+
         let useCase = DefaultFetchRootUrlUseCase(repository: repository)
 
         // When & Then
@@ -93,8 +95,7 @@ extension FetchRootUrlUseCaseTest {
             switch error {
                 case .unknown(let repoError):
                     XCTAssertTrue(repoError is Dummy)
-                    let callCount = await repository.fetchRootURLCallCount
-                    XCTAssertEqual(callCount, 1, "에러 발생 시에도 Repository 호출은 1회 발생해야 합니다.")
+                    await repository.verify()
                 default:
                     XCTFail("Expected .unknown, got \(error)")
             }

--- a/ChaGok/Domain/Tests/WorkSpace/FetchRootUrlUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/FetchRootUrlUseCaseTest.swift
@@ -9,7 +9,7 @@ final class FetchRootUrlUseCaseTest: XCTestCase {
 
 extension FetchRootUrlUseCaseTest {
 
-    func test_execute_리포지토리가성공했을때_URL을반환한다() async throws {
+    func test_execute_루트URL조회에성공하면_URL을반환한다() async throws {
         // Given
         let expectedURL = URL.applicationSupportDirectory
         let repository = MockWorkSpaceRepository()
@@ -31,7 +31,7 @@ extension FetchRootUrlUseCaseTest {
 
 extension FetchRootUrlUseCaseTest {
 
-    func test_execute_리포지토리에서취소되었을때_cancelled에러를던진다() async {
+    func test_execute_루트URL조회중취소되면_cancelled에러를던진다() async {
         // Given
         let repository = MockWorkSpaceRepository()
         await repository.setRootURLResult(.failure(.cancelled))
@@ -51,7 +51,7 @@ extension FetchRootUrlUseCaseTest {
         }
     }
 
-    func test_execute_작업이이미취소되었을때_즉시cancelled에러를던진다() async {
+    func test_execute_루트URL조회작업이이미취소되었으면_즉시cancelled에러를던진다() async {
         // Given
         let testURL: URL = .applicationSupportDirectory
         let repository = MockWorkSpaceRepository()
@@ -77,7 +77,7 @@ extension FetchRootUrlUseCaseTest {
         }
     }
 
-    func test_execute_리포지토리에서알수없는에러가발생했을때_unknown에러를던진다() async {
+    func test_execute_루트URL조회중알수없는에러가발생하면_unknown에러를던진다() async {
         // Given
         struct Dummy: Error {}
         let dummyError = Dummy()

--- a/ChaGok/Domain/Tests/WorkSpace/FetchRootUrlUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/FetchRootUrlUseCaseTest.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import Domain
+
+final class FetchRootUrlUseCaseTest: XCTestCase {
+    typealias UseCaseError = FetchRootUrlUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension FetchRootUrlUseCaseTest {
+    /// 성공 Case: Repository가 정상적으로 URL을 반환할 때
+    /// UseCase도 해당 URL을 반환하는지 확인
+    func test_execute_returnsURL_whenRepositorySucceeds() async throws {
+        // Given
+        let expectedURL = URL.applicationSupportDirectory
+        let useCase = DefaultFetchRootUrlUseCase(
+            repository: MockWorkSpaceRepository(
+                rootUrlBehavior: .success(expectedURL)
+            )
+        )
+
+        // When
+        let url = try await useCase.execute()
+
+        // Then
+        XCTAssertEqual(url, expectedURL)
+    }
+}
+
+// MARK: - Error Cases
+
+extension FetchRootUrlUseCaseTest {
+
+    /// 취소 Case (Repository): Repository 단계에서 cancelled 에러가 발생한 경우
+    /// UseCase가 .cancelled 에러를 던지는지 확인
+    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+        // Given
+        let useCase = DefaultFetchRootUrlUseCase(
+            repository: MockWorkSpaceRepository(
+                rootUrlBehavior: .cancelled
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("Repository가 cancelled 에러를 던지면 UseCase도 cancelled 에러를 던져야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+        // Given
+        let testURL: URL = .applicationSupportDirectory
+        let useCase = DefaultFetchRootUrlUseCase(
+            repository: MockWorkSpaceRepository(
+                rootUrlBehavior: .success(testURL)
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute() }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("이미 취소된 Task이므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected FetchRootUrlUseCaseError.cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case (During Execution): Repository가 작업 중일 때 Task가 취소된 경우
+    /// Repository 또는 UseCase에서 .cancelled 에러를 올바르게 전파하는지 확인
+    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
+        // Given
+        let testURL: URL = .applicationSupportDirectory
+        let useCase = DefaultFetchRootUrlUseCase(
+            repository: MockWorkSpaceRepository(
+                rootUrlBehavior: .success(testURL),
+                rootUrlDelay: 100_000_000 // 0.1초 지연
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute() }
+
+        // 작업을 시작할 시간을 조금 준 뒤 취소
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected FetchRootUrlUseCaseError.cancelled, got \(error)")
+        }
+    }
+
+    /// 알 수 없는 에러 Case: Repository에서 정의되지 않은 에러를 던졌을 때
+    /// UseCase가 이를 .unknown 케이스로 래핑하여 던지는지 확인
+    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+        // Given
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let useCase = DefaultFetchRootUrlUseCase(
+            repository: MockWorkSpaceRepository(
+                rootUrlBehavior: .unknown(dummyError)
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("Repository가 unknown 에러를 던지면 UseCase도 .unknown 에러를 던져야 합니다.")
+        } catch let error {
+            switch error {
+                case .unknown(let repoError):
+                    XCTAssertTrue(repoError is Dummy)
+                default:
+                    XCTFail("Expected .unknown, got \(error)")
+            }
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/WorkSpace/MockWorkSpaceRepository.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/MockWorkSpaceRepository.swift
@@ -1,7 +1,7 @@
 import Foundation
-import Domain
+@testable import Domain
 
-struct MockWorkSpaceRepository: WorkSpaceRepository {
+actor MockWorkSpaceRepository: WorkSpaceRepository {
 
     enum RootURLBehavior: Sendable {
         case success(URL)       // 성공한 경우
@@ -19,7 +19,11 @@ struct MockWorkSpaceRepository: WorkSpaceRepository {
 
     var rootUrlBehavior: RootURLBehavior?
     var basicFolderBehavior: BasicFolderBehavior?
-    var rootUrlDelay: UInt64 = 0
+    var delay: UInt64 = 0
+
+    // 호출 횟수 기록
+    var fetchRootURLCallCount = 0
+    var fetchOrCreateBasicFolderCallCount = 0
 
     typealias RootURLError = Domain.WorkSpaceRootURLRepositoryError
     typealias BasicFolderError = Domain.WorkSpaceBasicFolderRepositoryError
@@ -27,16 +31,18 @@ struct MockWorkSpaceRepository: WorkSpaceRepository {
     init(
         rootUrlBehavior: RootURLBehavior? = nil,
         basicFolderBehavior: BasicFolderBehavior? = nil,
-        rootUrlDelay: UInt64 = 0
+        delay: UInt64 = 0
     ) {
         self.rootUrlBehavior = rootUrlBehavior
         self.basicFolderBehavior = basicFolderBehavior
-        self.rootUrlDelay = rootUrlDelay
+        self.delay = delay
     }
 
     func fetchRootURL() async throws(RootURLError) -> URL {
-        if rootUrlDelay > 0 {
-            try? await Task.sleep(nanoseconds: rootUrlDelay)
+        fetchRootURLCallCount += 1
+
+        if delay > 0 {
+            try? await Task.sleep(nanoseconds: delay)
         }
 
         if Task.isCancelled {
@@ -56,8 +62,10 @@ struct MockWorkSpaceRepository: WorkSpaceRepository {
     }
 
     func fetchOrCreateBasicFolder() async throws(BasicFolderError) -> Domain.Folder {
-        if rootUrlDelay > 0 {
-            try? await Task.sleep(nanoseconds: rootUrlDelay)
+        fetchOrCreateBasicFolderCallCount += 1
+
+        if delay > 0 {
+            try? await Task.sleep(nanoseconds: delay)
         }
 
         if Task.isCancelled {

--- a/ChaGok/Domain/Tests/WorkSpace/MockWorkSpaceRepository.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/MockWorkSpaceRepository.swift
@@ -1,91 +1,87 @@
-import Foundation
+import XCTest
 @testable import Domain
 
 actor MockWorkSpaceRepository: WorkSpaceRepository {
 
-    enum RootURLBehavior: Sendable {
-        case success(URL)       // 성공한 경우
-        case cancelled          // 작업 취소의 경우
-        case unknown(Error)     // 알수 없는 오류
+    // Results
+    private var rootURLResult: Result<URL, WorkSpaceRootURLRepositoryError>?
+    private var basicFolderResult: Result<Folder, WorkSpaceBasicFolderRepositoryError>?
+
+    // 호출 검증 Count
+    private(set) var fetchRootURLCallCount = 0
+    private(set) var fetchOrCreateBasicFolderCallCount = 0
+
+    // Expected Call Counts
+    private var expectedFetchRootURLCallCount: Int?
+    private var expectedFetchOrCreateBasicFolderCallCount: Int?
+
+    // 작업 도중 취소 테스트를 위한 제어 변수
+    private var shouldWaitUntilCancelled = false
+
+    // MARK: - Setup
+
+    func setRootURLResult(_ result: Result<URL, WorkSpaceRootURLRepositoryError>) {
+        self.rootURLResult = result
     }
 
-    enum BasicFolderBehavior: Sendable {
-        case success(Folder)    // 성공한 경우
-        case cancelled          // 작업 취소 경우
-        case notFound           // 기본 폴더를 찾을 수 없는 경우
-        case createFailed       // 기본 폴더 Entity 생성 실패의 경우
-        case unknown(Error)     // 알수 없는 오류
+    func setBasicFolderResult(_ result: Result<Folder, WorkSpaceBasicFolderRepositoryError>) {
+        self.basicFolderResult = result
     }
 
-    var rootUrlBehavior: RootURLBehavior?
-    var basicFolderBehavior: BasicFolderBehavior?
-    var delay: UInt64 = 0
-
-    // 호출 횟수 기록
-    var fetchRootURLCallCount = 0
-    var fetchOrCreateBasicFolderCallCount = 0
-
-    typealias RootURLError = Domain.WorkSpaceRootURLRepositoryError
-    typealias BasicFolderError = Domain.WorkSpaceBasicFolderRepositoryError
-
-    init(
-        rootUrlBehavior: RootURLBehavior? = nil,
-        basicFolderBehavior: BasicFolderBehavior? = nil,
-        delay: UInt64 = 0
-    ) {
-        self.rootUrlBehavior = rootUrlBehavior
-        self.basicFolderBehavior = basicFolderBehavior
-        self.delay = delay
+    func setWaitUntilCancelled(_ shouldWait: Bool) {
+        self.shouldWaitUntilCancelled = shouldWait
     }
 
-    func fetchRootURL() async throws(RootURLError) -> URL {
+    // MARK: - Expectations
+
+    func expectFetchRootURL(callCount: Int) {
+        expectedFetchRootURLCallCount = callCount
+    }
+
+    func expectFetchOrCreateBasicFolder(callCount: Int) {
+        expectedFetchOrCreateBasicFolderCallCount = callCount
+    }
+
+    // MARK: - Verification
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedFetchRootURLCallCount {
+            XCTAssertEqual(fetchRootURLCallCount, expected, "fetchRootURL call count mismatch", file: file, line: line)
+        }
+        if let expected = expectedFetchOrCreateBasicFolderCallCount {
+            XCTAssertEqual(fetchOrCreateBasicFolderCallCount, expected, "fetchOrCreateBasicFolder call count mismatch", file: file, line: line)
+        }
+    }
+
+    // MARK: - WorkSpaceRepository
+
+    func fetchRootURL() async throws(WorkSpaceRootURLRepositoryError) -> URL {
         fetchRootURLCallCount += 1
 
-        if delay > 0 {
-            try? await Task.sleep(nanoseconds: delay)
+        guard let result = rootURLResult else {
+            fatalError("MockWorkSpaceRepository.rootURLResult not set")
         }
 
-        if Task.isCancelled {
-            throw RootURLError.cancelled
-        }
-
-        switch rootUrlBehavior {
+        switch result {
             case .success(let url):
                 return url
-            case .cancelled:
-                throw RootURLError.cancelled
-            case .unknown(let error):
-                throw RootURLError.unknown(error)
-            case .none:
-                fatalError("RootURLBehavior가 없습니다.")
+            case .failure(let error):
+                throw error
         }
     }
 
-    func fetchOrCreateBasicFolder() async throws(BasicFolderError) -> Domain.Folder {
+    func fetchOrCreateBasicFolder() async throws(WorkSpaceBasicFolderRepositoryError) -> Folder {
         fetchOrCreateBasicFolderCallCount += 1
 
-        if delay > 0 {
-            try? await Task.sleep(nanoseconds: delay)
+        guard let result = basicFolderResult else {
+            fatalError("MockWorkSpaceRepository.basicFolderResult not set")
         }
 
-        if Task.isCancelled {
-            throw BasicFolderError.cancelled
-        }
-
-        switch basicFolderBehavior {
+        switch result {
             case .success(let folder):
                 return folder
-            case .cancelled:
-                throw BasicFolderError.cancelled
-            case .notFound:
-                throw BasicFolderError.notFound
-            case .createFailed:
-                throw BasicFolderError.createFailed
-            case .unknown(let error):
-                throw BasicFolderError.unknown(error)
-            case .none:
-                fatalError("BasicFolderBehavior가 없습니다.")
+            case .failure(let error):
+                throw error
         }
     }
-
 }

--- a/ChaGok/Domain/Tests/WorkSpace/MockWorkSpaceRepository.swift
+++ b/ChaGok/Domain/Tests/WorkSpace/MockWorkSpaceRepository.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Domain
+
+struct MockWorkSpaceRepository: WorkSpaceRepository {
+
+    enum RootURLBehavior: Sendable {
+        case success(URL)       // 성공한 경우
+        case cancelled          // 작업 취소의 경우
+        case unknown(Error)     // 알수 없는 오류
+    }
+
+    enum BasicFolderBehavior: Sendable {
+        case success(Folder)    // 성공한 경우
+        case cancelled          // 작업 취소 경우
+        case notFound           // 기본 폴더를 찾을 수 없는 경우
+        case createFailed       // 기본 폴더 Entity 생성 실패의 경우
+        case unknown(Error)     // 알수 없는 오류
+    }
+
+    var rootUrlBehavior: RootURLBehavior?
+    var basicFolderBehavior: BasicFolderBehavior?
+    var rootUrlDelay: UInt64 = 0
+
+    typealias RootURLError = Domain.WorkSpaceRootURLRepositoryError
+    typealias BasicFolderError = Domain.WorkSpaceBasicFolderRepositoryError
+
+    init(
+        rootUrlBehavior: RootURLBehavior? = nil,
+        basicFolderBehavior: BasicFolderBehavior? = nil,
+        rootUrlDelay: UInt64 = 0
+    ) {
+        self.rootUrlBehavior = rootUrlBehavior
+        self.basicFolderBehavior = basicFolderBehavior
+        self.rootUrlDelay = rootUrlDelay
+    }
+
+    func fetchRootURL() async throws(RootURLError) -> URL {
+        if rootUrlDelay > 0 {
+            try? await Task.sleep(nanoseconds: rootUrlDelay)
+        }
+
+        if Task.isCancelled {
+            throw RootURLError.cancelled
+        }
+
+        switch rootUrlBehavior {
+            case .success(let url):
+                return url
+            case .cancelled:
+                throw RootURLError.cancelled
+            case .unknown(let error):
+                throw RootURLError.unknown(error)
+            case .none:
+                fatalError("RootURLBehavior가 없습니다.")
+        }
+    }
+
+    func fetchOrCreateBasicFolder() async throws(BasicFolderError) -> Domain.Folder {
+        if rootUrlDelay > 0 {
+            try? await Task.sleep(nanoseconds: rootUrlDelay)
+        }
+
+        if Task.isCancelled {
+            throw BasicFolderError.cancelled
+        }
+
+        switch basicFolderBehavior {
+            case .success(let folder):
+                return folder
+            case .cancelled:
+                throw BasicFolderError.cancelled
+            case .notFound:
+                throw BasicFolderError.notFound
+            case .createFailed:
+                throw BasicFolderError.createFailed
+            case .unknown(let error):
+                throw BasicFolderError.unknown(error)
+            case .none:
+                fatalError("BasicFolderBehavior가 없습니다.")
+        }
+    }
+
+}


### PR DESCRIPTION
## ✨ 작업 요약
**WorkSpace 도메인 테스트 환경 고도화 및 UseCase 단위 테스트 구현**

---

## 📋 구체적인 내용
- **추가/변경된 동작**:
    - **`MockWorkSpaceRepository` 고도화**: 커스텀 Behavior Enum 대신 Swift 표준 `Result` 타입을 사용하여 성공/실패 시나리오를 주입받도록 개선 (에러 케이스 추가 시 Mock 수정 불필요).
    - **Expectation/Verification 시스템**: Mock 객체 내부에 기대 호출 횟수 설정(`expect...`) 및 통합 검증 메서드(`verify()`)를 도입하여 테스트 코드의 선언성 확보.
    - **`FetchRootUrlUseCaseTest` / `FetchBasicFolderUseCaseTest`**: 
        - 모든 테스트 메서드명을 `test_동작_조건_기대결과` 형식의 한글로 변경하여 가독성 강화.
        - `withUnsafeCurrentTask`를 이용한 선제적 취소(Preemptive Cancellation) 상황 검증 로직 구현.
- **영향 받는 모듈**: `Domain/Tests/WorkSpace`

---

## 🔗 연관 이슈
- close #59
- close #58 

---

## 🧩 설계·구현 노트

- **선택한 방식: Result 기반 Mocking & 전용 Verification**
    - **OCP 준수**: 리포지토리의 에러 Enum에 새로운 케이스가 추가되어도 Mock의 `switch` 문을 수정할 필요가 없는 `Result` 타입을 직접 던지는 방식을 선택했습니다.
    - **테스트 가독성**: 한글 메서드명을 통해 테스트 의도를 명확히 전달하고, `Given-When-Then` 주석과 `verify()` 메서드를 조합하여 복잡한 검증 로직을 단순화했습니다.
- **취소 테스트 전략 변경**
    - 이전에 고려했던 `delay`와 `yield()` 기법 대신, `withUnsafeCurrentTask`를 사용해 시작 전 취소 상태를 확정적으로 만들어 선제적 취소 로직이 제대로 작동하는지 검증했습니다.

---

## ✅ 확인 사항
- [x] 모든 유닛 테스트 통과 확인 (`FetchRootUrl`, `FetchBasicFolder`)
- [x] Mock 객체의 에러 매핑 및 호출 횟수 검증 정상 작동 확인
- [x] 한글 명명 규칙 및 주석 구조의 일관성 확인

---

## 👀 리뷰 포인트

**1. 새로운 Mock 패턴의 적절성**
- `Result<Success, Failure>`를 직접 주입받고 `verify()` 한 줄로 호출 횟수를 검증하는 방식이 기존 방식보다 유지보수하기 편리한지 봐주세요.

**2. 한글 테스트 메서드 명명 규칙**
- `test_동작_조건_기대결과` 형식이 도메인 로직을 설명하는 데 충분히 명확한지 확인 부탁드립니다.

**3. Cancellation Test**
- `withUnsafeCurrentTask`를 이용한 취소 상황 검증이 적절하게 구현되었는지 검토 부탁드립니다.
