### PR TITLE
Recording 관련 UseCase 에러 처리를 개선하고 단위 테스트를 추가합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 buildServer.json
 .DS_Store
 .cursorrules
+.cursor/

--- a/ChaGok/.gitignore
+++ b/ChaGok/.gitignore
@@ -69,3 +69,6 @@ Derived/
 
 ### Tuist managed dependencies ###
 Tuist/.build
+
+### Cursor ###
+.cursor

--- a/ChaGok/Domain/Sources/UseCases/Authority/CheckMicrophonePermissionUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Authority/CheckMicrophonePermissionUseCase.swift
@@ -25,11 +25,17 @@ public struct DefaultCheckMicrophonePermissionUseCase: CheckMicrophonePermission
             try await repository.checkRecordingPermission()
         } catch {
             AppLogger.error(error)
-            switch error {
-            case .permissionDenied: throw .permissionDenied
-            case .cancelled: throw .cancelled
-            case .unknown(let error): throw .unknown(error)
-            }
+            throw CheckMicrophonePermissionUseCaseError(error)
+        }
+    }
+}
+
+extension CheckMicrophonePermissionUseCaseError {
+    fileprivate init(_ error: VoiceRecordPermissionRepositoryError) {
+        switch error {
+        case .permissionDenied: self = .permissionDenied
+        case .cancelled: self = .cancelled
+        case .unknown(let error): self = .unknown(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/VoiceRecords/FinishRecordingUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/VoiceRecords/FinishRecordingUseCase.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// 녹음 완료 유스케이스 프로토콜.
 /// 녹음을 종료하고, 저장된 오디오 파일 경로·길이 등이 담긴 `VoiceRecord`를 반환합니다.
-public protocol FinishRecordingUseCase {
+public protocol FinishRecordingUseCase: Sendable {
     /// 녹음을 완료하고 저장된 녹음 정보를 반환합니다.
     /// - Returns: 저장된 녹음 엔티티 (id, 생성일시, 오디오 파일 경로, 길이 등)
     /// - Throws: `FinishRecordingUseCaseError` (녹음 진행 중 아님, 저장·인코딩 실패)
@@ -25,13 +25,19 @@ public struct DefaultFinishRecordingUseCase: FinishRecordingUseCase {
             return try await recordingRepository.finishRecording()
         } catch {
             AppLogger.error(error)
-            switch error {
-            case .notRecording: throw .notRecording
-            case .finishFailed: throw .finishFailed
-            case .encodingFailed: throw .encodingFailed
-            case .cancelled: throw .cancelled
-            case .unknown(let error): throw .unknown(error)
-            }
+            throw FinishRecordingUseCaseError(error)
+        }
+    }
+}
+
+extension FinishRecordingUseCaseError {
+    fileprivate init(_ error: VoiceRecordFinishRepositoryError) {
+        switch error {
+        case .notRecording: self = .notRecording
+        case .finishFailed: self = .finishFailed
+        case .encodingFailed: self = .encodingFailed
+        case .cancelled: self = .cancelled
+        case .unknown(let error): self = .unknown(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/VoiceRecords/PauseRecordingUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/VoiceRecords/PauseRecordingUseCase.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// 녹음 일시정지 유스케이스 프로토콜.
 /// 이미 시작된 녹음을 일시 정지할 때 사용합니다. 재시작은 `ResumeRecordingUseCase`로 합니다.
-public protocol PauseRecordingUseCase {
+public protocol PauseRecordingUseCase: Sendable {
     /// 녹음을 일시 정지합니다.
     /// - Throws: `PauseRecordingUseCaseError` (녹음 진행 중 아님, 일시정지 실패)
     func execute() async throws(PauseRecordingUseCaseError)
@@ -24,12 +24,18 @@ public struct DefaultPauseRecordingUseCase: PauseRecordingUseCase {
             try await recordingRepository.pauseRecording()
         } catch {
             AppLogger.error(error)
-            switch error {
-            case .notRecording: throw .notRecording
-            case .pauseFailed: throw .pauseFailed
-            case .cancelled: throw .cancelled
-            case .unknown(let error): throw .unknown(error)
-            }
+            throw PauseRecordingUseCaseError(error)
+        }
+    }
+}
+
+extension PauseRecordingUseCaseError {
+    fileprivate init(_ error: VoiceRecordPauseRepositoryError) {
+        switch error {
+        case .notRecording: self = .notRecording
+        case .pauseFailed: self = .pauseFailed
+        case .cancelled: self = .cancelled
+        case .unknown(let error): self = .unknown(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/VoiceRecords/ResumeRecordingUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/VoiceRecords/ResumeRecordingUseCase.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// 녹음 재시작 유스케이스 프로토콜.
 /// `PauseRecordingUseCase`로 일시 정지한 녹음을 재개할 때 사용합니다.
-public protocol ResumeRecordingUseCase {
+public protocol ResumeRecordingUseCase: Sendable {
     /// 녹음을 재시작합니다.
     /// - Throws: `ResumeRecordingUseCaseError` (일시 정지된 녹음 없음, 재시작 실패)
     func execute() async throws(ResumeRecordingUseCaseError)
@@ -24,12 +24,18 @@ public struct DefaultResumeRecordingUseCase: ResumeRecordingUseCase {
             try await recordingRepository.resumeRecording()
         } catch {
             AppLogger.error(error)
-            switch error {
-            case .notPaused: throw .notPaused
-            case .resumeFailed: throw .resumeFailed
-            case .cancelled: throw .cancelled
-            case .unknown(let error): throw .unknown(error)
-            }
+            throw ResumeRecordingUseCaseError(error)
+        }
+    }
+}
+
+extension ResumeRecordingUseCaseError {
+    fileprivate init(_ error: VoiceRecordResumeRepositoryError) {
+        switch error {
+        case .notPaused: self = .notPaused
+        case .resumeFailed: self = .resumeFailed
+        case .cancelled: self = .cancelled
+        case .unknown(let error): self = .unknown(error)
         }
     }
 }

--- a/ChaGok/Domain/Sources/UseCases/VoiceRecords/StartRecordingUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/VoiceRecords/StartRecordingUseCase.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// 녹음 시작 유스케이스 프로토콜.
 /// 호출 시 마이크 권한을 확인하고, 허용된 경우 녹음을 시작한 뒤 파형(Waveform) 스트림을 반환합니다.
-public protocol StartRecordingUseCase {
+public protocol StartRecordingUseCase: Sendable {
     /// 녹음을 시작하고 실시간 파형 데이터 스트림을 반환합니다.
     /// - Returns: 녹음 중 생성되는 파형 샘플 스트림. 호출부에서 `for await`로 소비하여 UI에 파형을 그릴 수 있습니다.
     /// - Throws: `StartRecordingUseCaseError` (권한 거부, 녹음 시작 실패)
@@ -34,25 +34,27 @@ public struct DefaultStartRecordingUseCase: StartRecordingUseCase {
             return try await recordingRepository.startRecording()
         } catch {
             AppLogger.error(error)
-            throw mapFromRepository(error)
+            throw StartRecordingUseCaseError(error)
         }
     }
+}
 
-    private func mapFromRepository(_ error: Error) -> StartRecordingUseCaseError {
+extension StartRecordingUseCaseError {
+    fileprivate init(_ error: Error) {
         if let repositoryError = error as? VoiceRecordPermissionRepositoryError {
             switch repositoryError {
-            case .permissionDenied: return .permissionDenied
-            case .cancelled: return .cancelled
-            case .unknown(let error): return .unknown(error)
+            case .permissionDenied: self = .permissionDenied
+            case .cancelled: self = .cancelled
+            case .unknown(let error): self = .unknown(error)
             }
         } else if let repositoryError = error as? VoiceRecordStartRepositoryError {
             switch repositoryError {
-            case .startFailed: return .startFailed
-            case .cancelled: return .cancelled
-            case .unknown(let error): return .unknown(error)
+            case .startFailed: self = .startFailed
+            case .cancelled: self = .cancelled
+            case .unknown(let error): self = .unknown(error)
             }
         } else {
-            return .unknown(error)
+            self = .unknown(error)
         }
     }
 }

--- a/ChaGok/Domain/Tests/Mocks/Entities/VoiceRecord+Stub.swift
+++ b/ChaGok/Domain/Tests/Mocks/Entities/VoiceRecord+Stub.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+@testable import Domain
+
+extension VoiceRecord {
+    static func stub(
+        id: UUID = UUID(),
+        createdAt: Date = Date(),
+        audioFilePath: URL = URL(fileURLWithPath: "/test/path.m4a"),
+        duration: Double = 60.0
+    ) -> VoiceRecord {
+        VoiceRecord(
+            id: id,
+            createdAt: createdAt,
+            audioFilePath: audioFilePath,
+            duration: duration
+        )
+    }
+}

--- a/ChaGok/Domain/Tests/Mocks/Entities/Waveform+Stub.swift
+++ b/ChaGok/Domain/Tests/Mocks/Entities/Waveform+Stub.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+@testable import Domain
+
+extension Waveform {
+    static func stub(
+        amplitudes: [Float] = [0.1, 0.2]
+    ) -> Waveform {
+        Waveform(amplitudes: amplitudes)
+    }
+}

--- a/ChaGok/Domain/Tests/Mocks/Repositories/VoiceRecords/MockVoiceRecordFinishRepository.swift
+++ b/ChaGok/Domain/Tests/Mocks/Repositories/VoiceRecords/MockVoiceRecordFinishRepository.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import Domain
+
+actor MockVoiceRecordFinishRepository: VoiceRecordFinishRepository {
+
+    private var result: Result<VoiceRecord, VoiceRecordFinishRepositoryError>?
+
+    private var actualFinishRecordingCallCount = 0
+    private var expectedFinishRecordingCallCount: Int?
+
+    func setResult(_ result: Result<VoiceRecord, VoiceRecordFinishRepositoryError>) {
+        self.result = result
+    }
+
+    func expectFinishRecording(callCount: Int) {
+        expectedFinishRecordingCallCount = callCount
+    }
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedFinishRecordingCallCount {
+            XCTAssertEqual(
+                actualFinishRecordingCallCount,
+                expected,
+                "finishRecording callCount",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func finishRecording() async throws(VoiceRecordFinishRepositoryError) -> VoiceRecord {
+        actualFinishRecordingCallCount += 1
+
+        switch result {
+        case .success(let record):
+            return record
+        case .failure(let error):
+            throw error
+        case .none:
+            XCTFail("MockVoiceRecordFinishRepository.result 가 설정되지 않았습니다.")
+            throw .unknown(NSError(domain: "MockVoiceRecordFinishRepository.result", code: -1))
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Mocks/Repositories/VoiceRecords/MockVoiceRecordPauseRepository.swift
+++ b/ChaGok/Domain/Tests/Mocks/Repositories/VoiceRecords/MockVoiceRecordPauseRepository.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import Domain
+
+actor MockVoiceRecordPauseRepository: VoiceRecordPauseRepository {
+
+    private var result: Result<Void, VoiceRecordPauseRepositoryError>?
+
+    private var actualPauseRecordingCallCount = 0
+    private var expectedPauseRecordingCallCount: Int?
+
+    func setResult(_ result: Result<Void, VoiceRecordPauseRepositoryError>) {
+        self.result = result
+    }
+
+    func expectPauseRecording(callCount: Int) {
+        expectedPauseRecordingCallCount = callCount
+    }
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedPauseRecordingCallCount {
+            XCTAssertEqual(
+                actualPauseRecordingCallCount,
+                expected,
+                "pauseRecording callCount",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func pauseRecording() async throws(VoiceRecordPauseRepositoryError) {
+        actualPauseRecordingCallCount += 1
+
+        switch result {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        case .none:
+            XCTFail("MockVoiceRecordPauseRepository.result 가 설정되지 않았습니다.")
+            throw .unknown(NSError(domain: "MockVoiceRecordPauseRepository.result", code: -1))
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Mocks/Repositories/VoiceRecords/MockVoiceRecordPermissionRepository.swift
+++ b/ChaGok/Domain/Tests/Mocks/Repositories/VoiceRecords/MockVoiceRecordPermissionRepository.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import Domain
+
+actor MockVoiceRecordPermissionRepository: VoiceRecordPermissionRepository {
+
+    private var result: Result<Void, VoiceRecordPermissionRepositoryError>?
+
+    private var actualCheckRecordingPermissionCallCount = 0
+    private var expectedCheckRecordingPermissionCallCount: Int?
+
+    func setResult(_ result: Result<Void, VoiceRecordPermissionRepositoryError>) {
+        self.result = result
+    }
+
+    func expectCheckRecordingPermission(callCount: Int) {
+        expectedCheckRecordingPermissionCallCount = callCount
+    }
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedCheckRecordingPermissionCallCount {
+            XCTAssertEqual(
+                actualCheckRecordingPermissionCallCount,
+                expected,
+                "checkRecordingPermission callCount",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func checkRecordingPermission() async throws(VoiceRecordPermissionRepositoryError) {
+        actualCheckRecordingPermissionCallCount += 1
+
+        switch result {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        case .none:
+            XCTFail("MockVoiceRecordPermissionRepository.result 가 설정되지 않았습니다.")
+            throw .unknown(NSError(domain: "MockVoiceRecordPermissionRepository.result", code: -1))
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Mocks/Repositories/VoiceRecords/MockVoiceRecordResumeRepository.swift
+++ b/ChaGok/Domain/Tests/Mocks/Repositories/VoiceRecords/MockVoiceRecordResumeRepository.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import Domain
+
+actor MockVoiceRecordResumeRepository: VoiceRecordResumeRepository {
+
+    private var result: Result<Void, VoiceRecordResumeRepositoryError>?
+
+    private var actualResumeRecordingCallCount = 0
+    private var expectedResumeRecordingCallCount: Int?
+
+    func setResult(_ result: Result<Void, VoiceRecordResumeRepositoryError>) {
+        self.result = result
+    }
+
+    func expectResumeRecording(callCount: Int) {
+        expectedResumeRecordingCallCount = callCount
+    }
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedResumeRecordingCallCount {
+            XCTAssertEqual(
+                actualResumeRecordingCallCount,
+                expected,
+                "resumeRecording callCount",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func resumeRecording() async throws(VoiceRecordResumeRepositoryError) {
+        actualResumeRecordingCallCount += 1
+
+        switch result {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        case .none:
+            XCTFail("MockVoiceRecordResumeRepository.result 가 설정되지 않았습니다.")
+            throw .unknown(NSError(domain: "MockVoiceRecordResumeRepository.result", code: -1))
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Mocks/Repositories/VoiceRecords/MockVoiceRecordStartRepository.swift
+++ b/ChaGok/Domain/Tests/Mocks/Repositories/VoiceRecords/MockVoiceRecordStartRepository.swift
@@ -1,0 +1,46 @@
+import Core
+import XCTest
+
+@testable import Domain
+
+actor MockVoiceRecordStartRepository: VoiceRecordStartRepository {
+
+    private var result: Result<AsyncStream<Waveform>, VoiceRecordStartRepositoryError>?
+
+    private var actualStartRecordingCallCount = 0
+    private var expectedStartRecordingCallCount: Int?
+
+    func setResult(_ result: Result<AsyncStream<Waveform>, VoiceRecordStartRepositoryError>) {
+        self.result = result
+    }
+
+    func expectStartRecording(callCount: Int) {
+        expectedStartRecordingCallCount = callCount
+    }
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedStartRecordingCallCount {
+            XCTAssertEqual(
+                actualStartRecordingCallCount,
+                expected,
+                "startRecording callCount",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func startRecording() async throws(VoiceRecordStartRepositoryError) -> AsyncStream<Waveform> {
+        actualStartRecordingCallCount += 1
+
+        switch result {
+        case .success(let stream):
+            return stream
+        case .failure(let error):
+            throw error
+        case .none:
+            XCTFail("MockVoiceRecordStartRepository.result 가 설정되지 않았습니다.")
+            throw .unknown(NSError(domain: "MockVoiceRecordStartRepository.result", code: -1))
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/UseCases/VoiceRecords/FinishRecordingUseCaseTests.swift
+++ b/ChaGok/Domain/Tests/UseCases/VoiceRecords/FinishRecordingUseCaseTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import XCTest
+
+@testable import Domain
+
+final class FinishRecordingUseCaseTests: XCTestCase {
+
+    private var recordingRepository: MockVoiceRecordFinishRepository!
+    private var sut: DefaultFinishRecordingUseCase!
+
+    override func setUp() {
+        super.setUp()
+        recordingRepository = MockVoiceRecordFinishRepository()
+        sut = DefaultFinishRecordingUseCase(recordingRepository: recordingRepository)
+    }
+
+    override func tearDown() {
+        recordingRepository = nil
+        sut = nil
+        super.tearDown()
+    }
+}
+
+// MARK: - 성공
+extension FinishRecordingUseCaseTests {
+
+    func test_execute_녹음종료에성공하면_생성된VoiceRecord를반환한다() async throws {
+        // Given
+        let expectedRecord = VoiceRecord.stub()
+        await recordingRepository.setResult(.success(expectedRecord))
+        await recordingRepository.expectFinishRecording(callCount: 1)
+
+        // When
+        let record = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(record.id, expectedRecord.id)
+        XCTAssertEqual(record.audioFilePath, expectedRecord.audioFilePath)
+        XCTAssertEqual(record.duration, expectedRecord.duration, accuracy: 0.001)
+        await recordingRepository.verify()
+    }
+}
+
+// MARK: - 실패 / 에러 매핑
+extension FinishRecordingUseCaseTests {
+
+    func test_execute_녹음중이아니면_notRecording에러를던진다() async {
+        // Given
+        await recordingRepository.setResult(.failure(.notRecording))
+        await recordingRepository.expectFinishRecording(callCount: 1)
+
+        // When
+        do {
+            _ = try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .notRecording = error else {
+                return XCTFail("expected .notRecording, got \(error)")
+            }
+        }
+
+        await recordingRepository.verify()
+    }
+
+    func test_execute_녹음종료에실패하면_finishFailed에러를던진다() async {
+        // Given
+        await recordingRepository.setResult(.failure(.finishFailed))
+        await recordingRepository.expectFinishRecording(callCount: 1)
+
+        // When
+        do {
+            _ = try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .finishFailed = error else {
+                return XCTFail("expected .finishFailed, got \(error)")
+            }
+        }
+
+        await recordingRepository.verify()
+    }
+
+    func test_execute_인코딩에실패하면_encodingFailed에러를던진다() async {
+        // Given
+        await recordingRepository.setResult(.failure(.encodingFailed))
+        await recordingRepository.expectFinishRecording(callCount: 1)
+
+        // When
+        do {
+            _ = try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .encodingFailed = error else {
+                return XCTFail("expected .encodingFailed, got \(error)")
+            }
+        }
+
+        await recordingRepository.verify()
+    }
+
+    func test_execute_녹음종료중취소되면_cancelled에러를던진다() async {
+        // Given
+        await recordingRepository.setResult(.failure(.cancelled))
+        await recordingRepository.expectFinishRecording(callCount: 1)
+
+        // When
+        do {
+            _ = try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .cancelled = error else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+        }
+
+        await recordingRepository.verify()
+    }
+
+    func test_execute_녹음종료중알수없는에러가발생하면_unknown에러를던진다() async {
+        // Given
+        let underlyingError = NSError(domain: "Test", code: 404)
+        await recordingRepository.setResult(.failure(.unknown(underlyingError)))
+        await recordingRepository.expectFinishRecording(callCount: 1)
+
+        // When
+        do {
+            _ = try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .unknown(let wrappedError) = error else {
+                return XCTFail("expected .unknown, got \(error)")
+            }
+            XCTAssertEqual(wrappedError as NSError, underlyingError)
+        }
+
+        await recordingRepository.verify()
+    }
+}
+
+// MARK: - Task 취소
+extension FinishRecordingUseCaseTests {
+    func test_execute_실행전에태스크가취소되면_리포지토리호출없이cancelled에러를던진다() async {
+        guard let sut else {
+            XCTFail("sut은 반드시 설정되어야 합니다.")
+            return
+        }
+        // Given
+        await recordingRepository.setResult(.success(.stub()))
+        await recordingRepository.expectFinishRecording(callCount: 0)
+
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await sut.execute()
+        }
+
+        // When
+        do {
+            _ = try await task.value
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .cancelled = error as? FinishRecordingUseCaseError else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+            await recordingRepository.verify()
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/UseCases/VoiceRecords/PauseRecordingUseCaseTests.swift
+++ b/ChaGok/Domain/Tests/UseCases/VoiceRecords/PauseRecordingUseCaseTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+
+@testable import Domain
+
+final class PauseRecordingUseCaseTests: XCTestCase {
+
+    private var recordingRepository: MockVoiceRecordPauseRepository!
+    private var sut: DefaultPauseRecordingUseCase!
+
+    override func setUp() {
+        super.setUp()
+        recordingRepository = MockVoiceRecordPauseRepository()
+        sut = DefaultPauseRecordingUseCase(recordingRepository: recordingRepository)
+    }
+
+    override func tearDown() {
+        recordingRepository = nil
+        sut = nil
+        super.tearDown()
+    }
+}
+
+// MARK: - 성공
+extension PauseRecordingUseCaseTests {
+
+    func test_execute_녹음일시정지에성공하면_완료된다() async throws {
+        // Given
+        await recordingRepository.setResult(.success(()))
+        await recordingRepository.expectPauseRecording(callCount: 1)
+
+        // When
+        try await sut.execute()
+
+        // Then
+        await recordingRepository.verify()
+    }
+}
+
+// MARK: - 실패 / 에러 매핑
+extension PauseRecordingUseCaseTests {
+
+    func test_execute_녹음중이아니면_notRecording에러를던진다() async {
+        // Given
+        await recordingRepository.setResult(.failure(.notRecording))
+        await recordingRepository.expectPauseRecording(callCount: 1)
+
+        // When
+        do {
+            try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .notRecording = error else {
+                return XCTFail("expected .notRecording, got \(error)")
+            }
+        }
+
+        await recordingRepository.verify()
+    }
+
+    func test_execute_일시정지에실패하면_pauseFailed에러를던진다() async {
+        // Given
+        await recordingRepository.setResult(.failure(.pauseFailed))
+        await recordingRepository.expectPauseRecording(callCount: 1)
+
+        // When
+        do {
+            try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .pauseFailed = error else {
+                return XCTFail("expected .pauseFailed, got \(error)")
+            }
+        }
+
+        await recordingRepository.verify()
+    }
+
+    func test_execute_일시정지중취소되면_cancelled에러를던진다() async {
+        // Given
+        await recordingRepository.setResult(.failure(.cancelled))
+        await recordingRepository.expectPauseRecording(callCount: 1)
+
+        // When
+        do {
+            try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .cancelled = error else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+        }
+
+        await recordingRepository.verify()
+    }
+
+    func test_execute_일시정지중알수없는에러가발생하면_unknown에러를던진다() async {
+        // Given
+        let underlyingError = NSError(domain: "Test", code: 123)
+        await recordingRepository.setResult(.failure(.unknown(underlyingError)))
+        await recordingRepository.expectPauseRecording(callCount: 1)
+
+        // When
+        do {
+            try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .unknown(let wrappedError) = error else {
+                return XCTFail("expected .unknown, got \(error)")
+            }
+            XCTAssertEqual(wrappedError as NSError, underlyingError)
+        }
+
+        await recordingRepository.verify()
+    }
+}
+
+// MARK: - Task 취소
+extension PauseRecordingUseCaseTests {
+
+    func test_execute_실행전에태스크가취소되면_리포지토리호출없이cancelled에러를던진다() async {
+        guard let sut else {
+            XCTFail("sut은 반드시 설정되어야 합니다.")
+            return
+        }
+        // Given
+        await recordingRepository.setResult(.success(()))
+        await recordingRepository.expectPauseRecording(callCount: 0)
+
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await sut.execute()
+        }
+
+        // When
+        do {
+            _ = try await task.value
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .cancelled = error as? PauseRecordingUseCaseError else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+            await recordingRepository.verify()
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/UseCases/VoiceRecords/ResumeRecordingUseCaseTests.swift
+++ b/ChaGok/Domain/Tests/UseCases/VoiceRecords/ResumeRecordingUseCaseTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+
+@testable import Domain
+
+final class ResumeRecordingUseCaseTests: XCTestCase {
+
+    private var recordingRepository: MockVoiceRecordResumeRepository!
+    private var sut: DefaultResumeRecordingUseCase!
+
+    override func setUp() {
+        super.setUp()
+        recordingRepository = MockVoiceRecordResumeRepository()
+        sut = DefaultResumeRecordingUseCase(recordingRepository: recordingRepository)
+    }
+
+    override func tearDown() {
+        recordingRepository = nil
+        sut = nil
+        super.tearDown()
+    }
+}
+
+// MARK: - 성공
+extension ResumeRecordingUseCaseTests {
+
+    func test_execute_녹음재개에성공하면_완료된다() async throws {
+        // Given
+        await recordingRepository.setResult(.success(()))
+        await recordingRepository.expectResumeRecording(callCount: 1)
+
+        // When
+        try await sut.execute()
+
+        // Then
+        await recordingRepository.verify()
+    }
+}
+
+// MARK: - 실패 / 에러 매핑
+extension ResumeRecordingUseCaseTests {
+
+    func test_execute_일시정지상태가아니면_notPaused에러를던진다() async {
+        // Given
+        await recordingRepository.setResult(.failure(.notPaused))
+        await recordingRepository.expectResumeRecording(callCount: 1)
+
+        // When
+        do {
+            try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .notPaused = error else {
+                return XCTFail("expected .notPaused, got \(error)")
+            }
+        }
+
+        // Then
+        await recordingRepository.verify()
+    }
+
+    func test_execute_재개에실패하면_resumeFailed에러를던진다() async {
+        // Given
+        await recordingRepository.setResult(.failure(.resumeFailed))
+        await recordingRepository.expectResumeRecording(callCount: 1)
+
+        // When
+        do {
+            try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .resumeFailed = error else {
+                return XCTFail("expected .resumeFailed, got \(error)")
+            }
+        }
+
+        // Then
+        await recordingRepository.verify()
+    }
+
+    func test_execute_재개중취소되면_cancelled에러를던진다() async {
+        // Given
+        await recordingRepository.setResult(.failure(.cancelled))
+        await recordingRepository.expectResumeRecording(callCount: 1)
+
+        // When
+        do {
+            try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .cancelled = error else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+        }
+
+        // Then
+        await recordingRepository.verify()
+    }
+
+    func test_execute_재개중알수없는에러가발생하면_unknown에러를던진다() async {
+        // Given
+        let underlyingError = NSError(domain: "Test", code: -999)
+        await recordingRepository.setResult(.failure(.unknown(underlyingError)))
+        await recordingRepository.expectResumeRecording(callCount: 1)
+
+        // When
+        do {
+            try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .unknown(let wrappedError) = error else {
+                return XCTFail("expected .unknown, got \(error)")
+            }
+            XCTAssertEqual(wrappedError as NSError, underlyingError)
+        }
+
+        // Then
+        await recordingRepository.verify()
+    }
+}
+
+// MARK: - Task 취소
+extension ResumeRecordingUseCaseTests {
+
+    func test_execute_실행전에태스크가취소되면_리포지토리호출없이cancelled에러를던진다() async {
+        guard let sut else {
+            XCTFail("sut은 반드시 설정되어야 합니다.")
+            return
+        }
+        // Given
+        await recordingRepository.setResult(.success(()))
+        await recordingRepository.expectResumeRecording(callCount: 0)
+
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await sut.execute()
+        }
+
+        // When
+        do {
+            _ = try await task.value
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .cancelled = error as? ResumeRecordingUseCaseError else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+            // Then
+            await recordingRepository.verify()
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/UseCases/VoiceRecords/StartRecordingUseCaseTests.swift
+++ b/ChaGok/Domain/Tests/UseCases/VoiceRecords/StartRecordingUseCaseTests.swift
@@ -1,0 +1,207 @@
+import Core
+import XCTest
+
+@testable import Domain
+
+final class StartRecordingUseCaseTests: XCTestCase {
+
+    private var permissionRepository: MockVoiceRecordPermissionRepository!
+    private var recordingRepository: MockVoiceRecordStartRepository!
+    private var sut: DefaultStartRecordingUseCase!
+
+    override func setUp() {
+        super.setUp()
+        permissionRepository = MockVoiceRecordPermissionRepository()
+        recordingRepository = MockVoiceRecordStartRepository()
+        sut = DefaultStartRecordingUseCase(
+            permissionRepository: permissionRepository,
+            recordingRepository: recordingRepository
+        )
+    }
+
+    override func tearDown() {
+        permissionRepository = nil
+        recordingRepository = nil
+        sut = nil
+        super.tearDown()
+    }
+}
+
+// MARK: - 성공
+extension StartRecordingUseCaseTests {
+
+    func test_execute_권한이허용되고시작에성공하면_파형스트림을반환한다() async throws {
+        // Given
+        await permissionRepository.setResult(.success(()))
+        await permissionRepository.expectCheckRecordingPermission(callCount: 1)
+
+        let expectedStream = AsyncStream<Waveform> { continuation in
+            continuation.yield(.stub())
+            continuation.finish()
+        }
+        await recordingRepository.setResult(.success(expectedStream))
+        await recordingRepository.expectStartRecording(callCount: 1)
+
+        // When
+        let stream = try await sut.execute()
+
+        // Then
+        var collected: [Waveform] = []
+        for await waveform in stream {
+            collected.append(waveform)
+        }
+        XCTAssertEqual(collected.map(\.amplitudes), [Waveform.stub().amplitudes])
+        await permissionRepository.verify()
+        await recordingRepository.verify()
+    }
+}
+
+// MARK: - 실패 / 에러 매핑
+extension StartRecordingUseCaseTests {
+
+    func test_execute_권한이거부되면_permissionDenied에러를던진다() async {
+        // Given
+        await permissionRepository.setResult(.failure(.permissionDenied))
+        await permissionRepository.expectCheckRecordingPermission(callCount: 1)
+
+        await recordingRepository.expectStartRecording(callCount: 0)
+
+        // When
+        do {
+            _ = try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .permissionDenied = error else {
+                return XCTFail("expected .permissionDenied, got \(error)")
+            }
+        }
+
+        await permissionRepository.verify()
+        await recordingRepository.verify()
+    }
+
+    func test_execute_녹음시작에실패하면_startFailed에러를던진다() async {
+        // Given
+        await permissionRepository.setResult(.success(()))
+        await permissionRepository.expectCheckRecordingPermission(callCount: 1)
+
+        await recordingRepository.setResult(.failure(.startFailed))
+        await recordingRepository.expectStartRecording(callCount: 1)
+
+        // When
+        do {
+            _ = try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .startFailed = error else {
+                return XCTFail("expected .startFailed, got \(error)")
+            }
+        }
+
+        await permissionRepository.verify()
+        await recordingRepository.verify()
+    }
+
+    func test_execute_권한확인중취소되면_cancelled에러를던진다() async {
+        // Given
+        await permissionRepository.setResult(.failure(.cancelled))
+        await permissionRepository.expectCheckRecordingPermission(callCount: 1)
+
+        await recordingRepository.expectStartRecording(callCount: 0)
+
+        // When
+        do {
+            _ = try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .cancelled = error else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+        }
+
+        await permissionRepository.verify()
+        await recordingRepository.verify()
+    }
+
+    func test_execute_녹음시작중취소되면_cancelled에러를던진다() async {
+        // Given
+        await permissionRepository.setResult(.success(()))
+        await permissionRepository.expectCheckRecordingPermission(callCount: 1)
+
+        await recordingRepository.setResult(.failure(.cancelled))
+        await recordingRepository.expectStartRecording(callCount: 1)
+
+        // When
+        do {
+            _ = try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .cancelled = error else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+        }
+
+        await permissionRepository.verify()
+        await recordingRepository.verify()
+    }
+
+    func test_execute_권한확인중알수없는에러가발생하면_unknown에러를던진다() async {
+        // Given
+        let underlyingError = NSError(domain: "TestDomain", code: -1)
+        await permissionRepository.setResult(.failure(.unknown(underlyingError)))
+        await permissionRepository.expectCheckRecordingPermission(callCount: 1)
+
+        await recordingRepository.expectStartRecording(callCount: 0)
+
+        // When
+        do {
+            _ = try await sut.execute()
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .unknown(let wrappedError) = error else {
+                return XCTFail("expected .unknown, got \(error)")
+            }
+            XCTAssertEqual(wrappedError as NSError, underlyingError)
+        }
+
+        await permissionRepository.verify()
+        await recordingRepository.verify()
+    }
+}
+
+// MARK: - Task 취소
+extension StartRecordingUseCaseTests {
+
+    func test_execute_실행전에태스크가취소되면_리포지토리호출없이cancelled에러를던진다() async {
+        guard let sut else {
+            XCTFail("sut은 반드시 설정되어야 합니다.")
+            return
+        }
+        // Given
+        await permissionRepository.expectCheckRecordingPermission(callCount: 0)
+        await recordingRepository.expectStartRecording(callCount: 0)
+
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await sut.execute()
+        }
+
+        // When
+        do {
+            _ = try await task.value
+            XCTFail("에러를 throw 해야 합니다.")
+        } catch {
+            // Then
+            guard case .cancelled = error as? StartRecordingUseCaseError else {
+                return XCTFail("expected .cancelled, got \(error)")
+            }
+            await permissionRepository.verify()
+            await recordingRepository.verify()
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 작업 요약
Domain의 Recording 관련 UseCase 에러 매핑 방식을 개선하고, 각 UseCase에 대한 단위 테스트 및 Mock을 추가합니다.

## 📋 구체적인 내용
- **추가/변경된 동작**
  - **UseCase 리팩토링**: `Start`, `Pause`, `Resume`, `Finish`, `CheckMicrophonePermission` UseCase의 에러 매핑 로직을 에러 타입의 `init`으로 분리하여 구조를 개선하고, `Sendable` 프로토콜을 채택하여 동시성 안정성을 확보했습니다.
  - **단위 테스트 추가**: 각 UseCase별 성공, 실패, 취소 시나리오를 검증하는 테스트 코드를 작성했습니다.
  - **Mock 및 Stub 추가**: 테스트에 필요한 Repository Mock과 VoiceRecord, Waveform Stub 데이터를 추가했습니다.
- **영향 받는 화면/모듈**
  - Domain 모듈 및 DomainTests 타겟

---

## 🔗 연관 이슈
- closed #77

---

## 🧩 설계·구현 노트
- **선택한 방식**
  - 에러 매핑 로직을 `fileprivate init`으로 캡슐화하여 UseCase의 `execute` 메서드 가독성을 높였습니다.
  - `Sendable` 채택을 통해 Swift Concurrency 환경에서 UseCase 인스턴스 전달 시의 경고를 방지했습니다.

---

## ✅ 확인 사항
- [x] DomainTests 스킴으로 전체 테스트 통과
- [x] 정상 플로우 및 에러/취소 경로 테스트 포함
- [x] .gitignore 설정 확인

---

## 👀 리뷰 포인트
- [x] 에러 매핑 로직의 분리 방식이 적절한지
- [x] Mock 및 Stub의 구조와 테스트 가독성
- [x] UseCase에 `Sendable`을 추가한 방향성