### PR TITLE
Folder (생성, 조회, 수정) UseCase 단위 테스트를 진행합니다.

### DIFF
--- a/ChaGok/Core/Sources/Constant/FolderConstant.swift
+++ b/ChaGok/Core/Sources/Constant/FolderConstant.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+// 폴더 매직 상수를 정의 하는 enum값
+public enum FolderConstants {
+    /// 폴더 이름의 최대 글자 수
+    public static let maxNameLength: Int = 50
+}

--- a/ChaGok/Domain/Sources/Errors/Folders/CreateFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/CreateFolderUseCaseError.swift
@@ -5,6 +5,8 @@ public enum CreateFolderUseCaseError: LocalizedError, Sendable {
     case cancelled
     /// 유효하지 않은 이름의 경우
     case invalidName
+    /// 유효하지 않은 글자 수의 경우
+    case invailedLengthName
     /// 동일한 이름의 폴더가 이미 존재하는 경우 (생성, 수정 시 발생)
     case duplicateName
     /// 폴더 생성이 실패한 경우
@@ -20,6 +22,8 @@ public enum CreateFolderUseCaseError: LocalizedError, Sendable {
                 "폴더 이름을 한 글자 이상 입력해 주세요."
             case .duplicateName:
                 "이미 동일한 이름의 폴더가 존재합니다."
+            case .invailedLengthName:
+                "폴더 이름이 너무 길어요."
             case .createFailed:
                 "폴더 생성에 실패했습니다."
             case .unknown(let error):

--- a/ChaGok/Domain/Sources/Errors/Folders/CreateFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/CreateFolderUseCaseError.swift
@@ -6,7 +6,7 @@ public enum CreateFolderUseCaseError: LocalizedError, Sendable {
     /// 유효하지 않은 이름의 경우
     case invalidName
     /// 유효하지 않은 글자 수의 경우
-    case invailedLengthName
+    case invalidLengthName
     /// 동일한 이름의 폴더가 이미 존재하는 경우 (생성, 수정 시 발생)
     case duplicateName
     /// 폴더 생성이 실패한 경우
@@ -22,7 +22,7 @@ public enum CreateFolderUseCaseError: LocalizedError, Sendable {
                 "폴더 이름을 한 글자 이상 입력해 주세요."
             case .duplicateName:
                 "이미 동일한 이름의 폴더가 존재합니다."
-            case .invailedLengthName:
+            case .invalidLengthName:
                 "폴더 이름이 너무 길어요."
             case .createFailed:
                 "폴더 생성에 실패했습니다."

--- a/ChaGok/Domain/Sources/Errors/Folders/UpdateFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/UpdateFolderUseCaseError.swift
@@ -6,7 +6,7 @@ public enum UpdateFolderUseCaseError: LocalizedError, Sendable {
     /// 유효하지 않음 이름의 경우
     case invalidName
     /// 유효하지 않은 글자 수의 경우
-    case invailedLengthName
+    case invalidLengthName
     /// 폴더를 찾을 수 없는 경우 (조회, 수정 시 발생)
     case notFound
     /// 동일한 이름의 폴더가 이미 존재하는 경우 (생성, 수정 시 발생)
@@ -22,7 +22,7 @@ public enum UpdateFolderUseCaseError: LocalizedError, Sendable {
                 nil
             case .invalidName:
                 "폴더 이름을 한 글자 이상 입력해 주세요."
-            case .invailedLengthName:
+            case .invalidLengthName:
                 "폴더 이름이 너무 길어요."
             case .notFound:
                 "해당 폴더를 찾을 수 없습니다."

--- a/ChaGok/Domain/Sources/Errors/Folders/UpdateFolderUseCaseError.swift
+++ b/ChaGok/Domain/Sources/Errors/Folders/UpdateFolderUseCaseError.swift
@@ -5,6 +5,8 @@ public enum UpdateFolderUseCaseError: LocalizedError, Sendable {
     case cancelled
     /// 유효하지 않음 이름의 경우
     case invalidName
+    /// 유효하지 않은 글자 수의 경우
+    case invailedLengthName
     /// 폴더를 찾을 수 없는 경우 (조회, 수정 시 발생)
     case notFound
     /// 동일한 이름의 폴더가 이미 존재하는 경우 (생성, 수정 시 발생)
@@ -20,6 +22,8 @@ public enum UpdateFolderUseCaseError: LocalizedError, Sendable {
                 nil
             case .invalidName:
                 "폴더 이름을 한 글자 이상 입력해 주세요."
+            case .invailedLengthName:
+                "폴더 이름이 너무 길어요."
             case .notFound:
                 "해당 폴더를 찾을 수 없습니다."
             case .duplicateName:

--- a/ChaGok/Domain/Sources/UseCases/Folders/CreateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/CreateFolderUseCase.swift
@@ -23,6 +23,9 @@ public struct DefaultCreateFolderUseCase: CreateFolderUseCase {
         typealias UseCaseError = CreateFolderUseCaseError
         if Task.isCancelled { throw UseCaseError.cancelled }
 
+        // 폴더 이름 제한
+        guard name.count <= 50 else { throw UseCaseError.invailedLengthName }
+
         // invalidName 유효성 검증
         guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw UseCaseError.invalidName

--- a/ChaGok/Domain/Sources/UseCases/Folders/CreateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/CreateFolderUseCase.swift
@@ -24,7 +24,7 @@ public struct DefaultCreateFolderUseCase: CreateFolderUseCase {
         if Task.isCancelled { throw UseCaseError.cancelled }
 
         // 폴더 이름 제한
-        guard name.count <= 50 else { throw UseCaseError.invailedLengthName }
+        guard name.count <= FolderConstants.maxNameLength else { throw UseCaseError.invalidLengthName }
 
         // invalidName 유효성 검증
         guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {

--- a/ChaGok/Domain/Sources/UseCases/Folders/UpdateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/UpdateFolderUseCase.swift
@@ -24,7 +24,7 @@ public struct DefaultUpdateFolderUseCase: UpdateFolderUseCase {
         if Task.isCancelled { throw UseCaseError.cancelled }
 
         // 폴더 이름 제한
-        guard folder.name.count <= 50 else { throw UseCaseError.invailedLengthName }
+        guard folder.name.count <= FolderConstants.maxNameLength else { throw UseCaseError.invalidLengthName }
 
         // invalidName 유효성 검증
         guard !folder.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {

--- a/ChaGok/Domain/Sources/UseCases/Folders/UpdateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/UpdateFolderUseCase.swift
@@ -23,6 +23,9 @@ public struct DefaultUpdateFolderUseCase: UpdateFolderUseCase {
         typealias UseCaseError = UpdateFolderUseCaseError
         if Task.isCancelled { throw UseCaseError.cancelled }
 
+        // 폴더 이름 제한
+        guard folder.name.count <= 50 else { throw UseCaseError.invailedLengthName }
+
         // invalidName 유효성 검증
         guard !folder.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw UseCaseError.invalidName

--- a/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
@@ -13,11 +13,10 @@ extension CreateFolderUseCaseTest {
         // Given
         let expectedName = "New Folder"
         let expectedFolder = Folder(path: URL(fileURLWithPath: "/test"), name: expectedName)
-        let useCase = DefaultCreateFolderUseCase(
-            repository: MockFolderRepository(
-                createBehavior: .success(expectedFolder)
-            )
+        let repository = MockFolderRepository(
+            createBehavior: .success(expectedFolder)
         )
+        let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When
         let folder = try await useCase.execute(name: expectedName)
@@ -25,6 +24,8 @@ extension CreateFolderUseCaseTest {
         // Then
         XCTAssertEqual(folder.name, expectedName)
         XCTAssertEqual(folder.id, expectedFolder.id)
+        let callCount = await repository.createCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
     }
 }
 
@@ -34,9 +35,8 @@ extension CreateFolderUseCaseTest {
     /// 유효하지 않은 이름 Case: 폴더 이름이 비어있거나 공백일 때 .invalidName 확인
     func test_execute_throwsInvalidName_whenNameIsEmpty() async {
         // Given
-        let useCase = DefaultCreateFolderUseCase(
-            repository: MockFolderRepository()
-        )
+        let repository = MockFolderRepository()
+        let useCase = DefaultCreateFolderUseCase(repository: repository)
         let invalidNames = ["", " ", "  \n  "]
 
         // When & Then
@@ -54,15 +54,19 @@ extension CreateFolderUseCaseTest {
                 }
             }
         }
+
+        let callCount = await repository.createCallCount
+        XCTAssertEqual(callCount, 0, "유효하지 않은 이름일 경우 Repository를 호출하지 않아야 합니다.")
     }
 
     /// 이름의 길이가 50을 넘어가는 경우 .invailedLength 확인
     func test_execute_throwsInvalidLength_whenNameIsTooLong() async {
-        let useCase = DefaultCreateFolderUseCase(
-            repository: MockFolderRepository()
-        )
+        // Given
+        let repository = MockFolderRepository()
+        let useCase = DefaultCreateFolderUseCase(repository: repository)
         let tooLongName = String(repeating: "a", count: 51)
 
+        // When & Then
         do {
             _ = try await useCase.execute(name: tooLongName)
             XCTFail("invailedLengthName이 발생해야 합니다. (input: \(tooLongName))")
@@ -71,16 +75,16 @@ extension CreateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .invailedLengthName, got \(error) for name: \(tooLongName)")
         }
+
+        let callCount = await repository.createCallCount
+        XCTAssertEqual(callCount, 0, "이름이 너무 길 경우 Repository를 호출하지 않아야 합니다.")
     }
 
     /// 이름 중복 Case: 이미 같은 이름의 폴더가 존재할 때 .duplicateName 대칭 확인
     func test_execute_throwsDuplicateName_whenRepositoryReturnsDuplicateName() async {
         // Given
-        let useCase = DefaultCreateFolderUseCase(
-            repository: MockFolderRepository(
-                createBehavior: .duplicateName
-            )
-        )
+        let repository = MockFolderRepository(createBehavior: .duplicateName)
+        let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -91,16 +95,16 @@ extension CreateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .duplicateName, got \(error)")
         }
+
+        let callCount = await repository.createCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
     }
 
     /// 생성 실패 Case: repository가 .createFailed를 반환할 때
     func test_execute_throwsCreateFailed_whenRepositoryReturnsCreateFailed() async {
         // Given
-        let useCase = DefaultCreateFolderUseCase(
-            repository: MockFolderRepository(
-                createBehavior: .createFailed
-            )
-        )
+        let repository = MockFolderRepository(createBehavior: .createFailed)
+        let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -111,16 +115,16 @@ extension CreateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .createFailed, got \(error)")
         }
+
+        let callCount = await repository.createCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
     }
 
     /// 찾을 수 없는 경우 Case: Repository에서 .notFound를 반환할 때 .unknown으로 맵핑되는지 확인
     func test_execute_throwsUnknown_whenRepositoryReturnsNotFound() async {
         // Given
-        let useCase = DefaultCreateFolderUseCase(
-            repository: MockFolderRepository(
-                createBehavior: .notFound
-            )
-        )
+        let repository = MockFolderRepository(createBehavior: .notFound)
+        let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -140,16 +144,16 @@ extension CreateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
+
+        let callCount = await repository.createCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
     }
 
     /// 수정 실패 Case: Repository에서 .updateFailed를 반환할 때 .unknown으로 맵핑되는지 확인
     func test_execute_throwsUnknown_whenRepositoryReturnsUpdateFailed() async {
         // Given
-        let useCase = DefaultCreateFolderUseCase(
-            repository: MockFolderRepository(
-                createBehavior: .updateFailed
-            )
-        )
+        let repository = MockFolderRepository(createBehavior: .updateFailed)
+        let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -169,16 +173,16 @@ extension CreateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
+
+        let callCount = await repository.createCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
     }
 
     /// 조회 실패 Case: Repository에서 .fetchFailed를 반환할 때 .unknown으로 맵핑되는지 확인
     func test_execute_throwsUnknown_whenRepositoryReturnsFetchFailed() async {
         // Given
-        let useCase = DefaultCreateFolderUseCase(
-            repository: MockFolderRepository(
-                createBehavior: .fetchFailed
-            )
-        )
+        let repository = MockFolderRepository(createBehavior: .fetchFailed)
+        let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -198,6 +202,9 @@ extension CreateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
+
+        let callCount = await repository.createCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
     }
 
     /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
@@ -205,11 +212,8 @@ extension CreateFolderUseCaseTest {
         // Given
         struct Dummy: Error {}
         let dummyError = Dummy()
-        let useCase = DefaultCreateFolderUseCase(
-            repository: MockFolderRepository(
-                createBehavior: .unknown(dummyError)
-            )
-        )
+        let repository = MockFolderRepository(createBehavior: .unknown(dummyError))
+        let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -229,6 +233,9 @@ extension CreateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
+
+        let callCount = await repository.createCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
     }
 }
 
@@ -239,11 +246,8 @@ extension CreateFolderUseCaseTest {
     /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
     func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
         // Given
-        let useCase = DefaultCreateFolderUseCase(
-            repository: MockFolderRepository(
-                createBehavior: .cancelled
-            )
-        )
+        let repository = MockFolderRepository(createBehavior: .cancelled)
+        let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -254,6 +258,9 @@ extension CreateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .cancelled, got \(error)")
         }
+
+        let callCount = await repository.createCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
     }
 
     /// 취소 Case: 작업이 즉시 취소된 경우 execute 함수 내부 isCancelled를 검증한다
@@ -272,32 +279,6 @@ extension CreateFolderUseCaseTest {
         do {
             _ = try await task.value
             XCTFail("작업이 즉시 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
-        } catch UseCaseError.cancelled {
-            // Success
-        } catch {
-            XCTFail("Expected .cancelled, got \(error)")
-        }
-    }
-
-    /// 취소 Case (During Execution): 작업 도중 Task가 취소된 경우
-    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
-        // Given
-        let useCase = DefaultCreateFolderUseCase(
-            repository: MockFolderRepository(
-                createBehavior: .success(Folder(path: URL(fileURLWithPath: "/"), name: "test")),
-                delay: 100_000_000 // 0.1초 지연
-            )
-        )
-
-        // When & Then
-        let task = Task { try await useCase.execute(name: "Cancel Test") }
-
-        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기 후 취소
-        task.cancel()
-
-        do {
-            _ = try await task.value
-            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
         } catch UseCaseError.cancelled {
             // Success
         } catch {

--- a/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
@@ -1,0 +1,308 @@
+import XCTest
+@testable import Domain
+
+final class CreateFolderUseCaseTest: XCTestCase {
+    typealias UseCaseError = CreateFolderUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension CreateFolderUseCaseTest {
+    /// 성공 Case: Repository가 정상적으로 Folder를 반환할 때
+    func test_execute_returnsFolder_whenRepositorySucceeds() async throws {
+        // Given
+        let expectedName = "New Folder"
+        let expectedFolder = Folder(path: URL(fileURLWithPath: "/test"), name: expectedName)
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .success(expectedFolder)
+            )
+        )
+
+        // When
+        let folder = try await useCase.execute(name: expectedName)
+
+        // Then
+        XCTAssertEqual(folder.name, expectedName)
+        XCTAssertEqual(folder.id, expectedFolder.id)
+    }
+}
+
+// MARK: - Error Cases
+
+extension CreateFolderUseCaseTest {
+    /// 유효하지 않은 이름 Case: 폴더 이름이 비어있거나 공백일 때 .invalidName 확인
+    func test_execute_throwsInvalidName_whenNameIsEmpty() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository()
+        )
+        let invalidNames = ["", " ", "  \n  "]
+
+        // When & Then
+        await withTaskGroup(of: Void.self) { group in
+            for name in invalidNames {
+                group.addTask {
+                    do {
+                        _ = try await useCase.execute(name: name)
+                        XCTFail("이름이 비어있는 경우 .invalidName 에러가 발생해야 합니다. (input: '\(name)')")
+                    } catch UseCaseError.invalidName {
+                        // Success
+                    } catch {
+                        XCTFail("Expected .invalidName, got \(error) for name: '\(name)'")
+                    }
+                }
+            }
+        }
+    }
+
+    /// 이름의 길이가 50을 넘어가는 경우 .invailedLength 확인
+    func test_execute_throwInvaildLength_whenNameIsTooLong() async {
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository()
+        )
+        let tooLongName = String(repeating: "a", count: 51)
+
+        do {
+            _ = try await useCase.execute(name: tooLongName)
+            XCTFail("invailedLengthName이 발생해야 합니다. (input: \(tooLongName))")
+        } catch UseCaseError.invailedLengthName {
+            // Success
+        } catch {
+            XCTFail("Expected .invailedLengthName, got \(error) for name: \(tooLongName)")
+        }
+    }
+
+    /// 이름 중복 Case: 이미 같은 이름의 폴더가 존재할 때 .duplicateName 대칭 확인
+    func test_execute_throwsDuplicateName_whenRepositoryReturnsDuplicateName() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .duplicateName
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "Existing Folder")
+            XCTFail("중복 이름인 경우 .duplicateName 에러가 발생해야 합니다.")
+        } catch UseCaseError.duplicateName {
+            // Success
+        } catch {
+            XCTFail("Expected .duplicateName, got \(error)")
+        }
+    }
+
+    /// 생성 실패 Case: repository가 .createFailed를 반환할 때
+    func test_execute_throwsCreateFailed_whenRepositoryReturnsCreateFailed() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .createFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "New Folder")
+            XCTFail("생성 실패의 경우 .createFailed 에러가 발생해야 합니다.")
+        } catch UseCaseError.createFailed {
+            // Success
+        } catch {
+            XCTFail("Expected .createFailed, got \(error)")
+        }
+    }
+
+    /// 찾을 수 없는 경우 Case: Repository에서 .notFound를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsNotFound() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .notFound
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "Existing Folder")
+            XCTFail("찾을 수 없을 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .notFound:
+                    break // Success
+                default:
+                    XCTFail("Expected .notFound, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 수정 실패 Case: Repository에서 .updateFailed를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsUpdateFailed() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .updateFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "Existing Folder")
+            XCTFail("찾을 수 없을 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .updateFailed:
+                    break // Success
+                default:
+                    XCTFail("Expected .updateFailed, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 조회 실패 Case: Repository에서 .fetchFailed를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsFetchFailed() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .fetchFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "Existing Folder")
+            XCTFail("찾을 수 없을 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .fetchFailed:
+                    break // Success
+                default:
+                    XCTFail("Expected .fetchFailed, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+        // Given
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .unknown(dummyError)
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "Unknown Test")
+            XCTFail("알 수 없는 에러 발생 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부에는 FolderRepositoryError가 포함되어야 합니다.")
+            }
+
+            switch repoError {
+                case .unknown(let underlyingError):
+                    XCTAssertTrue(underlyingError is Dummy)
+                default:
+                    XCTFail("Expected .unknown underlying error, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+}
+
+// MARK: - Error Cases ( Cancelled )
+
+extension CreateFolderUseCaseTest {
+
+    /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
+    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .cancelled
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(name: "Existing Folder")
+            XCTFail("작업 취소의 경우 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case: 작업이 즉시 취소된 경우 execute 함수 내부 isCancelled를 검증한다
+    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .success(Folder(path: URL.applicationSupportDirectory, name: "test"))
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute(name: "Cancel Test") }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업이 즉시 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case (During Execution): 작업 도중 Task가 취소된 경우
+    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
+        // Given
+        let useCase = DefaultCreateFolderUseCase(
+            repository: MockFolderRepository(
+                createBehavior: .success(Folder(path: URL(fileURLWithPath: "/"), name: "test")),
+                delay: 100_000_000 // 0.1초 지연
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute(name: "Cancel Test") }
+
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기 후 취소
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+}

--- a/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
@@ -15,7 +15,7 @@ extension CreateFolderUseCaseTest {
         let expectedFolder = Folder(path: URL(fileURLWithPath: "/test"), name: expectedName)
         let repository = MockFolderRepository()
         await repository.setCreateResult(.success(expectedFolder))
-        await repository.expectCreate(callCount: 1)
+        await repository.expectCreate(name: expectedName, callCount: 1)
 
         let useCase = DefaultCreateFolderUseCase(repository: repository)
 

--- a/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
@@ -57,7 +57,7 @@ extension CreateFolderUseCaseTest {
     }
 
     /// 이름의 길이가 50을 넘어가는 경우 .invailedLength 확인
-    func test_execute_throwInvaildLength_whenNameIsTooLong() async {
+    func test_execute_throwsInvalidLength_whenNameIsTooLong() async {
         let useCase = DefaultCreateFolderUseCase(
             repository: MockFolderRepository()
         )
@@ -66,7 +66,7 @@ extension CreateFolderUseCaseTest {
         do {
             _ = try await useCase.execute(name: tooLongName)
             XCTFail("invailedLengthName이 발생해야 합니다. (input: \(tooLongName))")
-        } catch UseCaseError.invailedLengthName {
+        } catch UseCaseError.invalidLengthName {
             // Success
         } catch {
             XCTFail("Expected .invailedLengthName, got \(error) for name: \(tooLongName)")

--- a/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
@@ -5,17 +5,18 @@ final class CreateFolderUseCaseTest: XCTestCase {
     typealias UseCaseError = CreateFolderUseCaseError
 }
 
-// MARK: - Success Cases
+// MARK: - 성공 케이스
 
 extension CreateFolderUseCaseTest {
-    /// 성공 Case: Repository가 정상적으로 Folder를 반환할 때
-    func test_execute_returnsFolder_whenRepositorySucceeds() async throws {
+
+    func test_폴더_생성_성공_생성된폴더를반환한다() async throws {
         // Given
         let expectedName = "New Folder"
         let expectedFolder = Folder(path: URL(fileURLWithPath: "/test"), name: expectedName)
-        let repository = MockFolderRepository(
-            createBehavior: .success(expectedFolder)
-        )
+        let repository = MockFolderRepository()
+        await repository.setCreateResult(.success(expectedFolder))
+        await repository.expectCreate(callCount: 1)
+
         let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When
@@ -24,18 +25,19 @@ extension CreateFolderUseCaseTest {
         // Then
         XCTAssertEqual(folder.name, expectedName)
         XCTAssertEqual(folder.id, expectedFolder.id)
-        let callCount = await repository.createCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 }
 
-// MARK: - Error Cases
+// MARK: - 에러 케이스
 
 extension CreateFolderUseCaseTest {
-    /// 유효하지 않은 이름 Case: 폴더 이름이 비어있거나 공백일 때 .invalidName 확인
-    func test_execute_throwsInvalidName_whenNameIsEmpty() async {
+
+    func test_폴더_생성_이름이비어있을때_invalidName에러를던진다() async {
         // Given
         let repository = MockFolderRepository()
+        await repository.expectCreate(callCount: 0)
+
         let useCase = DefaultCreateFolderUseCase(repository: repository)
         let invalidNames = ["", " ", "  \n  "]
 
@@ -55,35 +57,36 @@ extension CreateFolderUseCaseTest {
             }
         }
 
-        let callCount = await repository.createCallCount
-        XCTAssertEqual(callCount, 0, "유효하지 않은 이름일 경우 Repository를 호출하지 않아야 합니다.")
+        await repository.verify()
     }
 
-    /// 이름의 길이가 50을 넘어가는 경우 .invailedLength 확인
-    func test_execute_throwsInvalidLength_whenNameIsTooLong() async {
+    func test_폴더_생성_이름이너무길때_invalidLengthName에러를던진다() async {
         // Given
         let repository = MockFolderRepository()
+        await repository.expectCreate(callCount: 0)
+
         let useCase = DefaultCreateFolderUseCase(repository: repository)
         let tooLongName = String(repeating: "a", count: 51)
 
         // When & Then
         do {
             _ = try await useCase.execute(name: tooLongName)
-            XCTFail("invailedLengthName이 발생해야 합니다. (input: \(tooLongName))")
+            XCTFail("invalidLengthName이 발생해야 합니다. (input: \(tooLongName))")
         } catch UseCaseError.invalidLengthName {
             // Success
         } catch {
-            XCTFail("Expected .invailedLengthName, got \(error) for name: \(tooLongName)")
+            XCTFail("Expected .invalidLengthName, got \(error) for name: \(tooLongName)")
         }
 
-        let callCount = await repository.createCallCount
-        XCTAssertEqual(callCount, 0, "이름이 너무 길 경우 Repository를 호출하지 않아야 합니다.")
+        await repository.verify()
     }
 
-    /// 이름 중복 Case: 이미 같은 이름의 폴더가 존재할 때 .duplicateName 대칭 확인
-    func test_execute_throwsDuplicateName_whenRepositoryReturnsDuplicateName() async {
+    func test_폴더_생성_리포지토리중복이름에러시_duplicateName에러를던진다() async {
         // Given
-        let repository = MockFolderRepository(createBehavior: .duplicateName)
+        let repository = MockFolderRepository()
+        await repository.setCreateResult(.failure(.duplicateName))
+        await repository.expectCreate(callCount: 1)
+
         let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
@@ -96,14 +99,15 @@ extension CreateFolderUseCaseTest {
             XCTFail("Expected .duplicateName, got \(error)")
         }
 
-        let callCount = await repository.createCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 생성 실패 Case: repository가 .createFailed를 반환할 때
-    func test_execute_throwsCreateFailed_whenRepositoryReturnsCreateFailed() async {
+    func test_폴더_생성_리포지토리생성실패시_createFailed에러를던진다() async {
         // Given
-        let repository = MockFolderRepository(createBehavior: .createFailed)
+        let repository = MockFolderRepository()
+        await repository.setCreateResult(.failure(.createFailed))
+        await repository.expectCreate(callCount: 1)
+
         let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
@@ -116,14 +120,15 @@ extension CreateFolderUseCaseTest {
             XCTFail("Expected .createFailed, got \(error)")
         }
 
-        let callCount = await repository.createCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 찾을 수 없는 경우 Case: Repository에서 .notFound를 반환할 때 .unknown으로 맵핑되는지 확인
-    func test_execute_throwsUnknown_whenRepositoryReturnsNotFound() async {
+    func test_폴더_생성_리포지토리찾을수없음시_unknown에러를던진다() async {
         // Given
-        let repository = MockFolderRepository(createBehavior: .notFound)
+        let repository = MockFolderRepository()
+        await repository.setCreateResult(.failure(.notFound))
+        await repository.expectCreate(callCount: 1)
+
         let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
@@ -132,27 +137,28 @@ extension CreateFolderUseCaseTest {
             XCTFail("찾을 수 없을 시 .unknown으로 래핑되어야 합니다.")
         } catch UseCaseError.unknown(let error) {
             guard let repoError = error as? FolderRepositoryError else {
-                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다.")
             }
 
             switch repoError {
-                case .notFound:
-                    break // Success
-                default:
-                    XCTFail("Expected .notFound, but got \(repoError)")
+            case .notFound:
+                break // Success
+            default:
+                XCTFail("Expected .notFound, but got \(repoError)")
             }
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
 
-        let callCount = await repository.createCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 수정 실패 Case: Repository에서 .updateFailed를 반환할 때 .unknown으로 맵핑되는지 확인
-    func test_execute_throwsUnknown_whenRepositoryReturnsUpdateFailed() async {
+    func test_폴더_생성_리포지토리수정실패시_unknown에러를던진다() async {
         // Given
-        let repository = MockFolderRepository(createBehavior: .updateFailed)
+        let repository = MockFolderRepository()
+        await repository.setCreateResult(.failure(.updateFailed))
+        await repository.expectCreate(callCount: 1)
+
         let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
@@ -161,27 +167,28 @@ extension CreateFolderUseCaseTest {
             XCTFail("찾을 수 없을 시 .unknown으로 래핑되어야 합니다.")
         } catch UseCaseError.unknown(let error) {
             guard let repoError = error as? FolderRepositoryError else {
-                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다.")
             }
 
             switch repoError {
-                case .updateFailed:
-                    break // Success
-                default:
-                    XCTFail("Expected .updateFailed, but got \(repoError)")
+            case .updateFailed:
+                break // Success
+            default:
+                XCTFail("Expected .updateFailed, but got \(repoError)")
             }
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
 
-        let callCount = await repository.createCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 조회 실패 Case: Repository에서 .fetchFailed를 반환할 때 .unknown으로 맵핑되는지 확인
-    func test_execute_throwsUnknown_whenRepositoryReturnsFetchFailed() async {
+    func test_폴더_생성_리포지토리조회실패시_unknown에러를던진다() async {
         // Given
-        let repository = MockFolderRepository(createBehavior: .fetchFailed)
+        let repository = MockFolderRepository()
+        await repository.setCreateResult(.failure(.fetchFailed))
+        await repository.expectCreate(callCount: 1)
+
         let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
@@ -190,29 +197,30 @@ extension CreateFolderUseCaseTest {
             XCTFail("찾을 수 없을 시 .unknown으로 래핑되어야 합니다.")
         } catch UseCaseError.unknown(let error) {
             guard let repoError = error as? FolderRepositoryError else {
-                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다.")
             }
 
             switch repoError {
-                case .fetchFailed:
-                    break // Success
-                default:
-                    XCTFail("Expected .fetchFailed, but got \(repoError)")
+            case .fetchFailed:
+                break // Success
+            default:
+                XCTFail("Expected .fetchFailed, but got \(repoError)")
             }
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
 
-        let callCount = await repository.createCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
-    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+    func test_폴더_생성_리포지토리알수없는에러시_unknown에러를던진다() async {
         // Given
         struct Dummy: Error {}
         let dummyError = Dummy()
-        let repository = MockFolderRepository(createBehavior: .unknown(dummyError))
+        let repository = MockFolderRepository()
+        await repository.setCreateResult(.failure(.unknown(dummyError)))
+        await repository.expectCreate(callCount: 1)
+
         let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
@@ -225,28 +233,29 @@ extension CreateFolderUseCaseTest {
             }
 
             switch repoError {
-                case .unknown(let underlyingError):
-                    XCTAssertTrue(underlyingError is Dummy)
-                default:
-                    XCTFail("Expected .unknown underlying error, but got \(repoError)")
+            case .unknown(let underlyingError):
+                XCTAssertTrue(underlyingError is Dummy)
+            default:
+                XCTFail("Expected .unknown underlying error, but got \(repoError)")
             }
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
 
-        let callCount = await repository.createCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 }
 
-// MARK: - Error Cases ( Cancelled )
+// MARK: - 취소 케이스
 
 extension CreateFolderUseCaseTest {
 
-    /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
-    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+    func test_폴더_생성_리포지토리취소시_cancelled에러를던진다() async {
         // Given
-        let repository = MockFolderRepository(createBehavior: .cancelled)
+        let repository = MockFolderRepository()
+        await repository.setCreateResult(.failure(.cancelled))
+        await repository.expectCreate(callCount: 1)
+
         let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
@@ -259,22 +268,22 @@ extension CreateFolderUseCaseTest {
             XCTFail("Expected .cancelled, got \(error)")
         }
 
-        let callCount = await repository.createCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 create가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 취소 Case: 작업이 즉시 취소된 경우 execute 함수 내부 isCancelled를 검증한다
-    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+    func test_폴더_생성_작업이미취소시_즉시cancelled에러를던진다() async {
         // Given
-        let useCase = DefaultCreateFolderUseCase(
-            repository: MockFolderRepository(
-                createBehavior: .success(Folder(path: URL.applicationSupportDirectory, name: "test"))
-            )
-        )
+        let repository = MockFolderRepository()
+        await repository.setCreateResult(.success(Folder(path: URL.applicationSupportDirectory, name: "test")))
+        await repository.expectCreate(callCount: 0)
+
+        let useCase = DefaultCreateFolderUseCase(repository: repository)
 
         // When & Then
-        let task = Task { try await useCase.execute(name: "Cancel Test") }
-        task.cancel()
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            _ = try await useCase.execute(name: "Cancel Test")
+        }
 
         do {
             _ = try await task.value
@@ -284,6 +293,7 @@ extension CreateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .cancelled, got \(error)")
         }
-    }
 
+        await repository.verify()
+    }
 }

--- a/ChaGok/Domain/Tests/Folders/MockFolderRepository.swift
+++ b/ChaGok/Domain/Tests/Folders/MockFolderRepository.swift
@@ -13,10 +13,17 @@ actor MockFolderRepository: FolderRepository {
     private(set) var fetchAllCallCount = 0
     private(set) var updateCallCount = 0
 
-    // Expected Call Counts
+    // 인자 검증
+    private(set) var actualName: String?
+    private(set) var actualFolder: Folder?
+
+    // Expected Values
     private var expectedCreateCallCount: Int?
     private var expectedFetchAllCallCount: Int?
     private var expectedUpdateCallCount: Int?
+
+    private var expectedName: String?
+    private var expectedFolderID: UUID?
 
     // MARK: - Setup
 
@@ -34,7 +41,8 @@ actor MockFolderRepository: FolderRepository {
 
     // MARK: - Expectations
 
-    func expectCreate(callCount: Int) {
+    func expectCreate(name: String? = nil, callCount: Int) {
+        expectedName = name
         expectedCreateCallCount = callCount
     }
 
@@ -42,7 +50,8 @@ actor MockFolderRepository: FolderRepository {
         expectedFetchAllCallCount = callCount
     }
 
-    func expectUpdate(callCount: Int) {
+    func expectUpdate(folderID: UUID? = nil, callCount: Int) {
+        expectedFolderID = folderID
         expectedUpdateCallCount = callCount
     }
 
@@ -52,11 +61,20 @@ actor MockFolderRepository: FolderRepository {
         if let expected = expectedCreateCallCount {
             XCTAssertEqual(createCallCount, expected, "create call count mismatch", file: file, line: line)
         }
+
+        if let expectedName = expectedName {
+            XCTAssertEqual(actualName, expectedName, "create name argument mismatch", file: file, line: line)
+        }
+
         if let expected = expectedFetchAllCallCount {
             XCTAssertEqual(fetchAllCallCount, expected, "fetchAll call count mismatch", file: file, line: line)
         }
+
         if let expected = expectedUpdateCallCount {
             XCTAssertEqual(updateCallCount, expected, "update call count mismatch", file: file, line: line)
+        }
+        if let expectedID = expectedFolderID {
+            XCTAssertEqual(actualFolder?.id, expectedID, "update folder ID mismatch", file: file, line: line)
         }
     }
 
@@ -64,46 +82,48 @@ actor MockFolderRepository: FolderRepository {
 
     func create(name: String) async throws(FolderRepositoryError) -> Folder {
         createCallCount += 1
+        actualName = name
 
-        guard let result = createResult else {
-            fatalError("MockFolderRepository.createResult not set")
-        }
-
-        switch result {
+        switch createResult {
             case .success(let folder):
                 return folder
             case .failure(let error):
                 throw error
+            case .none:
+                XCTFail("MockVoiceNoteCreateRepository.createResult가 설정되지 않았습니다.")
+                let error = NSError(domain: "MockFolderRepository.createResult", code: 0)
+                throw .unknown(error)
         }
     }
 
     func fetchAll() async throws(FolderRepositoryError) -> [Folder] {
         fetchAllCallCount += 1
 
-        guard let result = fetchAllResult else {
-            fatalError("MockFolderRepository.fetchAllResult not set")
-        }
-
-        switch result {
+        switch fetchAllResult {
             case .success(let folders):
                 return folders
             case .failure(let error):
                 throw error
+            case .none:
+                XCTFail("MockVoiceNoteCreateRepository.fetchAll이 설정되지 않았습니다.")
+                let error = NSError(domain: "MockFolderRepository.fetchAllResult", code: 0)
+                throw .unknown(error)
         }
     }
 
     func update(_ folder: Folder) async throws(FolderRepositoryError) -> Folder {
         updateCallCount += 1
+        actualFolder = folder
 
-        guard let result = updateResult else {
-            fatalError("MockFolderRepository.updateResult not set")
-        }
-
-        switch result {
+        switch updateResult {
             case .success(let updatedFolder):
                 return updatedFolder
             case .failure(let error):
                 throw error
+            case .none:
+                XCTFail("MockVoiceNoteCreateRepository.updateResult가 설정되지 않았습니다.")
+                let error = NSError(domain: "MockFolderRepository.updateResult", code: 0)
+                throw .unknown(error)
         }
     }
 }

--- a/ChaGok/Domain/Tests/Folders/MockFolderRepository.swift
+++ b/ChaGok/Domain/Tests/Folders/MockFolderRepository.swift
@@ -1,85 +1,109 @@
-import Foundation
+import XCTest
 @testable import Domain
 
 actor MockFolderRepository: FolderRepository {
 
-    enum Behavior<T: Sendable>: Sendable {
-        case success(T)         // 성공한 경우
-        case cancelled          // 작업 취소의 경우
-        case notFound           // 폴더를 찾을 수 없는 경우
-        case duplicateName      // 이름이 중복된 경우
-        case createFailed       // 생성에 실패한 경우
-        case fetchFailed        // 조회에 실패한 경우
-        case updateFailed       // 수정에 실패한 경우
-        case unknown(Error)     // 알 수 없는 오류의 경우
+    // Results
+    private var createResult: Result<Folder, FolderRepositoryError>?
+    private var fetchAllResult: Result<[Folder], FolderRepositoryError>?
+    private var updateResult: Result<Folder, FolderRepositoryError>?
+
+    // 호출 검증 Count
+    private(set) var createCallCount = 0
+    private(set) var fetchAllCallCount = 0
+    private(set) var updateCallCount = 0
+
+    // Expected Call Counts
+    private var expectedCreateCallCount: Int?
+    private var expectedFetchAllCallCount: Int?
+    private var expectedUpdateCallCount: Int?
+
+    // MARK: - Setup
+
+    func setCreateResult(_ result: Result<Folder, FolderRepositoryError>) {
+        self.createResult = result
     }
 
-    var createBehavior: Behavior<Folder>?
-    var fetchAllBehavior: Behavior<[Folder]>?
-    var updateBehavior: Behavior<Folder>?
-
-    var delay: UInt64 = 0
-
-    var createCallCount = 0
-    var fetchAllCallCount = 0
-    var updateCallCount = 0
-
-    init(
-        createBehavior: Behavior<Folder>? = nil,
-        fetchAllBehavior: Behavior<[Folder]>? = nil,
-        updateBehavior: Behavior<Folder>? = nil,
-        delay: UInt64 = 0
-    ) {
-        self.createBehavior = createBehavior
-        self.fetchAllBehavior = fetchAllBehavior
-        self.updateBehavior = updateBehavior
-        self.delay = delay
+    func setFetchAllResult(_ result: Result<[Folder], FolderRepositoryError>) {
+        self.fetchAllResult = result
     }
+
+    func setUpdateResult(_ result: Result<Folder, FolderRepositoryError>) {
+        self.updateResult = result
+    }
+
+    // MARK: - Expectations
+
+    func expectCreate(callCount: Int) {
+        expectedCreateCallCount = callCount
+    }
+
+    func expectFetchAll(callCount: Int) {
+        expectedFetchAllCallCount = callCount
+    }
+
+    func expectUpdate(callCount: Int) {
+        expectedUpdateCallCount = callCount
+    }
+
+    // MARK: - Verification
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedCreateCallCount {
+            XCTAssertEqual(createCallCount, expected, "create call count mismatch", file: file, line: line)
+        }
+        if let expected = expectedFetchAllCallCount {
+            XCTAssertEqual(fetchAllCallCount, expected, "fetchAll call count mismatch", file: file, line: line)
+        }
+        if let expected = expectedUpdateCallCount {
+            XCTAssertEqual(updateCallCount, expected, "update call count mismatch", file: file, line: line)
+        }
+    }
+
+    // MARK: - FolderRepository
 
     func create(name: String) async throws(FolderRepositoryError) -> Folder {
         createCallCount += 1
-        return try await handleBehavior(createBehavior, methodName: "create")
+
+        guard let result = createResult else {
+            fatalError("MockFolderRepository.createResult not set")
+        }
+
+        switch result {
+            case .success(let folder):
+                return folder
+            case .failure(let error):
+                throw error
+        }
     }
 
     func fetchAll() async throws(FolderRepositoryError) -> [Folder] {
         fetchAllCallCount += 1
-        return try await handleBehavior(fetchAllBehavior, methodName: "fetchAll")
+
+        guard let result = fetchAllResult else {
+            fatalError("MockFolderRepository.fetchAllResult not set")
+        }
+
+        switch result {
+            case .success(let folders):
+                return folders
+            case .failure(let error):
+                throw error
+        }
     }
 
     func update(_ folder: Folder) async throws(FolderRepositoryError) -> Folder {
         updateCallCount += 1
-        return try await handleBehavior(updateBehavior, methodName: "update")
-    }
-}
 
-// MARK: - Helper Function
-
-extension MockFolderRepository {
-    private func handleBehavior<T>(
-        _ behavior: Behavior<T>?,
-        methodName: String
-    ) async throws(FolderRepositoryError) -> T {
-        if delay > 0 {
-            try? await Task.sleep(nanoseconds: delay)
+        guard let result = updateResult else {
+            fatalError("MockFolderRepository.updateResult not set")
         }
 
-        if Task.isCancelled {
-            throw .cancelled
-        }
-
-        guard let behavior = behavior else {
-            fatalError("\(methodName)의 Behavior가 설정되지 않았습니다.")
-        }
-
-        switch behavior {
-            case .success(let value): return value
-            case .cancelled: throw .cancelled
-            case .notFound: throw .notFound
-            case .duplicateName: throw .duplicateName
-            case .createFailed: throw .createFailed
-            case .fetchFailed: throw .fetchFailed
-            case .updateFailed: throw .updateFailed
-            case .unknown(let error): throw .unknown(error)
+        switch result {
+            case .success(let updatedFolder):
+                return updatedFolder
+            case .failure(let error):
+                throw error
         }
     }
 }

--- a/ChaGok/Domain/Tests/Folders/MockFolderRepository.swift
+++ b/ChaGok/Domain/Tests/Folders/MockFolderRepository.swift
@@ -1,0 +1,78 @@
+import Foundation
+@testable import Domain
+
+actor MockFolderRepository: FolderRepository {
+
+    enum Behavior<T: Sendable>: Sendable {
+        case success(T)         // 성공한 경우
+        case cancelled          // 작업 취소의 경우
+        case notFound           // 폴더를 찾을 수 없는 경우
+        case duplicateName      // 이름이 중복된 경우
+        case createFailed       // 생성에 실패한 경우
+        case fetchFailed        // 조회에 실패한 경우
+        case updateFailed       // 수정에 실패한 경우
+        case unknown(Error)     // 알 수 없는 오류의 경우
+    }
+
+    var createBehavior: Behavior<Folder>?
+    var fetchAllBehavior: Behavior<[Folder]>?
+    var updateBehavior: Behavior<Folder>?
+
+    var delay: UInt64 = 0
+
+    init(
+        createBehavior: Behavior<Folder>? = nil,
+        fetchAllBehavior: Behavior<[Folder]>? = nil,
+        updateBehavior: Behavior<Folder>? = nil,
+        delay: UInt64 = 0
+    ) {
+        self.createBehavior = createBehavior
+        self.fetchAllBehavior = fetchAllBehavior
+        self.updateBehavior = updateBehavior
+        self.delay = delay
+    }
+
+    func create(name: String) async throws(FolderRepositoryError) -> Folder {
+        try await handleBehavior(createBehavior, methodName: "create")
+    }
+
+    func fetchAll() async throws(FolderRepositoryError) -> [Folder] {
+        try await handleBehavior(fetchAllBehavior, methodName: "fetchAll")
+    }
+
+    func update(_ folder: Folder) async throws(FolderRepositoryError) -> Folder {
+        try await handleBehavior(updateBehavior, methodName: "update")
+    }
+}
+
+// MARK: - Helper Function
+
+extension MockFolderRepository {
+    private func handleBehavior<T>(
+        _ behavior: Behavior<T>?,
+        methodName: String
+    ) async throws(FolderRepositoryError) -> T {
+        if delay > 0 {
+            try? await Task.sleep(nanoseconds: delay)
+        }
+
+        if Task.isCancelled {
+            throw .cancelled
+        }
+
+        guard let behavior = behavior else {
+            fatalError("\(methodName)의 Behavior가 설정되지 않았습니다.")
+        }
+
+        switch behavior {
+            case .success(let value): return value
+            case .cancelled: throw .cancelled
+            case .notFound: throw .notFound
+            case .duplicateName: throw .duplicateName
+            case .createFailed: throw .createFailed
+            case .fetchFailed: throw .fetchFailed
+            case .updateFailed: throw .updateFailed
+            case .unknown(let error): throw .unknown(error)
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Folders/MockFolderRepository.swift
+++ b/ChaGok/Domain/Tests/Folders/MockFolderRepository.swift
@@ -20,6 +20,10 @@ actor MockFolderRepository: FolderRepository {
 
     var delay: UInt64 = 0
 
+    var createCallCount = 0
+    var fetchAllCallCount = 0
+    var updateCallCount = 0
+
     init(
         createBehavior: Behavior<Folder>? = nil,
         fetchAllBehavior: Behavior<[Folder]>? = nil,
@@ -33,15 +37,18 @@ actor MockFolderRepository: FolderRepository {
     }
 
     func create(name: String) async throws(FolderRepositoryError) -> Folder {
-        try await handleBehavior(createBehavior, methodName: "create")
+        createCallCount += 1
+        return try await handleBehavior(createBehavior, methodName: "create")
     }
 
     func fetchAll() async throws(FolderRepositoryError) -> [Folder] {
-        try await handleBehavior(fetchAllBehavior, methodName: "fetchAll")
+        fetchAllCallCount += 1
+        return try await handleBehavior(fetchAllBehavior, methodName: "fetchAll")
     }
 
     func update(_ folder: Folder) async throws(FolderRepositoryError) -> Folder {
-        try await handleBehavior(updateBehavior, methodName: "update")
+        updateCallCount += 1
+        return try await handleBehavior(updateBehavior, methodName: "update")
     }
 }
 

--- a/ChaGok/Domain/Tests/Folders/ReadFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/ReadFolderUseCaseTest.swift
@@ -1,0 +1,242 @@
+import XCTest
+@testable import Domain
+
+final class ReadFolderUseCaseTest: XCTestCase {
+    typealias UseCaseError = ReadFolderUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension ReadFolderUseCaseTest {
+    /// 성공 Case: 모든 폴더 목록을 정상적으로 반환할 때
+    func test_execute_returnsFolders_whenRepositorySucceeds() async throws {
+        // Given
+        let expectedFolders = [
+            Folder(path: URL(fileURLWithPath: "/1"), name: "Folder 1"),
+            Folder(path: URL(fileURLWithPath: "/2"), name: "Folder 2")
+        ]
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .success(expectedFolders)
+            )
+        )
+
+        // When
+        let folders = try await useCase.execute()
+
+        // Then
+        XCTAssertEqual(folders.count, 2)
+        XCTAssertEqual(folders[0].name, "Folder 1")
+        XCTAssertEqual(folders[0].id, expectedFolders[0].id)
+        XCTAssertEqual(folders[1].name, "Folder 2")
+        XCTAssertEqual(folders[1].id, expectedFolders[1].id)
+    }
+}
+
+// MARK: - Error Cases
+
+extension ReadFolderUseCaseTest {
+
+    /// 조회 실패 Case: fetchFailed 에러 전파 확인
+    func test_execute_throwsFetchFailed_whenRepositoryReturnsFetchFailed() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .fetchFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("조회 실패 시 .fetchFailed 에러가 발생해야 합니다.")
+        } catch UseCaseError.fetchFailed {
+            // Success
+        } catch {
+            XCTFail("Expected .fetchFailed, got \(error)")
+        }
+    }
+
+    /// 찾을 수 없는 경우 Case: Repository에서 .notFound를 반환할 때 동일하게 전파되는지 확인
+    func test_execute_throwsNotFound_whenRepositoryReturnsNotFound() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .notFound
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("찾을 수 없을 시 .notFound 에러가 발생해야 합니다.")
+        } catch UseCaseError.notFound {
+            // Success
+        } catch {
+            XCTFail("Expected .notFound, got \(error)")
+        }
+    }
+
+    /// 매핑 확인 Case: Repository에서 .createFailed를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsCreateFailed() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .createFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("생성 실패 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .createFailed:
+                    break // Success
+                default:
+                    XCTFail("Expected .createFailed, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 매핑 확인 Case: Repository에서 .updateFailed를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsUpdateFailed() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .updateFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("수정 실패 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .updateFailed:
+                    break // Success
+                default:
+                    XCTFail("Expected .updateFailed, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+        // Given
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .unknown(dummyError)
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("알 수 없는 에러 발생 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부에는 FolderRepositoryError가 포함되어야 합니다.")
+            }
+
+            switch repoError {
+                case .unknown(let underlyingError):
+                    XCTAssertTrue(underlyingError is Dummy)
+                default:
+                    XCTFail("Expected .unknown underlying error, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+}
+
+// MARK: - Error Cases ( Cancelled )
+
+extension ReadFolderUseCaseTest {
+
+    /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
+    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .cancelled
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("작업 취소의 경우 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case: 작업이 즉시 취소된 경우 execute 함수 내부 isCancelled를 검증한다
+    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .success([])
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute() }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업이 즉시 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case (During Execution): 작업 도중 Task가 취소된 경우
+    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
+        // Given
+        let useCase = DefaultReadFolderUseCase(
+            repository: MockFolderRepository(
+                fetchAllBehavior: .success([]),
+                delay: 100_000_000 // 0.1초 지연
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute() }
+
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기 후 취소
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Folders/ReadFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/ReadFolderUseCaseTest.swift
@@ -5,17 +5,20 @@ final class ReadFolderUseCaseTest: XCTestCase {
     typealias UseCaseError = ReadFolderUseCaseError
 }
 
-// MARK: - Success Cases
+// MARK: - 성공 케이스
 
 extension ReadFolderUseCaseTest {
-    /// 성공 Case: 모든 폴더 목록을 정상적으로 반환할 때
-    func test_execute_returnsFolders_whenRepositorySucceeds() async throws {
+
+    func test_폴더_조회_성공_폴더목록을반환한다() async throws {
         // Given
         let expectedFolders = [
             Folder(path: URL(fileURLWithPath: "/1"), name: "Folder 1"),
             Folder(path: URL(fileURLWithPath: "/2"), name: "Folder 2")
         ]
-        let repository = MockFolderRepository(fetchAllBehavior: .success(expectedFolders))
+        let repository = MockFolderRepository()
+        await repository.setFetchAllResult(.success(expectedFolders))
+        await repository.expectFetchAll(callCount: 1)
+
         let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When
@@ -27,19 +30,20 @@ extension ReadFolderUseCaseTest {
         XCTAssertEqual(folders[0].id, expectedFolders[0].id)
         XCTAssertEqual(folders[1].name, "Folder 2")
         XCTAssertEqual(folders[1].id, expectedFolders[1].id)
-        let callCount = await repository.fetchAllCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 }
 
-// MARK: - Error Cases
+// MARK: - 에러 케이스
 
 extension ReadFolderUseCaseTest {
 
-    /// 조회 실패 Case: fetchFailed 에러 전파 확인
-    func test_execute_throwsFetchFailed_whenRepositoryReturnsFetchFailed() async {
+    func test_폴더_조회_리포지토리조회실패시_fetchFailed에러를던진다() async {
         // Given
-        let repository = MockFolderRepository(fetchAllBehavior: .fetchFailed)
+        let repository = MockFolderRepository()
+        await repository.setFetchAllResult(.failure(.fetchFailed))
+        await repository.expectFetchAll(callCount: 1)
+
         let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
@@ -52,14 +56,15 @@ extension ReadFolderUseCaseTest {
             XCTFail("Expected .fetchFailed, got \(error)")
         }
 
-        let callCount = await repository.fetchAllCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 찾을 수 없는 경우 Case: Repository에서 .notFound를 반환할 때 동일하게 전파되는지 확인
-    func test_execute_throwsNotFound_whenRepositoryReturnsNotFound() async {
+    func test_폴더_조회_리포지토리찾을수없음시_notFound에러를던진다() async {
         // Given
-        let repository = MockFolderRepository(fetchAllBehavior: .notFound)
+        let repository = MockFolderRepository()
+        await repository.setFetchAllResult(.failure(.notFound))
+        await repository.expectFetchAll(callCount: 1)
+
         let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
@@ -72,14 +77,15 @@ extension ReadFolderUseCaseTest {
             XCTFail("Expected .notFound, got \(error)")
         }
 
-        let callCount = await repository.fetchAllCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 매핑 확인 Case: Repository에서 .createFailed를 반환할 때 .unknown으로 맵핑되는지 확인
-    func test_execute_throwsUnknown_whenRepositoryReturnsCreateFailed() async {
+    func test_폴더_조회_리포지토리생성실패시_unknown에러를던진다() async {
         // Given
-        let repository = MockFolderRepository(fetchAllBehavior: .createFailed)
+        let repository = MockFolderRepository()
+        await repository.setFetchAllResult(.failure(.createFailed))
+        await repository.expectFetchAll(callCount: 1)
+
         let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
@@ -88,7 +94,7 @@ extension ReadFolderUseCaseTest {
             XCTFail("생성 실패 시 .unknown으로 래핑되어야 합니다.")
         } catch UseCaseError.unknown(let error) {
             guard let repoError = error as? FolderRepositoryError else {
-                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다.")
             }
 
             switch repoError {
@@ -101,14 +107,15 @@ extension ReadFolderUseCaseTest {
             XCTFail("Expected .unknown, got \(error)")
         }
 
-        let callCount = await repository.fetchAllCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 매핑 확인 Case: Repository에서 .updateFailed를 반환할 때 .unknown으로 맵핑되는지 확인
-    func test_execute_throwsUnknown_whenRepositoryReturnsUpdateFailed() async {
+    func test_폴더_조회_리포지토리수정실패시_unknown에러를던진다() async {
         // Given
-        let repository = MockFolderRepository(fetchAllBehavior: .updateFailed)
+        let repository = MockFolderRepository()
+        await repository.setFetchAllResult(.failure(.updateFailed))
+        await repository.expectFetchAll(callCount: 1)
+
         let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
@@ -117,7 +124,7 @@ extension ReadFolderUseCaseTest {
             XCTFail("수정 실패 시 .unknown으로 래핑되어야 합니다.")
         } catch UseCaseError.unknown(let error) {
             guard let repoError = error as? FolderRepositoryError else {
-                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다.")
             }
 
             switch repoError {
@@ -130,16 +137,17 @@ extension ReadFolderUseCaseTest {
             XCTFail("Expected .unknown, got \(error)")
         }
 
-        let callCount = await repository.fetchAllCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
-    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+    func test_폴더_조회_리포지토리알수없는에러시_unknown에러를던진다() async {
         // Given
         struct Dummy: Error {}
         let dummyError = Dummy()
-        let repository = MockFolderRepository(fetchAllBehavior: .unknown(dummyError))
+        let repository = MockFolderRepository()
+        await repository.setFetchAllResult(.failure(.unknown(dummyError)))
+        await repository.expectFetchAll(callCount: 1)
+
         let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
@@ -161,19 +169,20 @@ extension ReadFolderUseCaseTest {
             XCTFail("Expected .unknown, got \(error)")
         }
 
-        let callCount = await repository.fetchAllCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 }
 
-// MARK: - Error Cases ( Cancelled )
+// MARK: - 취소 케이스
 
 extension ReadFolderUseCaseTest {
 
-    /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
-    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+    func test_폴더_조회_리포지토리취소시_cancelled에러를던진다() async {
         // Given
-        let repository = MockFolderRepository(fetchAllBehavior: .cancelled)
+        let repository = MockFolderRepository()
+        await repository.setFetchAllResult(.failure(.cancelled))
+        await repository.expectFetchAll(callCount: 1)
+
         let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
@@ -186,22 +195,22 @@ extension ReadFolderUseCaseTest {
             XCTFail("Expected .cancelled, got \(error)")
         }
 
-        let callCount = await repository.fetchAllCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 취소 Case: 작업이 즉시 취소된 경우 execute 함수 내부 isCancelled를 검증한다
-    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+    func test_폴더_조회_작업전_즉시cancelled에러를던진다() async {
         // Given
-        let useCase = DefaultReadFolderUseCase(
-            repository: MockFolderRepository(
-                fetchAllBehavior: .success([])
-            )
-        )
+        let repository = MockFolderRepository()
+        await repository.setFetchAllResult(.success([]))
+        await repository.expectFetchAll(callCount: 0)
+
+        let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
-        let task = Task { try await useCase.execute() }
-        task.cancel()
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            _ = try await useCase.execute()
+        }
 
         do {
             _ = try await task.value
@@ -211,6 +220,7 @@ extension ReadFolderUseCaseTest {
         } catch {
             XCTFail("Expected .cancelled, got \(error)")
         }
-    }
 
+        await repository.verify()
+    }
 }

--- a/ChaGok/Domain/Tests/Folders/ReadFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/ReadFolderUseCaseTest.swift
@@ -15,11 +15,8 @@ extension ReadFolderUseCaseTest {
             Folder(path: URL(fileURLWithPath: "/1"), name: "Folder 1"),
             Folder(path: URL(fileURLWithPath: "/2"), name: "Folder 2")
         ]
-        let useCase = DefaultReadFolderUseCase(
-            repository: MockFolderRepository(
-                fetchAllBehavior: .success(expectedFolders)
-            )
-        )
+        let repository = MockFolderRepository(fetchAllBehavior: .success(expectedFolders))
+        let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When
         let folders = try await useCase.execute()
@@ -30,6 +27,8 @@ extension ReadFolderUseCaseTest {
         XCTAssertEqual(folders[0].id, expectedFolders[0].id)
         XCTAssertEqual(folders[1].name, "Folder 2")
         XCTAssertEqual(folders[1].id, expectedFolders[1].id)
+        let callCount = await repository.fetchAllCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
     }
 }
 
@@ -40,11 +39,8 @@ extension ReadFolderUseCaseTest {
     /// 조회 실패 Case: fetchFailed 에러 전파 확인
     func test_execute_throwsFetchFailed_whenRepositoryReturnsFetchFailed() async {
         // Given
-        let useCase = DefaultReadFolderUseCase(
-            repository: MockFolderRepository(
-                fetchAllBehavior: .fetchFailed
-            )
-        )
+        let repository = MockFolderRepository(fetchAllBehavior: .fetchFailed)
+        let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -55,16 +51,16 @@ extension ReadFolderUseCaseTest {
         } catch {
             XCTFail("Expected .fetchFailed, got \(error)")
         }
+
+        let callCount = await repository.fetchAllCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
     }
 
     /// 찾을 수 없는 경우 Case: Repository에서 .notFound를 반환할 때 동일하게 전파되는지 확인
     func test_execute_throwsNotFound_whenRepositoryReturnsNotFound() async {
         // Given
-        let useCase = DefaultReadFolderUseCase(
-            repository: MockFolderRepository(
-                fetchAllBehavior: .notFound
-            )
-        )
+        let repository = MockFolderRepository(fetchAllBehavior: .notFound)
+        let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -75,16 +71,16 @@ extension ReadFolderUseCaseTest {
         } catch {
             XCTFail("Expected .notFound, got \(error)")
         }
+
+        let callCount = await repository.fetchAllCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
     }
 
     /// 매핑 확인 Case: Repository에서 .createFailed를 반환할 때 .unknown으로 맵핑되는지 확인
     func test_execute_throwsUnknown_whenRepositoryReturnsCreateFailed() async {
         // Given
-        let useCase = DefaultReadFolderUseCase(
-            repository: MockFolderRepository(
-                fetchAllBehavior: .createFailed
-            )
-        )
+        let repository = MockFolderRepository(fetchAllBehavior: .createFailed)
+        let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -104,16 +100,16 @@ extension ReadFolderUseCaseTest {
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
+
+        let callCount = await repository.fetchAllCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
     }
 
     /// 매핑 확인 Case: Repository에서 .updateFailed를 반환할 때 .unknown으로 맵핑되는지 확인
     func test_execute_throwsUnknown_whenRepositoryReturnsUpdateFailed() async {
         // Given
-        let useCase = DefaultReadFolderUseCase(
-            repository: MockFolderRepository(
-                fetchAllBehavior: .updateFailed
-            )
-        )
+        let repository = MockFolderRepository(fetchAllBehavior: .updateFailed)
+        let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -133,6 +129,9 @@ extension ReadFolderUseCaseTest {
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
+
+        let callCount = await repository.fetchAllCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
     }
 
     /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
@@ -140,11 +139,8 @@ extension ReadFolderUseCaseTest {
         // Given
         struct Dummy: Error {}
         let dummyError = Dummy()
-        let useCase = DefaultReadFolderUseCase(
-            repository: MockFolderRepository(
-                fetchAllBehavior: .unknown(dummyError)
-            )
-        )
+        let repository = MockFolderRepository(fetchAllBehavior: .unknown(dummyError))
+        let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -164,6 +160,9 @@ extension ReadFolderUseCaseTest {
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
+
+        let callCount = await repository.fetchAllCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
     }
 }
 
@@ -174,11 +173,8 @@ extension ReadFolderUseCaseTest {
     /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
     func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
         // Given
-        let useCase = DefaultReadFolderUseCase(
-            repository: MockFolderRepository(
-                fetchAllBehavior: .cancelled
-            )
-        )
+        let repository = MockFolderRepository(fetchAllBehavior: .cancelled)
+        let useCase = DefaultReadFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -189,6 +185,9 @@ extension ReadFolderUseCaseTest {
         } catch {
             XCTFail("Expected .cancelled, got \(error)")
         }
+
+        let callCount = await repository.fetchAllCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 fetchAll이 1번 호출되어야 합니다.")
     }
 
     /// 취소 Case: 작업이 즉시 취소된 경우 execute 함수 내부 isCancelled를 검증한다
@@ -214,29 +213,4 @@ extension ReadFolderUseCaseTest {
         }
     }
 
-    /// 취소 Case (During Execution): 작업 도중 Task가 취소된 경우
-    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
-        // Given
-        let useCase = DefaultReadFolderUseCase(
-            repository: MockFolderRepository(
-                fetchAllBehavior: .success([]),
-                delay: 100_000_000 // 0.1초 지연
-            )
-        )
-
-        // When & Then
-        let task = Task { try await useCase.execute() }
-
-        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기 후 취소
-        task.cancel()
-
-        do {
-            _ = try await task.value
-            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
-        } catch UseCaseError.cancelled {
-            // Success
-        } catch {
-            XCTFail("Expected .cancelled, got \(error)")
-        }
-    }
 }

--- a/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
@@ -19,11 +19,8 @@ extension UpdateFolderUseCaseTest {
             createdAt: originalFolder.createdAt
         )
 
-        let useCase = DefaultUpdateFolderUseCase(
-            repository: MockFolderRepository(
-                updateBehavior: .success(updatedFolder)
-            )
-        )
+        let repository = MockFolderRepository(updateBehavior: .success(updatedFolder))
+        let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When
         let result = try await useCase.execute(originalFolder)
@@ -33,6 +30,8 @@ extension UpdateFolderUseCaseTest {
         XCTAssertEqual(result.id, originalFolder.id)
         XCTAssertEqual(result.path, originalFolder.path)
         XCTAssertEqual(result.createdAt, originalFolder.createdAt)
+        let callCount = await repository.updateCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
     }
 }
 
@@ -42,12 +41,13 @@ extension UpdateFolderUseCaseTest {
 
     /// 이름의 길이가 50을 넘어가는 경우 .invailedLength 확인
     func test_execute_throwsInvalidLength_whenNameIsTooLong() async {
-        let useCase = DefaultUpdateFolderUseCase(
-            repository: MockFolderRepository()
-        )
+        // Given
+        let repository = MockFolderRepository()
+        let useCase = DefaultUpdateFolderUseCase(repository: repository)
         let tooLongName = String(repeating: "a", count: 51)
         let folder: Folder = .init(path: URL.applicationSupportDirectory, name: tooLongName)
 
+        // When & Then
         do {
             _ = try await useCase.execute(folder)
             XCTFail("invailedLengthName이 발생해야 합니다. (input: \(tooLongName))")
@@ -56,14 +56,16 @@ extension UpdateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .invailedLengthName, got \(error) for name: \(tooLongName)")
         }
+
+        let callCount = await repository.updateCallCount
+        XCTAssertEqual(callCount, 0, "유효하지 않은 길이일 경우 Repository를 호출하지 않아야 합니다.")
     }
 
     /// 유효하지 않은 이름 Case: 폴더 이름이 비어있거나 공백일 때 .invalidName 확인
     func test_execute_throwsInvalidName_whenNameIsEmpty() async {
         // Given
-        let useCase = DefaultUpdateFolderUseCase(
-            repository: MockFolderRepository()
-        )
+        let repository = MockFolderRepository()
+        let useCase = DefaultUpdateFolderUseCase(repository: repository)
         let invalidNames = ["", " ", "  \n  "]
 
         // When & Then
@@ -71,6 +73,7 @@ extension UpdateFolderUseCaseTest {
             for name in invalidNames {
                 group.addTask {
                     let folder = Folder(path: URL(fileURLWithPath: "/"), name: name)
+
                     do {
                         _ = try await useCase.execute(folder)
                         XCTFail("이름이 비어있는 경우 .invalidName 에러가 발생해야 합니다. (input: '\(name)')")
@@ -82,17 +85,17 @@ extension UpdateFolderUseCaseTest {
                 }
             }
         }
+
+        let callCount = await repository.updateCallCount
+        XCTAssertEqual(callCount, 0, "유효하지 않은 이름일 경우 Repository를 호출하지 않아야 합니다.")
     }
 
     /// 찾을 수 없음 Case: 수정하려는 폴더가 존재하지 않을 때 .notFound 전파 확인
     func test_execute_throwsNotFound_whenRepositoryReturnsNotFound() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
-        let useCase = DefaultUpdateFolderUseCase(
-            repository: MockFolderRepository(
-                updateBehavior: .notFound
-            )
-        )
+        let repository = MockFolderRepository(updateBehavior: .notFound)
+        let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -103,17 +106,17 @@ extension UpdateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .notFound, got \(error)")
         }
+
+        let callCount = await repository.updateCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
     }
 
     /// 이름 중복 Case: 수정하려는 이름이 이미 존재할 때 .duplicateName 전파 확인
     func test_execute_throwsDuplicateName_whenRepositoryReturnsDuplicateName() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "New Name")
-        let useCase = DefaultUpdateFolderUseCase(
-            repository: MockFolderRepository(
-                updateBehavior: .duplicateName
-            )
-        )
+        let repository = MockFolderRepository(updateBehavior: .duplicateName)
+        let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -124,17 +127,17 @@ extension UpdateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .duplicateName, got \(error)")
         }
+
+        let callCount = await repository.updateCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
     }
 
     /// 수정 실패 Case: Repository에서 .updateFailed를 반환할 때 동일하게 전파되는지 확인
     func test_execute_throwsUpdateFailed_whenRepositoryReturnsUpdateFailed() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
-        let useCase = DefaultUpdateFolderUseCase(
-            repository: MockFolderRepository(
-                updateBehavior: .updateFailed
-            )
-        )
+        let repository = MockFolderRepository(updateBehavior: .updateFailed)
+        let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -145,17 +148,17 @@ extension UpdateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .updateFailed, got \(error)")
         }
+
+        let callCount = await repository.updateCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
     }
 
     /// 매핑 확인 Case: Repository에서 .createFailed를 반환할 때 .unknown으로 맵핑되는지 확인
     func test_execute_throwsUnknown_whenRepositoryReturnsCreateFailed() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
-        let useCase = DefaultUpdateFolderUseCase(
-            repository: MockFolderRepository(
-                updateBehavior: .createFailed
-            )
-        )
+        let repository = MockFolderRepository(updateBehavior: .createFailed)
+        let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -175,17 +178,17 @@ extension UpdateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
+
+        let callCount = await repository.updateCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
     }
 
     /// 매핑 확인 Case: Repository에서 .fetchFailed를 반환할 때 .unknown으로 맵핑되는지 확인
     func test_execute_throwsUnknown_whenRepositoryReturnsFetchFailed() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
-        let useCase = DefaultUpdateFolderUseCase(
-            repository: MockFolderRepository(
-                updateBehavior: .fetchFailed
-            )
-        )
+        let repository = MockFolderRepository(updateBehavior: .fetchFailed)
+        let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -205,6 +208,9 @@ extension UpdateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
+
+        let callCount = await repository.updateCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
     }
 
     /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
@@ -213,11 +219,8 @@ extension UpdateFolderUseCaseTest {
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
         struct Dummy: Error {}
         let dummyError = Dummy()
-        let useCase = DefaultUpdateFolderUseCase(
-            repository: MockFolderRepository(
-                updateBehavior: .unknown(dummyError)
-            )
-        )
+        let repository = MockFolderRepository(updateBehavior: .unknown(dummyError))
+        let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -237,6 +240,9 @@ extension UpdateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
+
+        let callCount = await repository.updateCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
     }
 }
 
@@ -247,11 +253,8 @@ extension UpdateFolderUseCaseTest {
     func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
-        let useCase = DefaultUpdateFolderUseCase(
-            repository: MockFolderRepository(
-                updateBehavior: .cancelled
-            )
-        )
+        let repository = MockFolderRepository(updateBehavior: .cancelled)
+        let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
         do {
@@ -262,6 +265,9 @@ extension UpdateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .cancelled, got \(error)")
         }
+
+        let callCount = await repository.updateCallCount
+        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
     }
 
     /// 취소 Case: 작업이 즉시 취소된 경우 execute 함수 내부 isCancelled를 검증한다
@@ -288,30 +294,4 @@ extension UpdateFolderUseCaseTest {
         }
     }
 
-    /// 취소 Case (During Execution): 작업 도중 Task가 취소된 경우
-    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
-        // Given
-        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
-        let useCase = DefaultUpdateFolderUseCase(
-            repository: MockFolderRepository(
-                updateBehavior: .success(folder),
-                delay: 100_000_000 // 0.1초 지연
-            )
-        )
-
-        // When & Then
-        let task = Task { try await useCase.execute(folder) }
-
-        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기 후 취소
-        task.cancel()
-
-        do {
-            _ = try await task.value
-            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
-        } catch UseCaseError.cancelled {
-            // Success
-        } catch {
-            XCTFail("Expected .cancelled, got \(error)")
-        }
-    }
 }

--- a/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
@@ -1,0 +1,317 @@
+import XCTest
+@testable import Domain
+
+final class UpdateFolderUseCaseTest: XCTestCase {
+    typealias UseCaseError = UpdateFolderUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension UpdateFolderUseCaseTest {
+    /// 성공 Case: 폴더 정보 업데이트가 정상적으로 완료될 때
+    func test_execute_returnsUpdatedFolder_whenRepositorySucceeds() async throws {
+        // Given
+        let originalFolder = Folder(path: URL(fileURLWithPath: "/test"), name: "Old Name")
+        let updatedFolder = Folder(
+            id: originalFolder.id,
+            path: originalFolder.path,
+            name: "New Name",
+            createdAt: originalFolder.createdAt
+        )
+
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .success(updatedFolder)
+            )
+        )
+
+        // When
+        let result = try await useCase.execute(originalFolder)
+
+        // Then
+        XCTAssertEqual(result.name, "New Name")
+        XCTAssertEqual(result.id, originalFolder.id)
+        XCTAssertEqual(result.path, originalFolder.path)
+        XCTAssertEqual(result.createdAt, originalFolder.createdAt)
+    }
+}
+
+// MARK: - Error Cases
+
+extension UpdateFolderUseCaseTest {
+
+    /// 이름의 길이가 50을 넘어가는 경우 .invailedLength 확인
+    func test_execute_throwInvaildLength_whenNameIsTooLong() async {
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository()
+        )
+        let tooLongName = String(repeating: "a", count: 51)
+        let folder: Folder = .init(path: URL.applicationSupportDirectory, name: tooLongName)
+
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("invailedLengthName이 발생해야 합니다. (input: \(tooLongName))")
+        } catch UseCaseError.invailedLengthName {
+            // Success
+        } catch {
+            XCTFail("Expected .invailedLengthName, got \(error) for name: \(tooLongName)")
+        }
+    }
+
+    /// 유효하지 않은 이름 Case: 폴더 이름이 비어있거나 공백일 때 .invalidName 확인
+    func test_execute_throwsInvalidName_whenNameIsEmpty() async {
+        // Given
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository()
+        )
+        let invalidNames = ["", " ", "  \n  "]
+
+        // When & Then
+        await withTaskGroup(of: Void.self) { group in
+            for name in invalidNames {
+                group.addTask {
+                    let folder = Folder(path: URL(fileURLWithPath: "/"), name: name)
+                    do {
+                        _ = try await useCase.execute(folder)
+                        XCTFail("이름이 비어있는 경우 .invalidName 에러가 발생해야 합니다. (input: '\(name)')")
+                    } catch UseCaseError.invalidName {
+                        // Success
+                    } catch {
+                        XCTFail("Expected .invalidName, got \(error) for name: '\(name)'")
+                    }
+                }
+            }
+        }
+    }
+
+    /// 찾을 수 없음 Case: 수정하려는 폴더가 존재하지 않을 때 .notFound 전파 확인
+    func test_execute_throwsNotFound_whenRepositoryReturnsNotFound() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .notFound
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("폴더를 찾을 수 없는 경우 .notFound 에러가 발생해야 합니다.")
+        } catch UseCaseError.notFound {
+            // Success
+        } catch {
+            XCTFail("Expected .notFound, got \(error)")
+        }
+    }
+
+    /// 이름 중복 Case: 수정하려는 이름이 이미 존재할 때 .duplicateName 전파 확인
+    func test_execute_throwsDuplicateName_whenRepositoryReturnsDuplicateName() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "New Name")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .duplicateName
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("이름이 중복된 경우 .duplicateName 에러가 발생해야 합니다.")
+        } catch UseCaseError.duplicateName {
+            // Success
+        } catch {
+            XCTFail("Expected .duplicateName, got \(error)")
+        }
+    }
+
+    /// 수정 실패 Case: Repository에서 .updateFailed를 반환할 때 동일하게 전파되는지 확인
+    func test_execute_throwsUpdateFailed_whenRepositoryReturnsUpdateFailed() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .updateFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("수정 실패 시 .updateFailed 에러가 발생해야 합니다.")
+        } catch UseCaseError.updateFailed {
+            // Success
+        } catch {
+            XCTFail("Expected .updateFailed, got \(error)")
+        }
+    }
+
+    /// 매핑 확인 Case: Repository에서 .createFailed를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsCreateFailed() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .createFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("생성 실패 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .createFailed:
+                    break // Success
+                default:
+                    XCTFail("Expected .createFailed, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 매핑 확인 Case: Repository에서 .fetchFailed를 반환할 때 .unknown으로 맵핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryReturnsFetchFailed() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .fetchFailed
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("조회 실패 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+            }
+
+            switch repoError {
+                case .fetchFailed:
+                    break // Success
+                default:
+                    XCTFail("Expected .fetchFailed, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
+    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .unknown(dummyError)
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("알 수 없는 에러 발생 시 .unknown으로 래핑되어야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            guard let repoError = error as? FolderRepositoryError else {
+                return XCTFail("Unknown 에러 내부에는 FolderRepositoryError가 포함되어야 합니다.")
+            }
+
+            switch repoError {
+                case .unknown(let underlyingError):
+                    XCTAssertTrue(underlyingError is Dummy)
+                default:
+                    XCTFail("Expected .unknown underlying error, but got \(repoError)")
+            }
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+}
+
+// MARK: - Error Cases ( Cancelled )
+
+extension UpdateFolderUseCaseTest {
+    /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
+    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .cancelled
+            )
+        )
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(folder)
+            XCTFail("작업 취소의 경우 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case: 작업이 즉시 취소된 경우 execute 함수 내부 isCancelled를 검증한다
+    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .success(folder)
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute(folder) }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업이 즉시 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+
+    /// 취소 Case (During Execution): 작업 도중 Task가 취소된 경우
+    func test_execute_throwsCancelled_whenTaskIsCancelledDuringExecution() async {
+        // Given
+        let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
+        let useCase = DefaultUpdateFolderUseCase(
+            repository: MockFolderRepository(
+                updateBehavior: .success(folder),
+                delay: 100_000_000 // 0.1초 지연
+            )
+        )
+
+        // When & Then
+        let task = Task { try await useCase.execute(folder) }
+
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초 대기 후 취소
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("작업 도중 취소되었으므로 .cancelled 에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            // Success
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
@@ -5,11 +5,11 @@ final class UpdateFolderUseCaseTest: XCTestCase {
     typealias UseCaseError = UpdateFolderUseCaseError
 }
 
-// MARK: - Success Cases
+// MARK: - 성공 케이스
 
 extension UpdateFolderUseCaseTest {
-    /// 성공 Case: 폴더 정보 업데이트가 정상적으로 완료될 때
-    func test_execute_returnsUpdatedFolder_whenRepositorySucceeds() async throws {
+
+    func test_폴더_수정_성공_업데이트된폴더를반환한다() async throws {
         // Given
         let originalFolder = Folder(path: URL(fileURLWithPath: "/test"), name: "Old Name")
         let updatedFolder = Folder(
@@ -19,7 +19,10 @@ extension UpdateFolderUseCaseTest {
             createdAt: originalFolder.createdAt
         )
 
-        let repository = MockFolderRepository(updateBehavior: .success(updatedFolder))
+        let repository = MockFolderRepository()
+        await repository.setUpdateResult(.success(updatedFolder))
+        await repository.expectUpdate(callCount: 1)
+
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When
@@ -30,19 +33,19 @@ extension UpdateFolderUseCaseTest {
         XCTAssertEqual(result.id, originalFolder.id)
         XCTAssertEqual(result.path, originalFolder.path)
         XCTAssertEqual(result.createdAt, originalFolder.createdAt)
-        let callCount = await repository.updateCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 }
 
-// MARK: - Error Cases
+// MARK: - 에러 케이스
 
 extension UpdateFolderUseCaseTest {
 
-    /// 이름의 길이가 50을 넘어가는 경우 .invailedLength 확인
-    func test_execute_throwsInvalidLength_whenNameIsTooLong() async {
+    func test_폴더_수정_이름이너무길때_invalidLengthName에러를던진다() async {
         // Given
         let repository = MockFolderRepository()
+        await repository.expectUpdate(callCount: 0)
+
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
         let tooLongName = String(repeating: "a", count: 51)
         let folder: Folder = .init(path: URL.applicationSupportDirectory, name: tooLongName)
@@ -54,17 +57,17 @@ extension UpdateFolderUseCaseTest {
         } catch UseCaseError.invalidLengthName {
             // Success
         } catch {
-            XCTFail("Expected .invailedLengthName, got \(error) for name: \(tooLongName)")
+            XCTFail("Expected .invalidLengthName, got \(error) for name: \(tooLongName)")
         }
 
-        let callCount = await repository.updateCallCount
-        XCTAssertEqual(callCount, 0, "유효하지 않은 길이일 경우 Repository를 호출하지 않아야 합니다.")
+        await repository.verify()
     }
 
-    /// 유효하지 않은 이름 Case: 폴더 이름이 비어있거나 공백일 때 .invalidName 확인
-    func test_execute_throwsInvalidName_whenNameIsEmpty() async {
+    func test_폴더_수정_이름이비어있을때_invalidName에러를던진다() async {
         // Given
         let repository = MockFolderRepository()
+        await repository.expectUpdate(callCount: 0)
+
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
         let invalidNames = ["", " ", "  \n  "]
 
@@ -86,15 +89,16 @@ extension UpdateFolderUseCaseTest {
             }
         }
 
-        let callCount = await repository.updateCallCount
-        XCTAssertEqual(callCount, 0, "유효하지 않은 이름일 경우 Repository를 호출하지 않아야 합니다.")
+        await repository.verify()
     }
 
-    /// 찾을 수 없음 Case: 수정하려는 폴더가 존재하지 않을 때 .notFound 전파 확인
-    func test_execute_throwsNotFound_whenRepositoryReturnsNotFound() async {
+    func test_폴더_수정_리포지토리찾을수없음시_notFound에러를던진다() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
-        let repository = MockFolderRepository(updateBehavior: .notFound)
+        let repository = MockFolderRepository()
+        await repository.setUpdateResult(.failure(.notFound))
+        await repository.expectUpdate(callCount: 1)
+
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
@@ -107,15 +111,16 @@ extension UpdateFolderUseCaseTest {
             XCTFail("Expected .notFound, got \(error)")
         }
 
-        let callCount = await repository.updateCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 이름 중복 Case: 수정하려는 이름이 이미 존재할 때 .duplicateName 전파 확인
-    func test_execute_throwsDuplicateName_whenRepositoryReturnsDuplicateName() async {
+    func test_폴더_수정_리포지토리중복이름에러시_duplicateName에러를던진다() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "New Name")
-        let repository = MockFolderRepository(updateBehavior: .duplicateName)
+        let repository = MockFolderRepository()
+        await repository.setUpdateResult(.failure(.duplicateName))
+        await repository.expectUpdate(callCount: 1)
+
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
@@ -128,15 +133,16 @@ extension UpdateFolderUseCaseTest {
             XCTFail("Expected .duplicateName, got \(error)")
         }
 
-        let callCount = await repository.updateCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 수정 실패 Case: Repository에서 .updateFailed를 반환할 때 동일하게 전파되는지 확인
-    func test_execute_throwsUpdateFailed_whenRepositoryReturnsUpdateFailed() async {
+    func test_폴더_수정_리포지토리수정실패시_updateFailed에러를던진다() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
-        let repository = MockFolderRepository(updateBehavior: .updateFailed)
+        let repository = MockFolderRepository()
+        await repository.setUpdateResult(.failure(.updateFailed))
+        await repository.expectUpdate(callCount: 1)
+
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
@@ -149,15 +155,16 @@ extension UpdateFolderUseCaseTest {
             XCTFail("Expected .updateFailed, got \(error)")
         }
 
-        let callCount = await repository.updateCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 매핑 확인 Case: Repository에서 .createFailed를 반환할 때 .unknown으로 맵핑되는지 확인
-    func test_execute_throwsUnknown_whenRepositoryReturnsCreateFailed() async {
+    func test_폴더_수정_리포지토리생성실패시_unknown에러를던진다() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
-        let repository = MockFolderRepository(updateBehavior: .createFailed)
+        let repository = MockFolderRepository()
+        await repository.setUpdateResult(.failure(.createFailed))
+        await repository.expectUpdate(callCount: 1)
+
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
@@ -166,28 +173,29 @@ extension UpdateFolderUseCaseTest {
             XCTFail("생성 실패 시 .unknown으로 래핑되어야 합니다.")
         } catch UseCaseError.unknown(let error) {
             guard let repoError = error as? FolderRepositoryError else {
-                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다.")
             }
 
             switch repoError {
-                case .createFailed:
-                    break // Success
-                default:
-                    XCTFail("Expected .createFailed, but got \(repoError)")
+            case .createFailed:
+                break // Success
+            default:
+                XCTFail("Expected .createFailed, but got \(repoError)")
             }
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
 
-        let callCount = await repository.updateCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 매핑 확인 Case: Repository에서 .fetchFailed를 반환할 때 .unknown으로 맵핑되는지 확인
-    func test_execute_throwsUnknown_whenRepositoryReturnsFetchFailed() async {
+    func test_폴더_수정_리포지토리조회실패시_unknown에러를던진다() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
-        let repository = MockFolderRepository(updateBehavior: .fetchFailed)
+        let repository = MockFolderRepository()
+        await repository.setUpdateResult(.failure(.fetchFailed))
+        await repository.expectUpdate(callCount: 1)
+
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
@@ -196,30 +204,31 @@ extension UpdateFolderUseCaseTest {
             XCTFail("조회 실패 시 .unknown으로 래핑되어야 합니다.")
         } catch UseCaseError.unknown(let error) {
             guard let repoError = error as? FolderRepositoryError else {
-                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다. ( Typed Throws )")
+                return XCTFail("Unknown 에러 내부는 FolderRepositoryError가 적용되어야 합니다.")
             }
 
             switch repoError {
-                case .fetchFailed:
-                    break // Success
-                default:
-                    XCTFail("Expected .fetchFailed, but got \(repoError)")
+            case .fetchFailed:
+                break // Success
+            default:
+                XCTFail("Expected .fetchFailed, but got \(repoError)")
             }
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
 
-        let callCount = await repository.updateCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 알 수 없는 에러 Case: Repository에서 맵핑되지 않은 에러를 던질 때 .unknown으로 래핑되는지 확인
-    func test_execute_throwsUnknown_whenRepositoryThrowsUnknown() async {
+    func test_폴더_수정_리포지토리알수없는에러시_unknown에러를던진다() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
         struct Dummy: Error {}
         let dummyError = Dummy()
-        let repository = MockFolderRepository(updateBehavior: .unknown(dummyError))
+        let repository = MockFolderRepository()
+        await repository.setUpdateResult(.failure(.unknown(dummyError)))
+        await repository.expectUpdate(callCount: 1)
+
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
@@ -232,28 +241,30 @@ extension UpdateFolderUseCaseTest {
             }
 
             switch repoError {
-                case .unknown(let underlyingError):
-                    XCTAssertTrue(underlyingError is Dummy)
-                default:
-                    XCTFail("Expected .unknown underlying error, but got \(repoError)")
+            case .unknown(let underlyingError):
+                XCTAssertTrue(underlyingError is Dummy)
+            default:
+                XCTFail("Expected .unknown underlying error, but got \(repoError)")
             }
         } catch {
             XCTFail("Expected .unknown, got \(error)")
         }
 
-        let callCount = await repository.updateCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 }
 
-// MARK: - Error Cases ( Cancelled )
+// MARK: - 취소 케이스
 
 extension UpdateFolderUseCaseTest {
-    /// 작업 취소 Case: repository Cancelled의 경우 UseCase.Cancelled와 대칭 확인
-    func test_execute_throwsCancelled_whenRepositoryReturnsCancelled() async {
+
+    func test_폴더_수정_리포지토리취소시_cancelled에러를던진다() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
-        let repository = MockFolderRepository(updateBehavior: .cancelled)
+        let repository = MockFolderRepository()
+        await repository.setUpdateResult(.failure(.cancelled))
+        await repository.expectUpdate(callCount: 1)
+
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
@@ -266,23 +277,23 @@ extension UpdateFolderUseCaseTest {
             XCTFail("Expected .cancelled, got \(error)")
         }
 
-        let callCount = await repository.updateCallCount
-        XCTAssertEqual(callCount, 1, "Repository의 update가 1번 호출되어야 합니다.")
+        await repository.verify()
     }
 
-    /// 취소 Case: 작업이 즉시 취소된 경우 execute 함수 내부 isCancelled를 검증한다
-    func test_execute_throwsCancelled_whenTaskIsCancelledPreemptively() async {
+    func test_폴더_수정_작업이미취소시_즉시cancelled에러를던진다() async {
         // Given
         let folder = Folder(path: URL(fileURLWithPath: "/test"), name: "Any")
-        let useCase = DefaultUpdateFolderUseCase(
-            repository: MockFolderRepository(
-                updateBehavior: .success(folder)
-            )
-        )
+        let repository = MockFolderRepository()
+        await repository.setUpdateResult(.success(folder))
+        await repository.expectUpdate(callCount: 0)
+
+        let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When & Then
-        let task = Task { try await useCase.execute(folder) }
-        task.cancel()
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            _ = try await useCase.execute(folder)
+        }
 
         do {
             _ = try await task.value
@@ -292,6 +303,7 @@ extension UpdateFolderUseCaseTest {
         } catch {
             XCTFail("Expected .cancelled, got \(error)")
         }
-    }
 
+        await repository.verify()
+    }
 }

--- a/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
@@ -21,7 +21,7 @@ extension UpdateFolderUseCaseTest {
 
         let repository = MockFolderRepository()
         await repository.setUpdateResult(.success(updatedFolder))
-        await repository.expectUpdate(callCount: 1)
+        await repository.expectUpdate(folderID: updatedFolder.id, callCount: 1)
 
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
 

--- a/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
@@ -41,7 +41,7 @@ extension UpdateFolderUseCaseTest {
 extension UpdateFolderUseCaseTest {
 
     /// 이름의 길이가 50을 넘어가는 경우 .invailedLength 확인
-    func test_execute_throwInvaildLength_whenNameIsTooLong() async {
+    func test_execute_throwsInvalidLength_whenNameIsTooLong() async {
         let useCase = DefaultUpdateFolderUseCase(
             repository: MockFolderRepository()
         )
@@ -51,7 +51,7 @@ extension UpdateFolderUseCaseTest {
         do {
             _ = try await useCase.execute(folder)
             XCTFail("invailedLengthName이 발생해야 합니다. (input: \(tooLongName))")
-        } catch UseCaseError.invailedLengthName {
+        } catch UseCaseError.invalidLengthName {
             // Success
         } catch {
             XCTFail("Expected .invailedLengthName, got \(error) for name: \(tooLongName)")

--- a/ChaGok/Domain/Tests/UseCases/VoiceNotes/FetchVoiceNoteUseCaseTests.swift
+++ b/ChaGok/Domain/Tests/UseCases/VoiceNotes/FetchVoiceNoteUseCaseTests.swift
@@ -29,7 +29,7 @@ extension FetchVoiceNoteUseCaseTests {
         let folderID = UUID()
         let expectedNotes = [
             VoiceNote.stub(title: "Title 1"),
-            VoiceNote.stub(title: "Title 2"),
+            VoiceNote.stub(title: "Title 2")
         ]
         await repository.setFetchAllResult(.success(expectedNotes))
         await repository.expectFetchAll(callCount: 1, folderID: folderID)


### PR DESCRIPTION
## ✨ 작업 요약
> 한 줄로 무엇을 추가/변경했는지

- `WorkSpace` 테스트 설계 패턴(`Result` 기반 Mock, `expect/verify` 검증)을 적용하여 Folder UseCase(`Create`, `Read`, `Update`) Unit Test 리팩토링 진행

## 📋 구체적인 내용
- 추가/변경된 동작:
   - **MockFolderRepository**: `Result` 타입을 활용하여 성공 및 에러 상태를 명확히 주입할 수 있도록 구현하고, `expect/verify` 방식의 호출 횟수 검증 기능과 전달 인자 캡처 기능을 추가하여 정합성을 강화했습니다.
   - **CreateFolderUseCaseTest**: 폴더 생성 성공, 빈 이름 검증(`invalidName`), `CreateFolderUseCaseError` 에러 매핑 및 즉시 취소(`cancelled`) 케이스 검증.
   - **ReadFolderUseCaseTest**: 전체 폴더 목록 조회 성공 유무 확인, `ReadFolderUseCaseError` 에러(`fetchFailed`, `unknown`) 매핑 및 취소 방어 케이스 검증.
   - **UpdateFolderUseCaseTest**: 폴더 정보 수정 성공, 이름 유효성 검증(`invalidName`, `invalidLengthName`), `UpdateFolderUseCaseError` 에러(`notFound`, `duplicateName`, `updateFailed`) 매핑 및 취소 방어 로직 검증.
   - **테스트 일관성 강화**: `extension`을 활용한 컨텍스트별 그룹화, `// Given/When/Then` 마커 부착, `XCTAssert` 내부 캡처 변수의 `await` 추출 등 가독성 개선 및 스타일 통일.
- 영향 받는 화면/모듈: Domain/Tests/Folders

---

## 🔗 연관 이슈

- closed #59 

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
   - **Result 기반 Mocking**: 기존의 복잡한 `Behavior` enum 대신 Swift의 기본 `Result<T, Error>` 및 `switch` 문을 활용하여 Mock에 예상 상태를 직관적으로 주입하도록 개선했습니다.
   - **Expect/Verify & 인자 검증(Argument Capture)**: 단순한 Stub을 넘어, 테스트 마지막에 `await repository.verify()`를 역호출해 실행 횟수를 엄격히 검증하고, 전달된 폴더 이름이나 아이템이 올바른지까지 검사하여 신뢰도를 높였습니다.
   - **즉시 취소(Immediate Cancellation) 시뮬레이션**: 인위적인 Delay 로직 없이, `withUnsafeCurrentTask { $0?.cancel() }`을 활용하여 테스트 환경에 구애받지 않는 결정론적인 취소 케이스를 구조화했습니다.
   
- **고려했다가 제외한 방식**
   - **Behavior 기반 Mock 및 State Flag 방식**: 구조가 무거워지고, 여러 Typed Throws 상황을 개별 설정하기에 불리하여 제외했습니다.
   - **Delay를 통한 비동기 취소 검증**: 시간 편차에 따른 비결정성(Flaky Test) 문제를 야기할 수 있어 제거하고, Task 즉각 취소 방식으로 대체했습니다.

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [x] 정상 플로우 동작 및 에러 매핑(`unknown` 포함) 구조 일치 확인
- [x] 전달 Parameter 인자 검증 및 Call Count 정합성 통과 확인
- [x] 즉시 Cancellation(Preemptive Cancel) 시 에러 방어 로직 작동 검사 완료
- [ ] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- **일관된 테스트 스타일**: `WorkSpace` 모듈 테스트와 동일한 패턴(`MARK`, `extension` 분리, `Given/When/Then` 마커)이 적용되었는지 확인 부탁드립니다.
- **Mock 검증(Verification) 활용**: 단순 반환값 제어가 아닌, UseCase 내에서 리포지토리로 전달한 인자와 호출 횟수(`verify()`)에 대한 실질적인 검증이 이뤄졌는지 봐주세요.
- **에러 핸들링 및 취소 안정성**: Delay 주입 없이 `withUnsafeCurrentTask`로 Task가 Cancel 되었을 때, 레포지토리가 불필요하게 호출되지 않고 `cancelled` 에러를 반환하는지 중점적으로 검토해 주세요.
- **UpdateFolderUseCase**: 폴더 이름 길이 제한(50자) 등 코어 비즈니스 로직에 대한 검증 유효성 확인.

---

## 📚 참고

- `Domain/Tests/WorkSpace` 방식의 리팩토링 선례를 기반으로 재작성함.
