### PR TITLE
Domain 휴지통(삭제, 조회, 이동) UseCase 단위 테스트를 진행합니다.

### DIFF
--- a/ChaGok/Domain/Sources/Entities/WasteBasketItem.swift
+++ b/ChaGok/Domain/Sources/Entities/WasteBasketItem.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 /// 휴지통 내부 모델 - Folder 또는 VoiceNote가 될 수 있다.
-public enum WasteBasketItem: Sendable {
+public enum WasteBasketItem: Equatable, Sendable {
     case folder(id: UUID)
     case voiceNote(id: UUID)
 }
 
 /// 휴지통 삭제 방식을 정의하는 열거형
-public enum DeleteWasteBasketMethod: Sendable {
+public enum DeleteWasteBasketMethod: Equatable, Sendable {
     /// 전체 삭제
     case all
     /// 다수 선택 삭제
@@ -28,7 +28,7 @@ public enum DeleteWasteBasketMethod: Sendable {
 }
 
 /// 휴지통으로 이동 방식을 정의하는 열거형
-public enum MoveWasteBasketMethod: Sendable {
+public enum MoveWasteBasketMethod: Equatable, Sendable {
     /// 개별 이동
     case single(item: WasteBasketItem)
     /// 다수 선택 이동

--- a/ChaGok/Domain/Tests/WasteBasket/DeleteWasteBasketUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WasteBasket/DeleteWasteBasketUseCaseTest.swift
@@ -1,0 +1,205 @@
+import XCTest
+@testable import Domain
+
+final class DeleteWasteBasketUseCaseTest: XCTestCase {
+    typealias UseCaseError = DeleteWasteBasketUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension DeleteWasteBasketUseCaseTest {
+
+    func test_휴지통_삭제_전체삭제_성공_리포지토리를호출한다() async throws {
+        // Given
+        let repository = MockWasteBasketRepository()
+        await repository.setDeleteResult(.success(()))
+        await repository.expectAllClear(callCount: 1)
+
+        let useCase = DefaultDeleteWasteBasketUseCase(repository: repository)
+
+        // When
+        _ = try await useCase.execute(method: .all)
+
+        // Then
+        await repository.verify()
+    }
+
+    func test_휴지통_삭제_다중삭제_성공_리포지토리를호출한다() async throws {
+        // Given
+        let items: [WasteBasketItem] = [
+            .folder(id: UUID()),
+            .voiceNote(id: UUID())
+        ]
+        let repository = MockWasteBasketRepository()
+        await repository.setDeleteResult(.success(()))
+        await repository.expectDeleteAll(callCount: 1)
+
+        let useCase = DefaultDeleteWasteBasketUseCase(repository: repository)
+
+        // When
+        _ = try await useCase.execute(method: .multiple(items: items))
+
+        // Then
+        let lastDeletedItems = await repository.lastDeletedItems
+        XCTAssertEqual(lastDeletedItems, items)
+        await repository.verify()
+    }
+
+    func test_휴지통_삭제_단일삭제_성공_리포지토리를호출한다() async throws {
+        // Given
+        let item: WasteBasketItem = .folder(id: UUID())
+        let repository = MockWasteBasketRepository()
+        await repository.setDeleteResult(.success(()))
+        await repository.expectDelete(callCount: 1)
+
+        let useCase = DefaultDeleteWasteBasketUseCase(repository: repository)
+
+        // When
+        _ = try await useCase.execute(method: .single(item: item))
+
+        // Then
+        let lastDeletedItem = await repository.lastDeletedItem
+        XCTAssertEqual(lastDeletedItem, item)
+        await repository.verify()
+    }
+}
+
+// MARK: - Error Mapping Cases
+
+extension DeleteWasteBasketUseCaseTest {
+
+    func test_휴지통_삭제_리포지토리삭제실패시_deleteFailed에러를던진다() async {
+        // Given
+        let method = DeleteWasteBasketMethod.all
+        let repository = MockWasteBasketRepository()
+        await repository.setDeleteResult(.failure(.deleteFailed(method)))
+        await repository.expectAllClear(callCount: 1)
+
+        let useCase = DefaultDeleteWasteBasketUseCase(repository: repository)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(method: method)
+            XCTFail("에러가 발생해야 합니다.")
+        } catch UseCaseError.deleteFailed(let failedMethod) {
+            XCTAssertEqual(failedMethod, method)
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .deleteFailed, got \(error)")
+        }
+    }
+
+    func test_휴지통_삭제_리포지토리단일삭제실패시_deleteFailed에러를던진다() async {
+        // Given
+        let item = WasteBasketItem.folder(id: UUID())
+        let method = DeleteWasteBasketMethod.single(item: item)
+        let repository = MockWasteBasketRepository()
+        await repository.setDeleteResult(.failure(.deleteFailed(method)))
+        await repository.expectDelete(callCount: 1)
+
+        let useCase = DefaultDeleteWasteBasketUseCase(repository: repository)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(method: method)
+            XCTFail("에러가 발생해야 합니다.")
+        } catch UseCaseError.deleteFailed(let failedMethod) {
+            XCTAssertEqual(failedMethod, method)
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .deleteFailed, got \(error)")
+        }
+    }
+
+    func test_휴지통_삭제_리포지토리다중삭제실패시_deleteFailed에러를던진다() async {
+        // Given
+        let items: [WasteBasketItem] = [.folder(id: UUID())]
+        let method = DeleteWasteBasketMethod.multiple(items: items)
+        let repository = MockWasteBasketRepository()
+        await repository.setDeleteResult(.failure(.deleteFailed(method)))
+        await repository.expectDeleteAll(callCount: 1)
+
+        let useCase = DefaultDeleteWasteBasketUseCase(repository: repository)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(method: method)
+            XCTFail("에러가 발생해야 합니다.")
+        } catch UseCaseError.deleteFailed(let failedMethod) {
+            XCTAssertEqual(failedMethod, method)
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .deleteFailed, got \(error)")
+        }
+    }
+
+    func test_휴지통_삭제_리포지토리알수없는에러시_unknown에러를던진다() async {
+        // Given
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let repository = MockWasteBasketRepository()
+        await repository.setDeleteResult(.failure(.unknown(dummyError)))
+        await repository.expectAllClear(callCount: 1)
+
+        let useCase = DefaultDeleteWasteBasketUseCase(repository: repository)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(method: .all)
+            XCTFail("에러가 발생해야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            XCTAssertTrue(error is Dummy)
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    func test_휴지통_삭제_리포지토리취소시_cancelled에러를던진다() async {
+        // Given
+        let repository = MockWasteBasketRepository()
+        await repository.setDeleteResult(.failure(.cancelled))
+        await repository.expectAllClear(callCount: 1)
+
+        let useCase = DefaultDeleteWasteBasketUseCase(repository: repository)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(method: .all)
+            XCTFail("에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+}
+
+// MARK: - Cancellation Case
+
+extension DeleteWasteBasketUseCaseTest {
+
+    func test_휴지통_삭제_작업전_즉시cancelled에러를던진다() async {
+        // Given
+        let repository = MockWasteBasketRepository()
+        await repository.setDeleteResult(.success(()))
+        await repository.expectAllClear(callCount: 0)
+
+        let useCase = DefaultDeleteWasteBasketUseCase(repository: repository)
+
+        // When & Then
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            _ = try await useCase.execute(method: .all)
+        }
+
+        do {
+            _ = try await task.value
+            XCTFail("작업이 취소되어야 합니다.")
+        } catch UseCaseError.cancelled {
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .cancelled error, but got \(error)")
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/WasteBasket/DeleteWasteBasketUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WasteBasket/DeleteWasteBasketUseCaseTest.swift
@@ -32,7 +32,7 @@ extension DeleteWasteBasketUseCaseTest {
         ]
         let repository = MockWasteBasketRepository()
         await repository.setDeleteResult(.success(()))
-        await repository.expectDeleteAll(callCount: 1)
+        await repository.expectDeleteAll(items: items, callCount: 1)
 
         let useCase = DefaultDeleteWasteBasketUseCase(repository: repository)
 
@@ -40,8 +40,6 @@ extension DeleteWasteBasketUseCaseTest {
         _ = try await useCase.execute(method: .multiple(items: items))
 
         // Then
-        let lastDeletedItems = await repository.lastDeletedItems
-        XCTAssertEqual(lastDeletedItems, items)
         await repository.verify()
     }
 
@@ -50,7 +48,7 @@ extension DeleteWasteBasketUseCaseTest {
         let item: WasteBasketItem = .folder(id: UUID())
         let repository = MockWasteBasketRepository()
         await repository.setDeleteResult(.success(()))
-        await repository.expectDelete(callCount: 1)
+        await repository.expectDelete(item: item, callCount: 1)
 
         let useCase = DefaultDeleteWasteBasketUseCase(repository: repository)
 
@@ -58,8 +56,6 @@ extension DeleteWasteBasketUseCaseTest {
         _ = try await useCase.execute(method: .single(item: item))
 
         // Then
-        let lastDeletedItem = await repository.lastDeletedItem
-        XCTAssertEqual(lastDeletedItem, item)
         await repository.verify()
     }
 }

--- a/ChaGok/Domain/Tests/WasteBasket/FetchWasteBasketFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WasteBasket/FetchWasteBasketFolderUseCaseTest.swift
@@ -25,7 +25,7 @@ extension FetchWasteBasketFolderUseCaseTest {
         let result = try await useCase.execute()
 
         // Then
-        XCTAssertEqual(result.count, expectedItems.count)
+        XCTAssertEqual(result, expectedItems)
         await repository.verify()
     }
 

--- a/ChaGok/Domain/Tests/WasteBasket/FetchWasteBasketFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WasteBasket/FetchWasteBasketFolderUseCaseTest.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import Domain
+
+final class FetchWasteBasketFolderUseCaseTest: XCTestCase {
+    typealias UseCaseError = FetchWasteBasketFolderUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension FetchWasteBasketFolderUseCaseTest {
+
+    func test_휴지통_조회_성공_항목을반환한다() async throws {
+        // Given
+        let expectedItems: [WasteBasketItem] = [
+            .folder(id: UUID()),
+            .voiceNote(id: UUID())
+        ]
+        let repository = MockWasteBasketRepository()
+        await repository.setFetchAllResult(.success(expectedItems))
+        await repository.expectFetchAll(callCount: 1)
+
+        let useCase = DefaultFetchWasteBasketFolderUseCase(repository: repository)
+
+        // When
+        let result = try await useCase.execute()
+
+        // Then
+        XCTAssertEqual(result.count, expectedItems.count)
+        await repository.verify()
+    }
+
+    func test_휴지통_조회_성공_항목이결과가없으면_빈배열을반환한다() async throws {
+        // Given
+        let repository = MockWasteBasketRepository()
+        await repository.setFetchAllResult(.success([]))
+        await repository.expectFetchAll(callCount: 1)
+
+        let useCase = DefaultFetchWasteBasketFolderUseCase(repository: repository)
+
+        // When
+        let result = try await useCase.execute()
+
+        // Then
+        XCTAssertTrue(result.isEmpty)
+        await repository.verify()
+    }
+}
+
+// MARK: - Error Mapping Cases
+
+extension FetchWasteBasketFolderUseCaseTest {
+
+    func test_휴지통_조회_리포지토리조회실패시_fetchFailed에러를던진다() async {
+        // Given
+        let repository = MockWasteBasketRepository()
+        await repository.setFetchAllResult(.failure(.fetchFailed))
+        await repository.expectFetchAll(callCount: 1)
+
+        let useCase = DefaultFetchWasteBasketFolderUseCase(repository: repository)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("에러가 발생해야 합니다.")
+        } catch UseCaseError.fetchFailed {
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .fetchFailed, got \(error)")
+        }
+    }
+
+    func test_휴지통_조회_리포지토리알수없는에러시_unknown에러를던진다() async {
+        // Given
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let repository = MockWasteBasketRepository()
+        await repository.setFetchAllResult(.failure(.unknown(dummyError)))
+        await repository.expectFetchAll(callCount: 1)
+
+        let useCase = DefaultFetchWasteBasketFolderUseCase(repository: repository)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("에러가 발생해야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            XCTAssertTrue(error is Dummy)
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    func test_휴지통_조회_리포지토리취소시_cancelled에러를던진다() async {
+        // Given
+        let repository = MockWasteBasketRepository()
+        await repository.setFetchAllResult(.failure(.cancelled))
+        await repository.expectFetchAll(callCount: 1)
+
+        let useCase = DefaultFetchWasteBasketFolderUseCase(repository: repository)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute()
+            XCTFail("에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+}
+
+// MARK: - Cancellation Case
+
+extension FetchWasteBasketFolderUseCaseTest {
+
+    func test_휴지통_조회_작업전_즉시cancelled에러를던진다() async {
+        // Given
+        let repository = MockWasteBasketRepository()
+        await repository.setFetchAllResult(.success([]))
+        await repository.expectFetchAll(callCount: 0)
+
+        let useCase = DefaultFetchWasteBasketFolderUseCase(repository: repository)
+
+        // When & Then
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            _ = try await useCase.execute()
+        }
+
+        do {
+            _ = try await task.value
+            XCTFail("작업이 취소되어야 합니다.")
+        } catch UseCaseError.cancelled {
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .cancelled error, but got \(error)")
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/WasteBasket/MockWasteBasketRepository.swift
+++ b/ChaGok/Domain/Tests/WasteBasket/MockWasteBasketRepository.swift
@@ -25,6 +25,12 @@ actor MockWasteBasketRepository: WasteBasketRepository {
     private var expectedDeleteAllCallCount: Int?
     private var expectedAllClearCallCount: Int?
 
+    // Expected Arguments
+    private var expectedLastMovedItem: WasteBasketItem?
+    private var expectedLastMovedItems: [WasteBasketItem]?
+    private var expectedLastDeletedItem: WasteBasketItem?
+    private var expectedLastDeletedItems: [WasteBasketItem]?
+
     // 받은 인자 기록 (Verification용)
     private(set) var lastMovedItem: WasteBasketItem?
     private(set) var lastMovedItems: [WasteBasketItem]?
@@ -51,20 +57,24 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         expectedFetchAllCallCount = callCount
     }
 
-    func expectMoveToWasteBasket(callCount: Int) {
+    func expectMoveToWasteBasket(item: WasteBasketItem? = nil, callCount: Int) {
         expectedMoveToWasteBasketCallCount = callCount
+        expectedLastMovedItem = item
     }
 
-    func expectMoveAllToWasteBasket(callCount: Int) {
+    func expectMoveAllToWasteBasket(items: [WasteBasketItem]? = nil, callCount: Int) {
         expectedMoveAllToWasteBasketCallCount = callCount
+        expectedLastMovedItems = items
     }
 
-    func expectDelete(callCount: Int) {
+    func expectDelete(item: WasteBasketItem? = nil, callCount: Int) {
         expectedDeleteCallCount = callCount
+        expectedLastDeletedItem = item
     }
 
-    func expectDeleteAll(callCount: Int) {
+    func expectDeleteAll(items: [WasteBasketItem]? = nil, callCount: Int) {
         expectedDeleteAllCallCount = callCount
+        expectedLastDeletedItems = items
     }
 
     func expectAllClear(callCount: Int) {
@@ -92,6 +102,20 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         if let expected = expectedAllClearCallCount {
             XCTAssertEqual(allClearCallCount, expected, "allClear call count mismatch", file: file, line: line)
         }
+
+        // Argument Verification
+        if let expected = expectedLastMovedItem {
+            XCTAssertEqual(lastMovedItem, expected, "lastMovedItem mismatch", file: file, line: line)
+        }
+        if let expected = expectedLastMovedItems {
+            XCTAssertEqual(lastMovedItems, expected, "lastMovedItems mismatch", file: file, line: line)
+        }
+        if let expected = expectedLastDeletedItem {
+            XCTAssertEqual(lastDeletedItem, expected, "lastDeletedItem mismatch", file: file, line: line)
+        }
+        if let expected = expectedLastDeletedItems {
+            XCTAssertEqual(lastDeletedItems, expected, "lastDeletedItems mismatch", file: file, line: line)
+        }
     }
 
     // MARK: - WasteBasketRepository (Fetch, Move, Delete)
@@ -99,15 +123,15 @@ actor MockWasteBasketRepository: WasteBasketRepository {
     func fetchAll() async throws(FetchWasteBasketRepositoryError) -> [WasteBasketItem] {
         fetchAllCallCount += 1
 
-        guard let result = fetchAllResult else {
-            fatalError("MockWasteBasketRepository.fetchAllResult not set")
-        }
-
-        switch result {
+        switch fetchAllResult {
             case .success(let items):
                 return items
             case .failure(let error):
                 throw error
+            case .none:
+                XCTFail("MockWasteBasketRepository.fetchAllResult를 찾을 수 없습니다")
+                let error = NSError(domain: "MockWasteBasketRepository.fetchAllResult", code: 0)
+                throw .unknown(error)
         }
     }
 
@@ -115,15 +139,15 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         moveToWasteBasketCallCount += 1
         lastMovedItem = item
 
-        guard let result = moveResult else {
-            fatalError("MockWasteBasketRepository.moveResult not set")
-        }
-
-        switch result {
+        switch moveResult {
             case .success:
                 return
             case .failure(let error):
                 throw error
+            case .none:
+                XCTFail("MockWasteBasketRepository.moveResult를 찾을 수 없습니다")
+                let error = NSError(domain: "MockWasteBasketRepository.moveResult", code: 0)
+                throw .unknown(error)
         }
     }
 
@@ -131,15 +155,15 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         moveAllToWasteBasketCallCount += 1
         lastMovedItems = items
 
-        guard let result = moveResult else {
-            fatalError("MockWasteBasketRepository.moveResult not set")
-        }
-
-        switch result {
+        switch moveResult {
             case .success:
                 return
             case .failure(let error):
                 throw error
+            case .none:
+                XCTFail("MockWasteBasketRepository.moveResult를 찾을 수 없습니다")
+                let error = NSError(domain: "MockWasteBasketRepository.moveResult", code: 0)
+                throw .unknown(error)
         }
     }
 
@@ -147,15 +171,15 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         deleteCallCount += 1
         lastDeletedItem = item
 
-        guard let result = deleteResult else {
-            fatalError("MockWasteBasketRepository.deleteResult not set")
-        }
-
-        switch result {
+        switch deleteResult {
             case .success:
                 return
             case .failure(let error):
                 throw error
+            case .none:
+                XCTFail("MockWasteBasketRepository.deleteResult를 찾을 수 없습니다")
+                let error = NSError(domain: "MockWasteBasketRepository.deleteResult", code: 0)
+                throw .unknown(error)
         }
     }
 
@@ -163,30 +187,30 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         deleteAllCallCount += 1
         lastDeletedItems = items
 
-        guard let result = deleteResult else {
-            fatalError("MockWasteBasketRepository.deleteResult not set")
-        }
-
-        switch result {
+        switch deleteResult {
             case .success:
                 return
             case .failure(let error):
                 throw error
+            case .none:
+                XCTFail("MockWasteBasketRepository.deleteResult를 찾을 수 없습니다")
+                let error = NSError(domain: "MockWasteBasketRepository.deleteResult", code: 0)
+                throw .unknown(error)
         }
     }
 
     func allClear() async throws(DeleteWasteBasketRepositoryError) {
         allClearCallCount += 1
 
-        guard let result = deleteResult else {
-            fatalError("MockWasteBasketRepository.deleteResult not set")
-        }
-
-        switch result {
+        switch deleteResult {
             case .success:
                 return
             case .failure(let error):
                 throw error
+            case .none:
+                XCTFail("MockWasteBasketRepository.deleteResult를 찾을 수 없습니다")
+                let error = NSError(domain: "MockWasteBasketRepository.deleteResult", code: 0)
+                throw .unknown(error)
         }
     }
 }

--- a/ChaGok/Domain/Tests/WasteBasket/MockWasteBasketRepository.swift
+++ b/ChaGok/Domain/Tests/WasteBasket/MockWasteBasketRepository.swift
@@ -1,0 +1,192 @@
+import Foundation
+import XCTest
+@testable import Domain
+
+actor MockWasteBasketRepository: WasteBasketRepository {
+
+    // Results
+    private var deleteResult: Result<Void, DeleteWasteBasketRepositoryError>?
+    private var moveResult: Result<Void, MoveWasteBasketRepositoryError>?
+    private var fetchAllResult: Result<[WasteBasketItem], FetchWasteBasketRepositoryError>?
+
+    // 호출 검증 Count
+    private(set) var fetchAllCallCount = 0
+    private(set) var moveToWasteBasketCallCount = 0
+    private(set) var moveAllToWasteBasketCallCount = 0
+    private(set) var deleteCallCount = 0
+    private(set) var deleteAllCallCount = 0
+    private(set) var allClearCallCount = 0
+
+    // Expected Call Counts
+    private var expectedFetchAllCallCount: Int?
+    private var expectedMoveToWasteBasketCallCount: Int?
+    private var expectedMoveAllToWasteBasketCallCount: Int?
+    private var expectedDeleteCallCount: Int?
+    private var expectedDeleteAllCallCount: Int?
+    private var expectedAllClearCallCount: Int?
+
+    // 받은 인자 기록 (Verification용)
+    private(set) var lastMovedItem: WasteBasketItem?
+    private(set) var lastMovedItems: [WasteBasketItem]?
+    private(set) var lastDeletedItem: WasteBasketItem?
+    private(set) var lastDeletedItems: [WasteBasketItem]?
+
+    // MARK: - Setup
+
+    func setFetchAllResult(_ result: Result<[WasteBasketItem], FetchWasteBasketRepositoryError>) {
+        self.fetchAllResult = result
+    }
+
+    func setMoveResult(_ result: Result<Void, MoveWasteBasketRepositoryError>) {
+        self.moveResult = result
+    }
+
+    func setDeleteResult(_ result: Result<Void, DeleteWasteBasketRepositoryError>) {
+        self.deleteResult = result
+    }
+
+    // MARK: - Expectations
+
+    func expectFetchAll(callCount: Int) {
+        expectedFetchAllCallCount = callCount
+    }
+
+    func expectMoveToWasteBasket(callCount: Int) {
+        expectedMoveToWasteBasketCallCount = callCount
+    }
+
+    func expectMoveAllToWasteBasket(callCount: Int) {
+        expectedMoveAllToWasteBasketCallCount = callCount
+    }
+
+    func expectDelete(callCount: Int) {
+        expectedDeleteCallCount = callCount
+    }
+
+    func expectDeleteAll(callCount: Int) {
+        expectedDeleteAllCallCount = callCount
+    }
+
+    func expectAllClear(callCount: Int) {
+        expectedAllClearCallCount = callCount
+    }
+
+    // MARK: - Verification
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedFetchAllCallCount {
+            XCTAssertEqual(fetchAllCallCount, expected, "fetchAll call count mismatch", file: file, line: line)
+        }
+        if let expected = expectedMoveToWasteBasketCallCount {
+            XCTAssertEqual(moveToWasteBasketCallCount, expected, "moveToWasteBasket call count mismatch", file: file, line: line)
+        }
+        if let expected = expectedMoveAllToWasteBasketCallCount {
+            XCTAssertEqual(moveAllToWasteBasketCallCount, expected, "moveAllToWasteBasket call count mismatch", file: file, line: line)
+        }
+        if let expected = expectedDeleteCallCount {
+            XCTAssertEqual(deleteCallCount, expected, "delete call count mismatch", file: file, line: line)
+        }
+        if let expected = expectedDeleteAllCallCount {
+            XCTAssertEqual(deleteAllCallCount, expected, "deleteAll call count mismatch", file: file, line: line)
+        }
+        if let expected = expectedAllClearCallCount {
+            XCTAssertEqual(allClearCallCount, expected, "allClear call count mismatch", file: file, line: line)
+        }
+    }
+
+    // MARK: - WasteBasketRepository (Fetch, Move, Delete)
+
+    func fetchAll() async throws(FetchWasteBasketRepositoryError) -> [WasteBasketItem] {
+        fetchAllCallCount += 1
+
+        guard let result = fetchAllResult else {
+            fatalError("MockWasteBasketRepository.fetchAllResult not set")
+        }
+
+        switch result {
+            case .success(let items):
+                return items
+            case .failure(let error):
+                throw error
+        }
+    }
+
+    func moveToWasteBasket(item: WasteBasketItem) async throws(MoveWasteBasketRepositoryError) {
+        moveToWasteBasketCallCount += 1
+        lastMovedItem = item
+
+        guard let result = moveResult else {
+            fatalError("MockWasteBasketRepository.moveResult not set")
+        }
+
+        switch result {
+            case .success:
+                return
+            case .failure(let error):
+                throw error
+        }
+    }
+
+    func moveAllToWasteBasket(items: [WasteBasketItem]) async throws(MoveWasteBasketRepositoryError) {
+        moveAllToWasteBasketCallCount += 1
+        lastMovedItems = items
+
+        guard let result = moveResult else {
+            fatalError("MockWasteBasketRepository.moveResult not set")
+        }
+
+        switch result {
+            case .success:
+                return
+            case .failure(let error):
+                throw error
+        }
+    }
+
+    func delete(item: WasteBasketItem) async throws(DeleteWasteBasketRepositoryError) {
+        deleteCallCount += 1
+        lastDeletedItem = item
+
+        guard let result = deleteResult else {
+            fatalError("MockWasteBasketRepository.deleteResult not set")
+        }
+
+        switch result {
+            case .success:
+                return
+            case .failure(let error):
+                throw error
+        }
+    }
+
+    func deleteAll(items: [WasteBasketItem]) async throws(DeleteWasteBasketRepositoryError) {
+        deleteAllCallCount += 1
+        lastDeletedItems = items
+
+        guard let result = deleteResult else {
+            fatalError("MockWasteBasketRepository.deleteResult not set")
+        }
+
+        switch result {
+            case .success:
+                return
+            case .failure(let error):
+                throw error
+        }
+    }
+
+    func allClear() async throws(DeleteWasteBasketRepositoryError) {
+        allClearCallCount += 1
+
+        guard let result = deleteResult else {
+            fatalError("MockWasteBasketRepository.deleteResult not set")
+        }
+
+        switch result {
+            case .success:
+                return
+            case .failure(let error):
+                throw error
+        }
+    }
+}

--- a/ChaGok/Domain/Tests/WasteBasket/MoveWasteBasketUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WasteBasket/MoveWasteBasketUseCaseTest.swift
@@ -17,7 +17,7 @@ extension MoveWasteBasketUseCaseTest {
         ]
         let repository = MockWasteBasketRepository()
         await repository.setMoveResult(.success(()))
-        await repository.expectMoveAllToWasteBasket(callCount: 1)
+        await repository.expectMoveAllToWasteBasket(items: items, callCount: 1)
 
         let useCase = DefaultMoveWasteBasketUseCase(repository: repository)
 
@@ -25,8 +25,6 @@ extension MoveWasteBasketUseCaseTest {
         _ = try await useCase.execute(method: .multiple(items: items))
 
         // Then
-        let lastMovedItems = await repository.lastMovedItems
-        XCTAssertEqual(lastMovedItems, items)
         await repository.verify()
     }
 
@@ -35,7 +33,7 @@ extension MoveWasteBasketUseCaseTest {
         let item: WasteBasketItem = .folder(id: UUID())
         let repository = MockWasteBasketRepository()
         await repository.setMoveResult(.success(()))
-        await repository.expectMoveToWasteBasket(callCount: 1)
+        await repository.expectMoveToWasteBasket(item: item, callCount: 1)
 
         let useCase = DefaultMoveWasteBasketUseCase(repository: repository)
 
@@ -43,8 +41,6 @@ extension MoveWasteBasketUseCaseTest {
         _ = try await useCase.execute(method: .single(item: item))
 
         // Then
-        let lastMovedItem = await repository.lastMovedItem
-        XCTAssertEqual(lastMovedItem, item)
         await repository.verify()
     }
 }

--- a/ChaGok/Domain/Tests/WasteBasket/MoveWasteBasketUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/WasteBasket/MoveWasteBasketUseCaseTest.swift
@@ -1,0 +1,171 @@
+import XCTest
+@testable import Domain
+
+final class MoveWasteBasketUseCaseTest: XCTestCase {
+    typealias UseCaseError = MoveWasteBasketUseCaseError
+}
+
+// MARK: - Success Cases
+
+extension MoveWasteBasketUseCaseTest {
+
+    func test_휴지통_이동_다중이동_성공_리포지토리를호출한다() async throws {
+        // Given
+        let items: [WasteBasketItem] = [
+            .folder(id: UUID()),
+            .voiceNote(id: UUID())
+        ]
+        let repository = MockWasteBasketRepository()
+        await repository.setMoveResult(.success(()))
+        await repository.expectMoveAllToWasteBasket(callCount: 1)
+
+        let useCase = DefaultMoveWasteBasketUseCase(repository: repository)
+
+        // When
+        _ = try await useCase.execute(method: .multiple(items: items))
+
+        // Then
+        let lastMovedItems = await repository.lastMovedItems
+        XCTAssertEqual(lastMovedItems, items)
+        await repository.verify()
+    }
+
+    func test_휴지통_이동_단일이동_성공_리포지토리를호출한다() async throws {
+        // Given
+        let item: WasteBasketItem = .folder(id: UUID())
+        let repository = MockWasteBasketRepository()
+        await repository.setMoveResult(.success(()))
+        await repository.expectMoveToWasteBasket(callCount: 1)
+
+        let useCase = DefaultMoveWasteBasketUseCase(repository: repository)
+
+        // When
+        _ = try await useCase.execute(method: .single(item: item))
+
+        // Then
+        let lastMovedItem = await repository.lastMovedItem
+        XCTAssertEqual(lastMovedItem, item)
+        await repository.verify()
+    }
+}
+
+// MARK: - Error Mapping Cases
+
+extension MoveWasteBasketUseCaseTest {
+
+    func test_휴지통_이동_리포지토리이동실패시_moveFailed에러를던진다() async {
+        // Given
+        let method = MoveWasteBasketMethod.single(item: .folder(id: UUID()))
+        let repository = MockWasteBasketRepository()
+        await repository.setMoveResult(.failure(.moveFailed(method)))
+        await repository.expectMoveToWasteBasket(callCount: 1)
+
+        let useCase = DefaultMoveWasteBasketUseCase(repository: repository)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(method: method)
+            XCTFail("에러가 발생해야 합니다.")
+        } catch UseCaseError.moveFailed(let failedMethod) {
+            XCTAssertEqual(failedMethod, method)
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .moveFailed, got \(error)")
+        }
+    }
+
+    func test_휴지통_이동_리포지토리다중이동실패시_moveFailed에러를던진다() async {
+        // Given
+        let items: [WasteBasketItem] = [.folder(id: UUID())]
+        let method = MoveWasteBasketMethod.multiple(items: items)
+        let repository = MockWasteBasketRepository()
+        await repository.setMoveResult(.failure(.moveFailed(method)))
+        await repository.expectMoveAllToWasteBasket(callCount: 1)
+
+        let useCase = DefaultMoveWasteBasketUseCase(repository: repository)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(method: method)
+            XCTFail("에러가 발생해야 합니다.")
+        } catch UseCaseError.moveFailed(let failedMethod) {
+            XCTAssertEqual(failedMethod, method)
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .moveFailed, got \(error)")
+        }
+    }
+
+    func test_휴지통_이동_리포지토리알수없는에러시_unknown에러를던진다() async {
+        // Given
+        let item: WasteBasketItem = .folder(id: UUID())
+        struct Dummy: Error {}
+        let dummyError = Dummy()
+        let repository = MockWasteBasketRepository()
+        await repository.setMoveResult(.failure(.unknown(dummyError)))
+        await repository.expectMoveToWasteBasket(callCount: 1)
+
+        let useCase = DefaultMoveWasteBasketUseCase(repository: repository)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(method: .single(item: item))
+            XCTFail("에러가 발생해야 합니다.")
+        } catch UseCaseError.unknown(let error) {
+            XCTAssertTrue(error is Dummy)
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .unknown, got \(error)")
+        }
+    }
+
+    func test_휴지통_이동_리포지토리취소시_cancelled에러를던진다() async {
+        // Given
+        let item: WasteBasketItem = .folder(id: UUID())
+        let repository = MockWasteBasketRepository()
+        await repository.setMoveResult(.failure(.cancelled))
+        await repository.expectMoveToWasteBasket(callCount: 1)
+
+        let useCase = DefaultMoveWasteBasketUseCase(repository: repository)
+
+        // When & Then
+        do {
+            _ = try await useCase.execute(method: .single(item: item))
+            XCTFail("에러가 발생해야 합니다.")
+        } catch UseCaseError.cancelled {
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .cancelled, got \(error)")
+        }
+    }
+}
+
+// MARK: - Cancellation Case
+
+extension MoveWasteBasketUseCaseTest {
+
+    func test_휴지통_이동_작업전_즉시cancelled에러를던진다() async {
+        // Given
+        let item: WasteBasketItem = .folder(id: UUID())
+        let repository = MockWasteBasketRepository()
+        await repository.setMoveResult(.success(()))
+        await repository.expectMoveToWasteBasket(callCount: 0)
+
+        let useCase = DefaultMoveWasteBasketUseCase(repository: repository)
+
+        // When & Then
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            _ = try await useCase.execute(method: .single(item: item))
+        }
+
+        do {
+            _ = try await task.value
+            XCTFail("작업이 취소되어야 합니다.")
+        } catch UseCaseError.cancelled {
+            await repository.verify()
+        } catch {
+            XCTFail("Expected .cancelled error, but got \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 작업 요약
- `MockWasteBasketRepository` 리팩토링 및 휴지통 관련 UseCase(`Fetch`, `Move`, `Delete`) Unit Test 스타일 통일 및 검증 강화

## 📋 구체적인 내용
- **추가/변경된 동작**:
   - **MockWasteBasketRepository**: `WorkSpace` 스타일을 반영하여 `Result` 기반 결과 주입, `expect/verify` 패턴의 호출 횟수 검증, 그리고 매개변수 캡처(`lastMovedItem`, `lastDeletedItem` 등) 로직을 구현하여 데이터 정합성 검증 가능하도록 개선.
   - **FetchWasteBasketFolderUseCaseTest**: 휴지통 조회 성공(항목 존재/빈 목록), 리포지토리 에러(`fetchFailed`, `unknown`, `cancelled`) 매핑 및 즉시 취소 시나리오 검증.
   - **MoveWasteBasketUseCaseTest**: 단일/다중 이동 성공 및 인자 검증, 이동 실패(`moveFailed`) 시 에러 타입 상세 검증(Equatable 활용), 취소 케이스 검증.
   - **DeleteWasteBasketUseCaseTest**: 전체/단일/다중 삭제 성공 및 인자 검증, 삭제 실패(`deleteFailed`) 시 에러 타입 상세 검증, 취소 케이스 검증.
- **영향 받는 화면/모듈**: Domain/Tests/WasteBasket

---

## 🔗 연관 이슈
- open #81 

---

## 🧩 설계·구현 노트

- **선택한 방식 (WorkSpace 스타일 동기화)**
   - **Result 기반 Mocking**: `Result<T, Error>` 타입을 사용해 성공/실패 시나리오를 명확히 주입하고, `switch` 문을 통한 구현으로 Mock 객체의 일관성을 높였습니다.
   - **Expect/Verify 패턴**: 테스트 코드 하단에서 `await repository.verify()`를 호출하여 예상된 호출 횟수와 실제 호출 횟수를 엄격하게 검증합니다.
   - **매개변수 검증 (Argument Capture)**: 단순히 호출 여부만 체크하는 것이 아니라, UseCase가 리포지토리에 전달한 인자(`lastMovedItem` 등)를 캡처하여 의도한 데이터가 정확히 전달되었는지 `XCTAssertEqual`로 검증합니다.
   - **테스트 구조화**: `extension`을 활용한 성공/에러/취소 케이스 그룹화, `// Given/When/Then` 섹션 마커, `// MARK:` 구분을 통해 테스트 가독성을 극대화했습니다.
   - **Await 추출**: `XCTAssertEqual` 등 assertion 내부의 `await` 호출을 외부 변수로 추출하여 테스트 코드의 직관성을 높였습니다.

- **고려했다가 제외한 방식**
   - **구형 Flag 기반 Mock**: 다양한 에러 타입(Typed Throws)과 매개변수 정합성을 한꺼번에 관리하기 위해 `WorkSpace`에서 검증된 `Result` + `expect/verify` 구조를 전면 채택했습니다.

---

## ✅ 확인 사항
- [x] 모든 WasteBasket 관련 테스트 정상 통과 확인
- [x] 에러 매핑 및 즉시 취소(Cancellation) 엣지 케이스 확인
- [x] 리포지토리 전달 인자(Parameter) 검증 완료

---

## 👀 리뷰 포인트

- **Mock 스타일 일관성**: `MockWasteBasketRepository`의 `verify` 메서드 및 에러 메시지 처리가 `WorkSpace`와 동일하게 유지되었는지 확인 부탁드립니다.
- **에러 및 인자 검증**: `Move/Delete` 시 특정 `method`나 `item`이 올바르게 전달되고 에러 시에도 해당 정보가 유지되는지 중점적으로 봐주세요.
- **가독성**: `extension` 기반 그룹화와 한글 네이밍이 복잡한 UseCase 로직을 이해하는 데 도움이 되는지 리뷰 부탁드립니다.

---

## 📚 참고
- `Domain/Tests/WorkSpace` 리팩토링 사례를 기준으로 스타일을 통일함
