### PR TITLE
폴더 생성/수정 시 폴더명 유효성 검증 (invaildName) 리펙토링 및 관련 테스트 코드 보강

### DIFF
--- a/ChaGok/Domain/Sources/UseCases/Folders/CreateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/CreateFolderUseCase.swift
@@ -23,16 +23,18 @@ public struct DefaultCreateFolderUseCase: CreateFolderUseCase {
         typealias UseCaseError = CreateFolderUseCaseError
         if Task.isCancelled { throw UseCaseError.cancelled }
 
-        // 폴더 이름 제한
-        guard name.count <= FolderConstants.maxNameLength else { throw UseCaseError.invalidLengthName }
+        let trimName: String = name.trimmingCharacters(in: .whitespacesAndNewlines)
 
         // invalidName 유효성 검증
-        guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !trimName.isEmpty, trimName == name else {
             throw UseCaseError.invalidName
         }
 
+        // 폴더 이름 제한
+        guard trimName.count <= FolderConstants.maxNameLength else { throw UseCaseError.invalidLengthName }
+
         do {
-            return try await repository.create(name: name)
+            return try await repository.create(name: trimName)
         } catch {
             AppLogger.error(error)
             throw UseCaseError(error)

--- a/ChaGok/Domain/Sources/UseCases/Folders/UpdateFolderUseCase.swift
+++ b/ChaGok/Domain/Sources/UseCases/Folders/UpdateFolderUseCase.swift
@@ -23,16 +23,27 @@ public struct DefaultUpdateFolderUseCase: UpdateFolderUseCase {
         typealias UseCaseError = UpdateFolderUseCaseError
         if Task.isCancelled { throw UseCaseError.cancelled }
 
-        // 폴더 이름 제한
-        guard folder.name.count <= FolderConstants.maxNameLength else { throw UseCaseError.invalidLengthName }
+        let trimName: String = folder.name.trimmingCharacters(in: .whitespacesAndNewlines)
 
         // invalidName 유효성 검증
-        guard !folder.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !trimName.isEmpty, trimName == folder.name else {
             throw UseCaseError.invalidName
         }
 
+        // 폴더 이름 제한
+        guard trimName.count <= FolderConstants.maxNameLength else { throw UseCaseError.invalidLengthName }
+
+        let updateFolder: Folder = .init(
+            id: folder.id,
+            path: folder.path,
+            name: trimName,
+            createdAt: folder.createdAt,
+            content: folder.content,
+            isDeletable: folder.isDeletable,
+            deletedAt: folder.deletedAt
+        )
         do {
-            return try await repository.update(folder)
+            return try await repository.update(updateFolder)
         } catch {
             AppLogger.error(error)
             throw UseCaseError(error)

--- a/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/CreateFolderUseCaseTest.swift
@@ -12,7 +12,7 @@ extension CreateFolderUseCaseTest {
     func test_폴더_생성_성공_생성된폴더를반환한다() async throws {
         // Given
         let expectedName = "New Folder"
-        let expectedFolder = Folder(path: URL(fileURLWithPath: "/test"), name: expectedName)
+        let expectedFolder = Folder.stub(path: URL(fileURLWithPath: "/test"), name: expectedName)
         let repository = MockFolderRepository()
         await repository.setCreateResult(.success(expectedFolder))
         await repository.expectCreate(name: expectedName, callCount: 1)
@@ -33,13 +33,13 @@ extension CreateFolderUseCaseTest {
 
 extension CreateFolderUseCaseTest {
 
-    func test_폴더_생성_이름이비어있을때_invalidName에러를던진다() async {
+    func test_폴더_생성_이름이비어있거나앞뒤공백이있을때_invalidName에러를던진다() async {
         // Given
         let repository = MockFolderRepository()
         await repository.expectCreate(callCount: 0)
 
         let useCase = DefaultCreateFolderUseCase(repository: repository)
-        let invalidNames = ["", " ", "  \n  "]
+        let invalidNames = ["", " ", "  \n  ", " 새폴더", "새 폴더 ", "  새 폴더  "]
 
         // When & Then
         await withTaskGroup(of: Void.self) { group in
@@ -47,7 +47,7 @@ extension CreateFolderUseCaseTest {
                 group.addTask {
                     do {
                         _ = try await useCase.execute(name: name)
-                        XCTFail("이름이 비어있는 경우 .invalidName 에러가 발생해야 합니다. (input: '\(name)')")
+                        XCTFail("유효하지 않은 이름의 경우 .invalidName 에러가 발생해야 합니다. (input: '\(name)')")
                     } catch UseCaseError.invalidName {
                         // Success
                     } catch {
@@ -274,7 +274,7 @@ extension CreateFolderUseCaseTest {
     func test_폴더_생성_작업이미취소시_즉시cancelled에러를던진다() async {
         // Given
         let repository = MockFolderRepository()
-        await repository.setCreateResult(.success(Folder(path: URL.applicationSupportDirectory, name: "test")))
+        await repository.setCreateResult(.success(Folder.stub(path: URL.applicationSupportDirectory, name: "test")))
         await repository.expectCreate(callCount: 0)
 
         let useCase = DefaultCreateFolderUseCase(repository: repository)

--- a/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
@@ -32,7 +32,7 @@ extension UpdateFolderUseCaseTest {
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
 
         // When
-        let result = try await useCase.execute(originalFolder)
+        let result = try await useCase.execute(updatedFolder)
 
         // Then
         XCTAssertEqual(result.name, "New Name")

--- a/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
+++ b/ChaGok/Domain/Tests/Folders/UpdateFolderUseCaseTest.swift
@@ -11,12 +11,18 @@ extension UpdateFolderUseCaseTest {
 
     func test_폴더_수정_성공_업데이트된폴더를반환한다() async throws {
         // Given
-        let originalFolder = Folder(path: URL(fileURLWithPath: "/test"), name: "Old Name")
-        let updatedFolder = Folder(
+        let originalFolder = Folder.stub(
+            name: "Old Name"
+        )
+
+        let updatedFolder = Folder.stub(
             id: originalFolder.id,
             path: originalFolder.path,
             name: "New Name",
-            createdAt: originalFolder.createdAt
+            createdAt: originalFolder.createdAt,
+            content: originalFolder.content,
+            isDeletable: originalFolder.isDeletable,
+            deletedAt: originalFolder.deletedAt
         )
 
         let repository = MockFolderRepository()
@@ -33,6 +39,10 @@ extension UpdateFolderUseCaseTest {
         XCTAssertEqual(result.id, originalFolder.id)
         XCTAssertEqual(result.path, originalFolder.path)
         XCTAssertEqual(result.createdAt, originalFolder.createdAt)
+        XCTAssertEqual(result.isDeletable, originalFolder.isDeletable)
+        XCTAssertEqual(result.deletedAt, originalFolder.deletedAt)
+        XCTAssertEqual(result.content.count, originalFolder.content.count)
+
         await repository.verify()
     }
 }
@@ -63,13 +73,13 @@ extension UpdateFolderUseCaseTest {
         await repository.verify()
     }
 
-    func test_폴더_수정_이름이비어있을때_invalidName에러를던진다() async {
+    func test_폴더_수정_이름이비어있거나앞뒤공백이있을때_invalidName에러를던진다() async {
         // Given
         let repository = MockFolderRepository()
         await repository.expectUpdate(callCount: 0)
 
         let useCase = DefaultUpdateFolderUseCase(repository: repository)
-        let invalidNames = ["", " ", "  \n  "]
+        let invalidNames = ["", " ", "  \n  ", " 새폴더", "새 폴더 ", "  새 폴더  "]
 
         // When & Then
         await withTaskGroup(of: Void.self) { group in
@@ -79,7 +89,7 @@ extension UpdateFolderUseCaseTest {
 
                     do {
                         _ = try await useCase.execute(folder)
-                        XCTFail("이름이 비어있는 경우 .invalidName 에러가 발생해야 합니다. (input: '\(name)')")
+                        XCTFail("유효하지 않은 이름의 경우 .invalidName 에러가 발생해야 합니다. (input: '\(name)')")
                     } catch UseCaseError.invalidName {
                         // Success
                     } catch {

--- a/ChaGok/Domain/Tests/Stubs/Entities/Folder+Stub.swift
+++ b/ChaGok/Domain/Tests/Stubs/Entities/Folder+Stub.swift
@@ -1,0 +1,24 @@
+import Foundation
+@testable import Domain
+
+extension Folder {
+    static func stub(
+        id: UUID = UUID(),
+        path: URL = URL(fileURLWithPath: "/test"),
+        name: String = "Stub Folder",
+        createdAt: Date = Date(),
+        content: [VoiceNote] = [],
+        isDeletable: Bool = true,
+        deletedAt: Date? = nil
+    ) -> Folder {
+        Folder(
+            id: id,
+            path: path,
+            name: name,
+            createdAt: createdAt,
+            content: content,
+            isDeletable: isDeletable,
+            deletedAt: deletedAt
+        )
+    }
+}


### PR DESCRIPTION
## ✨ 작업 요약
> 폴더 생성/수정 시 폴더명 유효성 검증 강화 및 관련 테스트 코드 보강

## 📋 구체적인 내용
- **추가/변경된 동작**: 
  - `CreateFolderUseCase`, `UpdateFolderUseCase`에서 폴더명 양끝에 공백(및 줄바꿈)이 포함된 경우 `.invalidName` 에러를 던지도록 수정 (엄격한 검증 방식 적용).
  - `UpdateFolderUseCase`에서 폴더 정보 업데이트 시 `isDeletable`, `deletedAt`, `content` 등 누락되었던 속성들이 유지되도록 필드 매핑 보완.
  - 테스트 효율성을 위해 `Folder.stub()` 확장 메서드 추가 및 기존 테스트 코드에 적용.
- **영향 받는 화면/모듈**: 
  - `Domain` 모듈 (UseCases, Entities, Tests)

---

## 🔗 연관 이슈

- closed #89 

---

## 🧩 설계·구현 노트

- **선택한 방식**
  - **엄격한 유효성 검사**: 도메인 계층(UseCase)에서 암묵적으로 공백을 잘라주기(Trim)보다, 잘못된 형식의 입력 자체를 에러로 차단(`trimName == originalName`)하여 상위 계층(UI)에서 올바른 값을 보내도록 유도했습니다.
  - **Stub 패턴 적용**: 테스트 데이터 생성을 캡슐화하여 `Folder` 모델 구조 변경 시 테스트 코드의 유지보수 비용을 최소화했습니다.

- **고려했다가 제외한 방식**
  - **자동 Trim 처리**: 사용자의 입력 실수를 관대하게 허용하여 내부적으로 공백을 제거하고 성공시키는 방식도 고려했으나, 데이터의 일관성과 명확한 에러 핸들링을 위해 엄격한 검증 방식을 선택했습니다.

---

## ✅ 확인 사항

- [x] 정상 플로우 동작 확인
- [x] 엣지 케이스 / 빈 값·에러 처리 확인
- [x] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [ ] **유효성 검사 로직**: `trimName == name` 조건을 통해 앞뒤 공백을 에러로 처리하는 정책이 적절한지
- [ ] **Update 로직**: `UpdateFolderUseCase`에서 기존의 메타데이터(`createdAt`, `isDeletable` 등)가 유실되지 않고 잘 복사되는지
- [ ] **테스트 코드**: 추가된 `invalidName` 에러 케이스(앞뒤 공백 사례 포함)들이 충분히 검증되고 있는지

**특히 봐줬으면 하는 부분**
- `UpdateFolderUseCase`에서 `Folder` 엔티티의 모든 프로퍼티를 정확하게 매핑하여 Repository로 전달하고 있는지 확인 부탁드립니다.

---

## 📚 참고
