### PR TITLE
마이크 및 STT 권한 요청 UseCase 를 추가합니다.

### DIFF
--- a/Domain/Sources/Errors/Authority/Repositories/RequestMicrophonePermissionRepositoryError.swift
+++ b/Domain/Sources/Errors/Authority/Repositories/RequestMicrophonePermissionRepositoryError.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// 마이크 권한 요청 리포지토리 에러
+public enum RequestMicrophonePermissionRepositoryError: LocalizedError, Sendable {
+    case cancelled
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .cancelled:
+            return nil
+        case .unknown(let error):
+            return error.localizedDescription
+        }
+    }
+}

--- a/Domain/Sources/Errors/Authority/Repositories/RequestSTTPermissionRepositoryError.swift
+++ b/Domain/Sources/Errors/Authority/Repositories/RequestSTTPermissionRepositoryError.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// STT 권한 요청 리포지토리 에러
+public enum RequestSTTPermissionRepositoryError: LocalizedError, Sendable {
+    case cancelled
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .cancelled:
+            return nil
+        case .unknown(let error):
+            return error.localizedDescription
+        }
+    }
+}

--- a/Domain/Sources/Errors/Authority/UseCases/RequestMicrophonePermissionUseCaseError.swift
+++ b/Domain/Sources/Errors/Authority/UseCases/RequestMicrophonePermissionUseCaseError.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// 마이크 권한 요청 유스케이스 에러
+public enum RequestMicrophonePermissionUseCaseError: LocalizedError, Sendable {
+    case cancelled
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .cancelled:
+            return nil
+        case .unknown(let error):
+            return error.localizedDescription
+        }
+    }
+
+    init(_ error: RequestMicrophonePermissionRepositoryError) {
+        switch error {
+        case .cancelled:
+            self = .cancelled
+        case .unknown(let error):
+            self = .unknown(error)
+        }
+    }
+}

--- a/Domain/Sources/Errors/Authority/UseCases/RequestSTTPermissionUseCaseError.swift
+++ b/Domain/Sources/Errors/Authority/UseCases/RequestSTTPermissionUseCaseError.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// STT 권한 요청 유스케이스 에러
+public enum RequestSTTPermissionUseCaseError: LocalizedError, Sendable {
+    case cancelled
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .cancelled:
+            return nil
+        case .unknown(let error):
+            return error.localizedDescription
+        }
+    }
+
+    init(_ error: RequestSTTPermissionRepositoryError) {
+        switch error {
+        case .cancelled:
+            self = .cancelled
+        case .unknown(let error):
+            self = .unknown(error)
+        }
+    }
+}

--- a/Domain/Sources/Interfaces/Authority/RequestMicrophonePermissionRepository.swift
+++ b/Domain/Sources/Interfaces/Authority/RequestMicrophonePermissionRepository.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// 마이크 권한 요청을 담당하는 리포지토리 프로토콜.
+public protocol RequestMicrophonePermissionRepository: Sendable {
+    /// 마이크 권한을 요청합니다.
+    /// - Returns: 요청 결과 권한 상태. 이미 거부된 경우 `.denied`를 반환합니다.
+    /// - Throws: `RequestMicrophonePermissionRepositoryError`
+    func requestMicrophonePermission() async throws(RequestMicrophonePermissionRepositoryError)
+        -> PermissionStatus
+}

--- a/Domain/Sources/Interfaces/Authority/RequestSTTPermissionRepository.swift
+++ b/Domain/Sources/Interfaces/Authority/RequestSTTPermissionRepository.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// STT 권한 요청을 담당하는 리포지토리 프로토콜.
+public protocol RequestSTTPermissionRepository: Sendable {
+    /// STT 권한을 요청합니다.
+    /// - Returns: 요청 결과 권한 상태. 이미 거부된 경우 `.denied`를 반환합니다.
+    /// - Throws: `RequestSTTPermissionRepositoryError`
+    func requestSTTPermission() async throws(RequestSTTPermissionRepositoryError) -> PermissionStatus
+}

--- a/Domain/Sources/UseCases/Authority/RequestMicrophonePermissionUseCase.swift
+++ b/Domain/Sources/UseCases/Authority/RequestMicrophonePermissionUseCase.swift
@@ -1,0 +1,30 @@
+import Core
+import Foundation
+
+/// 마이크 권한 요청을 위한 유스케이스
+public protocol RequestMicrophonePermissionUseCase: Sendable {
+    /// 마이크 권한을 요청합니다.
+    /// - Returns: 요청 결과 권한 상태. 이미 거부된 경우 `.denied`를 반환합니다.
+    /// - Throws: `RequestMicrophonePermissionUseCaseError`
+    func execute() async throws(RequestMicrophonePermissionUseCaseError) -> PermissionStatus
+}
+
+/// 마이크 권한을 요청합니다.
+public struct DefaultRequestMicrophonePermissionUseCase: RequestMicrophonePermissionUseCase {
+    private let repository: RequestMicrophonePermissionRepository
+
+    public init(repository: RequestMicrophonePermissionRepository) {
+        self.repository = repository
+    }
+
+    public func execute() async throws(RequestMicrophonePermissionUseCaseError) -> PermissionStatus {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            return try await repository.requestMicrophonePermission()
+        } catch {
+            AppLogger.error(error)
+            throw RequestMicrophonePermissionUseCaseError(error)
+        }
+    }
+}

--- a/Domain/Sources/UseCases/Authority/RequestSTTPermissionUseCase.swift
+++ b/Domain/Sources/UseCases/Authority/RequestSTTPermissionUseCase.swift
@@ -1,0 +1,30 @@
+import Core
+import Foundation
+
+/// STT 권한 요청을 위한 유스케이스
+public protocol RequestSTTPermissionUseCase: Sendable {
+    /// STT 권한을 요청합니다.
+    /// - Returns: 요청 결과 권한 상태. 이미 거부된 경우 `.denied`를 반환합니다.
+    /// - Throws: `RequestSTTPermissionUseCaseError`
+    func execute() async throws(RequestSTTPermissionUseCaseError) -> PermissionStatus
+}
+
+/// STT 권한을 요청합니다.
+public struct DefaultRequestSTTPermissionUseCase: RequestSTTPermissionUseCase {
+    private let repository: RequestSTTPermissionRepository
+
+    public init(repository: RequestSTTPermissionRepository) {
+        self.repository = repository
+    }
+
+    public func execute() async throws(RequestSTTPermissionUseCaseError) -> PermissionStatus {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            return try await repository.requestSTTPermission()
+        } catch {
+            AppLogger.error(error)
+            throw RequestSTTPermissionUseCaseError(error)
+        }
+    }
+}

--- a/Domain/Tests/Interfaces/Mocks/Authority/MockRequestMicrophonePermissionRepository.swift
+++ b/Domain/Tests/Interfaces/Mocks/Authority/MockRequestMicrophonePermissionRepository.swift
@@ -1,0 +1,45 @@
+@testable import Domain
+import XCTest
+
+actor MockRequestMicrophonePermissionRepository: RequestMicrophonePermissionRepository {
+    private var result: Result<PermissionStatus, RequestMicrophonePermissionRepositoryError>?
+
+    private var actualRequestMicrophonePermissionCallCount = 0
+    private var expectedRequestMicrophonePermissionCallCount: Int?
+
+    func setResult(_ result: Result<PermissionStatus, RequestMicrophonePermissionRepositoryError>) {
+        self.result = result
+    }
+
+    func expectRequestMicrophonePermission(callCount: Int) {
+        expectedRequestMicrophonePermissionCallCount = callCount
+    }
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedRequestMicrophonePermissionCallCount {
+            XCTAssertEqual(
+                actualRequestMicrophonePermissionCallCount,
+                expected,
+                "마이크 권한 요청 호출 횟수가 일치하지 않습니다.",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func requestMicrophonePermission() async throws(RequestMicrophonePermissionRepositoryError)
+        -> PermissionStatus
+    {
+        actualRequestMicrophonePermissionCallCount += 1
+
+        switch result {
+        case .success(let status):
+            return status
+        case .failure(let error):
+            throw error
+        case .none:
+            XCTFail("MockRequestMicrophonePermissionRepository.result 가 설정되지 않았습니다.")
+            throw .unknown(NSError(domain: "MockRequestMicrophonePermissionRepository.result", code: -1))
+        }
+    }
+}

--- a/Domain/Tests/Interfaces/Mocks/Authority/MockRequestSTTPermissionRepository.swift
+++ b/Domain/Tests/Interfaces/Mocks/Authority/MockRequestSTTPermissionRepository.swift
@@ -1,0 +1,43 @@
+@testable import Domain
+import XCTest
+
+actor MockRequestSTTPermissionRepository: RequestSTTPermissionRepository {
+    private var result: Result<PermissionStatus, RequestSTTPermissionRepositoryError>?
+
+    private var actualRequestSTTPermissionCallCount = 0
+    private var expectedRequestSTTPermissionCallCount: Int?
+
+    func setResult(_ result: Result<PermissionStatus, RequestSTTPermissionRepositoryError>) {
+        self.result = result
+    }
+
+    func expectRequestSTTPermission(callCount: Int) {
+        expectedRequestSTTPermissionCallCount = callCount
+    }
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedRequestSTTPermissionCallCount {
+            XCTAssertEqual(
+                actualRequestSTTPermissionCallCount,
+                expected,
+                "STT 권한 요청 호출 횟수가 일치하지 않습니다.",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func requestSTTPermission() async throws(RequestSTTPermissionRepositoryError) -> PermissionStatus {
+        actualRequestSTTPermissionCallCount += 1
+
+        switch result {
+        case .success(let status):
+            return status
+        case .failure(let error):
+            throw error
+        case .none:
+            XCTFail("MockRequestSTTPermissionRepository.result 가 설정되지 않았습니다.")
+            throw .unknown(NSError(domain: "MockRequestSTTPermissionRepository.result", code: -1))
+        }
+    }
+}

--- a/Domain/Tests/UseCases/Authority/RequestMicrophonePermissionUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Authority/RequestMicrophonePermissionUseCaseTest.swift
@@ -1,0 +1,110 @@
+@testable import Domain
+import Core
+import XCTest
+
+final class RequestMicrophonePermissionUseCaseTest: XCTestCase {
+    private var authorityRepository: MockRequestMicrophonePermissionRepository!
+    private var sut: DefaultRequestMicrophonePermissionUseCase!
+
+    override func setUp() {
+        super.setUp()
+        authorityRepository = MockRequestMicrophonePermissionRepository()
+        sut = DefaultRequestMicrophonePermissionUseCase(repository: authorityRepository)
+    }
+
+    override func tearDown() {
+        authorityRepository = nil
+        sut = nil
+        super.tearDown()
+    }
+}
+
+// MARK: - 성공 케이스
+
+extension RequestMicrophonePermissionUseCaseTest {
+    func test_마이크권한미결정상태_권한요청시_authorized를반환한다() async throws {
+        // Given
+        await authorityRepository.setResult(.success(.authorized))
+        await authorityRepository.expectRequestMicrophonePermission(callCount: 1)
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(result, .authorized)
+        await authorityRepository.verify()
+    }
+
+    func test_마이크권한이미거부상태_권한요청시_denied를반환한다() async throws {
+        // Given
+        await authorityRepository.setResult(.success(.denied))
+        await authorityRepository.expectRequestMicrophonePermission(callCount: 1)
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(result, .denied)
+        await authorityRepository.verify()
+    }
+}
+
+// MARK: - 에러 케이스
+
+extension RequestMicrophonePermissionUseCaseTest {
+    func test_리포지토리에러발생상태_권한요청시_unknown에러를던진다() async {
+        // Given
+        struct DummyError: Error {}
+        let expectedError = DummyError()
+        await authorityRepository.setResult(.failure(.unknown(expectedError)))
+        await authorityRepository.expectRequestMicrophonePermission(callCount: 1)
+
+        // When & Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("RequestMicrophonePermissionUseCaseError.unknown 에러를 throw 해야 합니다.")
+        } catch {
+            guard
+                case .unknown(let underlyingError) = error
+            else {
+                return XCTFail(
+                    "예상한 에러는 RequestMicrophonePermissionUseCaseError.unknown 이지만, 실제 받은 에러는 \(error) 입니다."
+                )
+            }
+            XCTAssertTrue(underlyingError is DummyError)
+        }
+
+        await authorityRepository.verify()
+    }
+}
+
+// MARK: - 취소 케이스
+
+extension RequestMicrophonePermissionUseCaseTest {
+    func test_태스크취소상태_권한요청시_cancelled에러를던진다() async throws {
+        guard let sut else {
+            return XCTFail("sut가 초기화되지 않았습니다.")
+        }
+        // Given
+        await authorityRepository.expectRequestMicrophonePermission(callCount: 0)
+
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await sut.execute()
+        }
+
+        // When & Then
+        do {
+            _ = try await task.value
+            XCTFail("RequestMicrophonePermissionUseCaseError.cancelled 에러를 throw 해야 합니다.")
+        } catch {
+            guard case .cancelled = error as? RequestMicrophonePermissionUseCaseError else {
+                return XCTFail(
+                    "예상한 에러는 RequestMicrophonePermissionUseCaseError.cancelled 이지만, 실제 받은 에러는 \(error) 입니다."
+                )
+            }
+        }
+
+        await authorityRepository.verify()
+    }
+}

--- a/Domain/Tests/UseCases/Authority/RequestSTTPermissionUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Authority/RequestSTTPermissionUseCaseTest.swift
@@ -1,0 +1,110 @@
+@testable import Domain
+import Core
+import XCTest
+
+final class RequestSTTPermissionUseCaseTest: XCTestCase {
+    private var authorityRepository: MockRequestSTTPermissionRepository!
+    private var sut: DefaultRequestSTTPermissionUseCase!
+
+    override func setUp() {
+        super.setUp()
+        authorityRepository = MockRequestSTTPermissionRepository()
+        sut = DefaultRequestSTTPermissionUseCase(repository: authorityRepository)
+    }
+
+    override func tearDown() {
+        authorityRepository = nil
+        sut = nil
+        super.tearDown()
+    }
+}
+
+// MARK: - 성공 케이스
+
+extension RequestSTTPermissionUseCaseTest {
+    func test_STT권한미결정상태_권한요청시_authorized를반환한다() async throws {
+        // Given
+        await authorityRepository.setResult(.success(.authorized))
+        await authorityRepository.expectRequestSTTPermission(callCount: 1)
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(result, .authorized)
+        await authorityRepository.verify()
+    }
+
+    func test_STT권한이미거부상태_권한요청시_denied를반환한다() async throws {
+        // Given
+        await authorityRepository.setResult(.success(.denied))
+        await authorityRepository.expectRequestSTTPermission(callCount: 1)
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(result, .denied)
+        await authorityRepository.verify()
+    }
+}
+
+// MARK: - 에러 케이스
+
+extension RequestSTTPermissionUseCaseTest {
+    func test_리포지토리에러발생상태_권한요청시_unknown에러를던진다() async {
+        // Given
+        struct DummyError: Error {}
+        let expectedError = DummyError()
+        await authorityRepository.setResult(.failure(.unknown(expectedError)))
+        await authorityRepository.expectRequestSTTPermission(callCount: 1)
+
+        // When & Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("RequestSTTPermissionUseCaseError.unknown 에러를 throw 해야 합니다.")
+        } catch {
+            guard
+                case .unknown(let underlyingError) = error
+            else {
+                return XCTFail(
+                    "예상한 에러는 RequestSTTPermissionUseCaseError.unknown 이지만, 실제 받은 에러는 \(error) 입니다."
+                )
+            }
+            XCTAssertTrue(underlyingError is DummyError)
+        }
+
+        await authorityRepository.verify()
+    }
+}
+
+// MARK: - 취소 케이스
+
+extension RequestSTTPermissionUseCaseTest {
+    func test_태스크취소상태_권한요청시_cancelled에러를던진다() async throws {
+        guard let sut else {
+            return XCTFail("sut가 초기화되지 않았습니다.")
+        }
+        // Given
+        await authorityRepository.expectRequestSTTPermission(callCount: 0)
+
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await sut.execute()
+        }
+
+        // When & Then
+        do {
+            _ = try await task.value
+            XCTFail("RequestSTTPermissionUseCaseError.cancelled 에러를 throw 해야 합니다.")
+        } catch {
+            guard case .cancelled = error as? RequestSTTPermissionUseCaseError else {
+                return XCTFail(
+                    "예상한 에러는 RequestSTTPermissionUseCaseError.cancelled 이지만, 실제 받은 에러는 \(error) 입니다."
+                )
+            }
+        }
+
+        await authorityRepository.verify()
+    }
+}


### PR DESCRIPTION
## ✨ 작업 요약
> 한 줄로 무엇을 추가/변경했는지

- 권한 요청(Request) UseCase 및 관련 타입을 Domain 레이어에 추가합니다.

## 📋 구체적인 내용
- 추가/변경된 동작:
  - `RequestMicrophonePermissionUseCase` / `RequestSTTPermissionUseCase` 프로토콜 및 Default 구현체 추가
  - 각 Repository 인터페이스 (`RequestMicrophonePermissionRepository`, `RequestSTTPermissionRepository`) 추가
  - Repository / UseCase 에러 타입 추가 (`cancelled`, `unknown`)
  - Mock Repository 및 UseCase 테스트 추가 (성공 2 / 에러 1 / 취소 1 케이스)
- 영향 받는 화면/모듈: `Domain` 모듈 (Data, Presentation 미포함)

---

## 🔗 연관 이슈

- closed #94

---

## 🧩 설계·구현 노트

- **선택한 방식**
  - CQS 원칙에 따라 Check(조회)와 Request(변경)를 별도 UseCase / Repository로 분리
  - `denied` 상태는 에러가 아닌 정상 반환값으로 처리 — iOS API 동작과 일치, Presentation에서 do-catch 불필요
  - `throws` 유지 — 실제로 발생 가능성은 낮으나, Data 레이어 미래 에러 대응 및 기존 패턴 일관성 확보

- **고려했다가 제외한 방식**
  - 기존 Check UseCase에 Request 로직 합치기 → 부수효과 혼재로 CQS 위반, 테스트 예측 불가

---

## ✅ 확인 사항

- [ ] 정상 플로우 동작 확인
- [ ] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [x] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- `async throws` 시그니처의 적절성 — iOS 권한 API는 throw하지 않으므로 `throws` 제거 여부

---

## 📚 참고

-