### PR TITLE
DefaultLanguageRepository 구현 및 단위 테스트 진행 합니다.

### DIFF
--- a/Data/Sources/Infrastructure/Language/LanguageSettingService.swift
+++ b/Data/Sources/Infrastructure/Language/LanguageSettingService.swift
@@ -1,0 +1,20 @@
+import Domain
+import Foundation
+
+public struct LanguageSettingService: LanguageService {
+    public init() {}
+
+    public func fetchLanguage() throws(LanguageServiceError) -> String {
+        // UserDefaults에서 저장된 언어 코드를 조회합니다.
+        guard let fetchResult = UserDefaults.standard.string(forKey: Policy.appSelectedLanguageKey)
+        else {
+            throw .notFound
+        }
+        return fetchResult
+    }
+
+    public func saveLanguage(_ language: String) {
+        // UserDefaults에 언어 코드를 저장합니다.
+        UserDefaults.standard.set(language, forKey: Policy.appSelectedLanguageKey)
+    }
+}

--- a/Data/Sources/Interfaces/Language/LanguageService.swift
+++ b/Data/Sources/Interfaces/Language/LanguageService.swift
@@ -1,0 +1,12 @@
+import Domain
+
+public protocol LanguageService: Sendable {
+    /// 저장된 앱 언어 설정 데이터를 조회합니다.
+    /// - Returns: 식별된 언어 정보가 담긴 데이터 (예: "ko", "en").
+    /// - Throws: 데이터가 없는 경우 .notFound 에러를 발생시킵니다.
+    func fetchLanguage() throws(LanguageSettingServiceError) -> String
+
+    /// 앱 언어 설정 데이터를 저장합니다.
+    /// - Parameter language: 저장하고자 하는 언어 식별 데이터
+    func saveLanguage(_ language: String)
+}

--- a/Data/Sources/Interfaces/Language/LanguageService.swift
+++ b/Data/Sources/Interfaces/Language/LanguageService.swift
@@ -4,7 +4,7 @@ public protocol LanguageService: Sendable {
     /// 저장된 앱 언어 설정 데이터를 조회합니다.
     /// - Returns: 식별된 언어 정보가 담긴 데이터 (예: "ko", "en").
     /// - Throws: 데이터가 없는 경우 .notFound 에러를 발생시킵니다.
-    func fetchLanguage() throws(LanguageSettingServiceError) -> String
+    func fetchLanguage() throws(LanguageServiceError) -> String
 
     /// 앱 언어 설정 데이터를 저장합니다.
     /// - Parameter language: 저장하고자 하는 언어 식별 데이터

--- a/Data/Sources/Interfaces/Language/LanguageServiceError.swift
+++ b/Data/Sources/Interfaces/Language/LanguageServiceError.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum LanguageServiceError: Error, Sendable {
+    case notFound
+}

--- a/Data/Sources/Repositories/Languages/DefaultLanguageRepository.swift
+++ b/Data/Sources/Repositories/Languages/DefaultLanguageRepository.swift
@@ -15,7 +15,7 @@ public struct DefaultLanguageRepository: LanguageRepository {
             return Language(rawValue: rawLanguage) ?? .ko
         } catch let error as FetchLanguagesRepositoryError {
             throw error
-        } catch is LanguageSettingServiceError {
+        } catch is LanguageServiceError {
             return .ko
         } catch {
             throw .unknown(error)

--- a/Data/Sources/Repositories/Languages/DefaultLanguageRepository.swift
+++ b/Data/Sources/Repositories/Languages/DefaultLanguageRepository.swift
@@ -1,0 +1,30 @@
+import Domain
+import Foundation
+
+public struct DefaultLanguageRepository: LanguageRepository {
+    private let service: any LanguageService
+
+    public init(service: any LanguageService) {
+        self.service = service
+    }
+
+    public func fetchLanguage() async throws(FetchLanguagesRepositoryError) -> Language {
+        do {
+            if Task.isCancelled { throw FetchLanguagesRepositoryError.cancelled }
+            let rawLanguage = try service.fetchLanguage()
+            return Language(rawValue: rawLanguage) ?? .ko
+        } catch let error as FetchLanguagesRepositoryError {
+            throw error
+        } catch is LanguageSettingServiceError {
+            return .ko
+        } catch {
+            throw .unknown(error)
+        }
+    }
+
+    public func saveLanguage(_ language: Language) async throws(SetLanguagesRepositoryError) {
+        // 1. Task 취소 여부만 체크 (필요 시)
+        if Task.isCancelled { throw .cancelled }
+        service.saveLanguage(language.rawValue)
+    }
+}

--- a/Data/Sources/Repositories/Languages/DefaultLanguageRepository.swift
+++ b/Data/Sources/Repositories/Languages/DefaultLanguageRepository.swift
@@ -2,29 +2,23 @@ import Domain
 import Foundation
 
 public struct DefaultLanguageRepository: LanguageRepository {
-    private let service: any LanguageService
+  private let service: any LanguageService
 
-    public init(service: any LanguageService) {
-        self.service = service
-    }
+  public init(service: any LanguageService) {
+    self.service = service
+  }
 
-    public func fetchLanguage() async throws(FetchLanguagesRepositoryError) -> Language {
-        do {
-            if Task.isCancelled { throw FetchLanguagesRepositoryError.cancelled }
-            let rawLanguage = try service.fetchLanguage()
-            return Language(rawValue: rawLanguage) ?? .ko
-        } catch let error as FetchLanguagesRepositoryError {
-            throw error
-        } catch is LanguageServiceError {
-            return .ko
-        } catch {
-            throw .unknown(error)
-        }
-    }
+  public func fetchLanguage() async throws(FetchLanguagesRepositoryError) -> Language {
+    if Task.isCancelled { throw FetchLanguagesRepositoryError.cancelled }
 
-    public func saveLanguage(_ language: Language) async throws(SetLanguagesRepositoryError) {
-        // 1. Task 취소 여부만 체크 (필요 시)
-        if Task.isCancelled { throw .cancelled }
-        service.saveLanguage(language.rawValue)
+    guard let rawLanguage = try? service.fetchLanguage() else {
+      return .ko
     }
+    return Language(rawValue: rawLanguage) ?? .ko
+  }
+
+  public func saveLanguage(_ language: Language) async throws(SetLanguagesRepositoryError) {
+    if Task.isCancelled { throw .cancelled }
+    service.saveLanguage(language.rawValue)
+  }
 }

--- a/Data/Sources/Repositories/Languages/DefaultLanguageRepository.swift
+++ b/Data/Sources/Repositories/Languages/DefaultLanguageRepository.swift
@@ -2,23 +2,23 @@ import Domain
 import Foundation
 
 public struct DefaultLanguageRepository: LanguageRepository {
-  private let service: any LanguageService
+    private let service: any LanguageService
 
-  public init(service: any LanguageService) {
-    self.service = service
-  }
-
-  public func fetchLanguage() async throws(FetchLanguagesRepositoryError) -> Language {
-    if Task.isCancelled { throw FetchLanguagesRepositoryError.cancelled }
-
-    guard let rawLanguage = try? service.fetchLanguage() else {
-      return .ko
+    public init(service: any LanguageService) {
+        self.service = service
     }
-    return Language(rawValue: rawLanguage) ?? .ko
-  }
 
-  public func saveLanguage(_ language: Language) async throws(SetLanguagesRepositoryError) {
-    if Task.isCancelled { throw .cancelled }
-    service.saveLanguage(language.rawValue)
-  }
+    public func fetchLanguage() async throws(FetchLanguagesRepositoryError) -> Language {
+        if Task.isCancelled { throw FetchLanguagesRepositoryError.cancelled }
+
+        guard let rawLanguage = try? service.fetchLanguage() else {
+            return .ko
+        }
+        return Language(rawValue: rawLanguage) ?? .ko
+    }
+
+    public func saveLanguage(_ language: Language) async throws(SetLanguagesRepositoryError) {
+        if Task.isCancelled { throw .cancelled }
+        service.saveLanguage(language.rawValue)
+    }
 }

--- a/Data/Tests/Interfaces/Language/MockLanguageService.swift
+++ b/Data/Tests/Interfaces/Language/MockLanguageService.swift
@@ -1,0 +1,78 @@
+@testable import Data
+import Domain
+import XCTest
+
+final class MockLanguageService: LanguageService, @unchecked Sendable {
+    private var fetchResult: Result<String, LanguageServiceError>?
+
+    private var actualFetchCallCount = 0
+    private var actualSaveCallCount = 0
+    private var actualSavedLanguage: String?
+
+    private var expectedFetchCallCount: Int?
+    private var expectedSaveCallCount: Int?
+    private var expectedSavedLanguage: String?
+
+    func setFetchResult(_ result: Result<String, LanguageServiceError>) {
+        fetchResult = result
+    }
+
+    func expectFetch(callCount: Int) {
+        expectedFetchCallCount = callCount
+    }
+
+    func expectSave(language: String? = nil, callCount: Int) {
+        expectedSavedLanguage = language
+        expectedSaveCallCount = callCount
+    }
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedFetchCallCount {
+            XCTAssertEqual(
+                actualFetchCallCount,
+                expected,
+                "fetchLanguage 호출 횟수가 일치하지 않습니다.",
+                file: file,
+                line: line
+            )
+        }
+        if let expected = expectedSaveCallCount {
+            XCTAssertEqual(
+                actualSaveCallCount,
+                expected,
+                "saveLanguage 호출 횟수가 일치하지 않습니다.",
+                file: file,
+                line: line
+            )
+        }
+        if let expected = expectedSavedLanguage {
+            XCTAssertEqual(
+                actualSavedLanguage,
+                expected,
+                "saveLanguage에 전달된 언어가 일치하지 않습니다.",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func fetchLanguage() throws(LanguageServiceError) -> String {
+        actualFetchCallCount += 1
+        guard let result = fetchResult else {
+            XCTFail("fetchResult이 설정되지 않았습니다. setFetchResult()를 먼저 호출하세요.")
+            throw .notFound
+        }
+
+        switch result {
+        case .success(let language):
+            return language
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func saveLanguage(_ language: String) {
+        actualSaveCallCount += 1
+        actualSavedLanguage = language
+    }
+}

--- a/Data/Tests/Repositories/Languages/DefaultLanguageRepositoryTest.swift
+++ b/Data/Tests/Repositories/Languages/DefaultLanguageRepositoryTest.swift
@@ -1,0 +1,113 @@
+@testable import Data
+import Domain
+import XCTest
+
+final class DefaultLanguageRepositoryTest: XCTestCase {}
+
+// MARK: - 조회 성공 케이스
+
+extension DefaultLanguageRepositoryTest {
+    func test_기존언어데이터가있는상태_언어조회시_저장된언어를반환한다() async throws {
+        let service = MockLanguageService()
+        let sut = DefaultLanguageRepository(service: service)
+
+        // Given
+        service.setFetchResult(.success("ko"))
+        service.expectFetch(callCount: 1)
+
+        // When
+        let language = try await sut.fetchLanguage()
+
+        // Then
+        XCTAssertEqual(language, .ko)
+        service.verify()
+    }
+
+    func test_저장된언어데이터가없는상태_언어조회시_기본값인한국어를반환한다() async throws {
+        let service = MockLanguageService()
+        let sut = DefaultLanguageRepository(service: service)
+
+        // Given
+        service.setFetchResult(.failure(.notFound))
+        service.expectFetch(callCount: 1)
+
+        // When
+        let language = try await sut.fetchLanguage()
+
+        // Then
+        XCTAssertEqual(language, .ko)
+        service.verify()
+    }
+}
+
+// MARK: - 저장 성공 케이스
+
+extension DefaultLanguageRepositoryTest {
+    func test_새로운언어가주어진상태_언어저장시_서비스에올바른언어를전달한다() async throws {
+        let service = MockLanguageService()
+        let sut = DefaultLanguageRepository(service: service)
+
+        // Given
+        service.expectSave(language: "en", callCount: 1)
+
+        // When
+        try await sut.saveLanguage(.en)
+
+        // Then
+        service.verify()
+    }
+}
+
+// MARK: - 취소 케이스
+
+extension DefaultLanguageRepositoryTest {
+    func test_태스크가취소된상태_언어조회시_cancelled에러를발생시킨다() async throws {
+        let service = MockLanguageService()
+        let sut = DefaultLanguageRepository(service: service)
+
+        // Given
+        service.expectFetch(callCount: 0)
+
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await sut.fetchLanguage()
+        }
+
+        // When & Then
+        do {
+            _ = try await task.value
+            XCTFail("FetchLanguagesRepositoryError.cancelled 에러를 throw 해야 합니다.")
+        } catch {
+            guard case .cancelled = error as? FetchLanguagesRepositoryError else {
+                return XCTFail("예상한 에러는 FetchLanguagesRepositoryError.cancelled 이지만, 실제 받은 에러는 \(error) 입니다.")
+            }
+        }
+
+        service.verify()
+    }
+
+    func test_태스크가취소된상태_언어저장시_cancelled에러를발생시킨다() async throws {
+        let service = MockLanguageService()
+        let sut = DefaultLanguageRepository(service: service)
+
+        // Given
+        service.expectSave(callCount: 0)
+
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            try await sut.saveLanguage(.ko)
+        }
+
+        // When & Then
+        do {
+            _ = try await task.value
+            XCTFail("SetLanguagesRepositoryError.cancelled 에러를 throw 해야 합니다.")
+        } catch {
+            guard case .cancelled = error as? SetLanguagesRepositoryError else {
+                return XCTFail("예상한 에러는 SetLanguagesRepositoryError.cancelled 이지만, 실제 받은 에러는 \(error) 입니다.")
+            }
+        }
+
+        service.verify()
+    }
+}

--- a/Domain/Sources/Entities/Language.swift
+++ b/Domain/Sources/Entities/Language.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Language: Sendable {
+public enum Language: String, Sendable {
     case ko
     case en
 }

--- a/Domain/Sources/Policy.swift
+++ b/Domain/Sources/Policy.swift
@@ -10,4 +10,7 @@ public enum Policy {
 
     /// Waveform 당 amplitude 샘플 수 (파형 막대 개수)
     public static let waveformSamplesPerBuffer: Int = 20
+
+    /// 앱 언어 설정을 저장하기 위한 UserDefaults 키
+    public static let appSelectedLanguageKey: String = "app_selected_language"
 }


### PR DESCRIPTION
---

## ✨ 작업 요약
> 언어 설정 관리 인프라 개선 및 레포지토리 계층 코드 리팩토링

- 언어 관련 서비스 인터페이스 명확화, 에러 타입 재배치, 레포지토리 매핑 로직 간소화 및 테스트 코드 BDD 스타일 리팩토링을 수행했습니다.

## 📋 구체적인 내용
- 추가/변경된 동작:
  - `LanguageService` 프로토콜의 내부 함수를 Sync 함수로 정의
  - `DefaultLanguageRepository` 내 언어 매핑 로직을 Enum의 `rawValue` 생성자를 활용하도록 개선하여 하드코팅을 제거했습니다.
  - 유닛 테스트 메서드 명명을 BDD 스타일(`test_[상태][행동][결과]`)로 변경하여 테스트 시나리오 가독성을 강화했습니다.
  - 인프라 종속적인 명칭인 `LanguageSettingServiceError`를 `LanguageServiceError`로 개칭하고 상위 레이어(`Interfaces`)로 재배치하여 의존성 구조를 개선했습니다.
- 영향 받는 화면/모듈:
  - `Data` 모듈의 언어 관련 인프라 및 레포지토리 레이어
  - 관련 유닛 테스트 (`DefaultLanguageRepositoryTest`)

---

## 🔗 연관 이슈

- closed #52 

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
  - **BDD 스타일 테스트 명명**: 테스트 코드 자체가 명세서 역할을 수행할 수 있도록 `test_[상태][행동][결과]` 규칙을 적용하여 가시성을 높였습니다.
  - **에러 타입 재배치**: 명칭에서 인프라 구체성(`SettingService`)을 제거하고 인터페이스 계층에 둠으로써 결합도를 낮췄습니다.
  - **Enum RawValue 활용**: 문자열 기반의 `switch-case` 분기 대신 형식 안전성이 보장되는 자동 매핑 방식을 선택했습니다.
- **고려했다가 제외한 방식**
  - **Optional(`nil`) 반환 방식**: `fetchLanguage()`에서 데이터 부재 시 `nil`을 반환하는 대신, 명확한 에러 타입(`.notFound`)을 던짐으로써 상위 계층에서 명확하게 에러 상황을 인지하고 정책(기본값 반환 등)을 결정할 수 있도록 유지했습니다.

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [x] 정상 플로우 동작 확인
- [x] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부 (N/A)
- [x] (로직 추가 시) 테스트 추가 여부 (기존 테스트 리팩토링 및 검증 완료)

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [x] 로직·엣지 케이스
- [x] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [x] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- BDD 스타일로 변경된 테스트 메서드 명칭이 작업 의도를 충분히 전달하고 있는지 검토 부탁드립니다.
- `DefaultLanguageRepository`에서 `LanguageServiceError` 발생 시 한국어(`.ko`)를 기본값으로 반환하는 정책적 판단이 적절한지 확인 부탁드립니다.

---

## 📚 참고