### PR TITLE
테스트 함수의 sut 초기화 방식을 변경합니다.

### DIFF
--- a/Core/Tests/Logger/AppLoggerProtocolTests.swift
+++ b/Core/Tests/Logger/AppLoggerProtocolTests.swift
@@ -2,17 +2,14 @@
 import Foundation
 import XCTest
 
-final class AppLoggerProtocolTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        MockLogger.reset()
-    }
-}
+final class AppLoggerProtocolTests: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension AppLoggerProtocolTests {
     func test_debug메서드_로그호출시_debug레벨로정확히기록된다() {
+        MockLogger.reset()
+
         // Given
         let message = "테스트 메시지"
 
@@ -26,6 +23,8 @@ extension AppLoggerProtocolTests {
     }
 
     func test_info메서드_로그호출시_info레벨로정확히기록된다() {
+        MockLogger.reset()
+
         // Given
         let message = "정보 메시지"
 
@@ -39,6 +38,8 @@ extension AppLoggerProtocolTests {
     }
 
     func test_warning메서드_로그호출시_warning레벨로정확히기록된다() {
+        MockLogger.reset()
+
         // Given
         let message = "경고 메시지"
 
@@ -52,6 +53,8 @@ extension AppLoggerProtocolTests {
     }
 
     func test_errorString메서드_로그호출시_error레벨로정확히기록된다() {
+        MockLogger.reset()
+
         // Given
         let message = "에러 메시지"
 
@@ -65,6 +68,8 @@ extension AppLoggerProtocolTests {
     }
 
     func test_errorError객체_로그호출시_Error의문자열설명이정확히기록된다() {
+        MockLogger.reset()
+
         // Given
         struct TestError: Error {}
         let error = TestError()
@@ -79,6 +84,8 @@ extension AppLoggerProtocolTests {
     }
 
     func test_여러로그_연속호출시_호출한순서대로정확히기록된다() {
+        MockLogger.reset()
+
         // Given
         let messages = ["1", "2", "3", "4"]
         let levels: [LogLevel] = [.debug, .info, .warning, .error]
@@ -98,6 +105,8 @@ extension AppLoggerProtocolTests {
     }
 
     func test_빈메시지_로그호출시_정상적으로기록된다() {
+        MockLogger.reset()
+
         // Given
         let emptyMessage = ""
 
@@ -110,6 +119,8 @@ extension AppLoggerProtocolTests {
     }
 
     func test_특수문자포함메시지_로그호출시_정상적으로기록된다() {
+        MockLogger.reset()
+
         // Given
         let specialMessage = "이모지 🔥 유니코드 日本語 \n 줄바꿈"
 
@@ -122,6 +133,8 @@ extension AppLoggerProtocolTests {
     }
 
     func test_LocalizedError미준수객체_로그호출시_기본문자열설명으로기록된다() {
+        MockLogger.reset()
+
         // Given
         struct CustomError: Error {
             let code: Int

--- a/Domain/Tests/UseCases/Authority/CheckFirstLaunchUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Authority/CheckFirstLaunchUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class CheckFirstLaunchUseCaseTest: XCTestCase {
-    private var authorityRepository: MockCheckFirstLaunchRepository!
-    private var sut: DefaultCheckFirstLaunchUseCase!
-
-    override func setUp() {
-        super.setUp()
-        authorityRepository = MockCheckFirstLaunchRepository()
-        sut = DefaultCheckFirstLaunchUseCase(repository: authorityRepository)
-    }
-
-    override func tearDown() {
-        authorityRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class CheckFirstLaunchUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension CheckFirstLaunchUseCaseTest {
     func test_첫실행상태_앱실행여부확인시_True를반환하고첫실행으로마크한다() {
+        let authorityRepository = MockCheckFirstLaunchRepository()
+        let sut = DefaultCheckFirstLaunchUseCase(repository: authorityRepository)
+
         // Given
         authorityRepository.setReturnValue(true)
         authorityRepository.expectCheckAndMarkFirstLaunch(callCount: 1)
@@ -36,6 +24,9 @@ extension CheckFirstLaunchUseCaseTest {
     }
 
     func test_기존사용자상태_앱실행여부확인시_False를반환하고첫실행으로마크하지않는다() {
+        let authorityRepository = MockCheckFirstLaunchRepository()
+        let sut = DefaultCheckFirstLaunchUseCase(repository: authorityRepository)
+
         // Given
         authorityRepository.setReturnValue(false)
         authorityRepository.expectCheckAndMarkFirstLaunch(callCount: 1)

--- a/Domain/Tests/UseCases/Authority/CheckMicrophonePermissionUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Authority/CheckMicrophonePermissionUseCaseTest.swift
@@ -87,7 +87,7 @@ extension CheckMicrophonePermissionUseCaseTest {
         await authorityRepository.verify()
     }
 
-    func test_태스크취소상태_권한조회시_cancelled에러를던진다() async throws {
+    func test_태스크취소상태_권한조회시_cancelled에러를던진다() async {
         let authorityRepository = MockMicrophonePermissionRepository()
         let sut = DefaultCheckMicrophonePermissionUseCase(repository: authorityRepository)
 

--- a/Domain/Tests/UseCases/Authority/CheckMicrophonePermissionUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Authority/CheckMicrophonePermissionUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class CheckMicrophonePermissionUseCaseTest: XCTestCase {
-    private var authorityRepository: MockMicrophonePermissionRepository!
-    private var sut: DefaultCheckMicrophonePermissionUseCase!
-
-    override func setUp() {
-        super.setUp()
-        authorityRepository = MockMicrophonePermissionRepository()
-        sut = DefaultCheckMicrophonePermissionUseCase(repository: authorityRepository)
-    }
-
-    override func tearDown() {
-        authorityRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class CheckMicrophonePermissionUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension CheckMicrophonePermissionUseCaseTest {
     func test_마이크권한허용상태_권한조회시_authorized를반환한다() async throws {
+        let authorityRepository = MockMicrophonePermissionRepository()
+        let sut = DefaultCheckMicrophonePermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.setCheckResult(.success(.authorized))
         await authorityRepository.expectCheckMicrophonePermission(callCount: 1)
@@ -36,6 +24,9 @@ extension CheckMicrophonePermissionUseCaseTest {
     }
 
     func test_마이크권한거부상태_권한조회시_denied를반환한다() async throws {
+        let authorityRepository = MockMicrophonePermissionRepository()
+        let sut = DefaultCheckMicrophonePermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.setCheckResult(.success(.denied))
         await authorityRepository.expectCheckMicrophonePermission(callCount: 1)
@@ -49,6 +40,9 @@ extension CheckMicrophonePermissionUseCaseTest {
     }
 
     func test_마이크권한미결정상태_권한조회시_notDetermined를반환한다() async throws {
+        let authorityRepository = MockMicrophonePermissionRepository()
+        let sut = DefaultCheckMicrophonePermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.setCheckResult(.success(.notDetermined))
         await authorityRepository.expectCheckMicrophonePermission(callCount: 1)
@@ -66,6 +60,9 @@ extension CheckMicrophonePermissionUseCaseTest {
 
 extension CheckMicrophonePermissionUseCaseTest {
     func test_리포지토리에러발생상태_권한조회시_unknown에러를던진다() async {
+        let authorityRepository = MockMicrophonePermissionRepository()
+        let sut = DefaultCheckMicrophonePermissionUseCase(repository: authorityRepository)
+
         // Given
         struct DummyError: Error {}
         let expectedError = DummyError()
@@ -91,9 +88,9 @@ extension CheckMicrophonePermissionUseCaseTest {
     }
 
     func test_태스크취소상태_권한조회시_cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let authorityRepository = MockMicrophonePermissionRepository()
+        let sut = DefaultCheckMicrophonePermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.expectCheckMicrophonePermission(callCount: 0)
 

--- a/Domain/Tests/UseCases/Authority/CheckSTTPermissionUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Authority/CheckSTTPermissionUseCaseTest.swift
@@ -86,7 +86,7 @@ extension CheckSTTPermissionUseCaseTest {
         await authorityRepository.verify()
     }
 
-    func test_태스크취소상태_권한조회시_cancelled에러를던진다() async throws {
+    func test_태스크취소상태_권한조회시_cancelled에러를던진다() async {
         let authorityRepository = MockSTTPermissionRepository()
         let sut = DefaultCheckSTTPermissionUseCase(repository: authorityRepository)
 

--- a/Domain/Tests/UseCases/Authority/CheckSTTPermissionUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Authority/CheckSTTPermissionUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class CheckSTTPermissionUseCaseTest: XCTestCase {
-    private var authorityRepository: MockSTTPermissionRepository!
-    private var sut: DefaultCheckSTTPermissionUseCase!
-
-    override func setUp() {
-        super.setUp()
-        authorityRepository = MockSTTPermissionRepository()
-        sut = DefaultCheckSTTPermissionUseCase(repository: authorityRepository)
-    }
-
-    override func tearDown() {
-        authorityRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class CheckSTTPermissionUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension CheckSTTPermissionUseCaseTest {
     func test_STT권한허용상태_권한조회시_authorized를반환한다() async throws {
+        let authorityRepository = MockSTTPermissionRepository()
+        let sut = DefaultCheckSTTPermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.setCheckResult(.success(.authorized))
         await authorityRepository.expectCheckSTTPermission(callCount: 1)
@@ -36,6 +24,9 @@ extension CheckSTTPermissionUseCaseTest {
     }
 
     func test_STT권한거부상태_권한조회시_denied를반환한다() async throws {
+        let authorityRepository = MockSTTPermissionRepository()
+        let sut = DefaultCheckSTTPermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.setCheckResult(.success(.denied))
         await authorityRepository.expectCheckSTTPermission(callCount: 1)
@@ -49,6 +40,9 @@ extension CheckSTTPermissionUseCaseTest {
     }
 
     func test_STT권한미결정상태_권한조회시_notDetermined를반환한다() async throws {
+        let authorityRepository = MockSTTPermissionRepository()
+        let sut = DefaultCheckSTTPermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.setCheckResult(.success(.notDetermined))
         await authorityRepository.expectCheckSTTPermission(callCount: 1)
@@ -66,6 +60,9 @@ extension CheckSTTPermissionUseCaseTest {
 
 extension CheckSTTPermissionUseCaseTest {
     func test_리포지토리에러발생상태_권한조회시_unknown에러를던진다() async {
+        let authorityRepository = MockSTTPermissionRepository()
+        let sut = DefaultCheckSTTPermissionUseCase(repository: authorityRepository)
+
         // Given
         struct DummyError: Error {}
         let expectedError = DummyError()
@@ -90,9 +87,9 @@ extension CheckSTTPermissionUseCaseTest {
     }
 
     func test_태스크취소상태_권한조회시_cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let authorityRepository = MockSTTPermissionRepository()
+        let sut = DefaultCheckSTTPermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.expectCheckSTTPermission(callCount: 0)
 

--- a/Domain/Tests/UseCases/Authority/RequestMicrophonePermissionUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Authority/RequestMicrophonePermissionUseCaseTest.swift
@@ -75,7 +75,7 @@ extension RequestMicrophonePermissionUseCaseTest {
 // MARK: - 취소 케이스
 
 extension RequestMicrophonePermissionUseCaseTest {
-    func test_태스크취소상태_권한요청시_cancelled에러를던진다() async throws {
+    func test_태스크취소상태_권한요청시_cancelled에러를던진다() async {
         let authorityRepository = MockMicrophonePermissionRepository()
         let sut = DefaultRequestMicrophonePermissionUseCase(repository: authorityRepository)
 

--- a/Domain/Tests/UseCases/Authority/RequestMicrophonePermissionUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Authority/RequestMicrophonePermissionUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class RequestMicrophonePermissionUseCaseTest: XCTestCase {
-    private var authorityRepository: MockMicrophonePermissionRepository!
-    private var sut: DefaultRequestMicrophonePermissionUseCase!
-
-    override func setUp() {
-        super.setUp()
-        authorityRepository = MockMicrophonePermissionRepository()
-        sut = DefaultRequestMicrophonePermissionUseCase(repository: authorityRepository)
-    }
-
-    override func tearDown() {
-        authorityRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class RequestMicrophonePermissionUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension RequestMicrophonePermissionUseCaseTest {
     func test_마이크권한미결정상태_권한요청시_authorized를반환한다() async throws {
+        let authorityRepository = MockMicrophonePermissionRepository()
+        let sut = DefaultRequestMicrophonePermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.setRequestResult(.success(.authorized))
         await authorityRepository.expectRequestMicrophonePermission(callCount: 1)
@@ -36,6 +24,9 @@ extension RequestMicrophonePermissionUseCaseTest {
     }
 
     func test_마이크권한이미거부상태_권한요청시_denied를반환한다() async throws {
+        let authorityRepository = MockMicrophonePermissionRepository()
+        let sut = DefaultRequestMicrophonePermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.setRequestResult(.success(.denied))
         await authorityRepository.expectRequestMicrophonePermission(callCount: 1)
@@ -53,6 +44,9 @@ extension RequestMicrophonePermissionUseCaseTest {
 
 extension RequestMicrophonePermissionUseCaseTest {
     func test_리포지토리에러발생상태_권한요청시_unknown에러를던진다() async {
+        let authorityRepository = MockMicrophonePermissionRepository()
+        let sut = DefaultRequestMicrophonePermissionUseCase(repository: authorityRepository)
+
         // Given
         struct DummyError: Error {}
         let expectedError = DummyError()
@@ -82,9 +76,9 @@ extension RequestMicrophonePermissionUseCaseTest {
 
 extension RequestMicrophonePermissionUseCaseTest {
     func test_태스크취소상태_권한요청시_cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let authorityRepository = MockMicrophonePermissionRepository()
+        let sut = DefaultRequestMicrophonePermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.expectRequestMicrophonePermission(callCount: 0)
 

--- a/Domain/Tests/UseCases/Authority/RequestSTTPermissionUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Authority/RequestSTTPermissionUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class RequestSTTPermissionUseCaseTest: XCTestCase {
-    private var authorityRepository: MockSTTPermissionRepository!
-    private var sut: DefaultRequestSTTPermissionUseCase!
-
-    override func setUp() {
-        super.setUp()
-        authorityRepository = MockSTTPermissionRepository()
-        sut = DefaultRequestSTTPermissionUseCase(repository: authorityRepository)
-    }
-
-    override func tearDown() {
-        authorityRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class RequestSTTPermissionUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension RequestSTTPermissionUseCaseTest {
     func test_STT권한미결정상태_권한요청시_authorized를반환한다() async throws {
+        let authorityRepository = MockSTTPermissionRepository()
+        let sut = DefaultRequestSTTPermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.setRequestResult(.success(.authorized))
         await authorityRepository.expectRequestSTTPermission(callCount: 1)
@@ -36,6 +24,9 @@ extension RequestSTTPermissionUseCaseTest {
     }
 
     func test_STT권한이미거부상태_권한요청시_denied를반환한다() async throws {
+        let authorityRepository = MockSTTPermissionRepository()
+        let sut = DefaultRequestSTTPermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.setRequestResult(.success(.denied))
         await authorityRepository.expectRequestSTTPermission(callCount: 1)
@@ -53,6 +44,9 @@ extension RequestSTTPermissionUseCaseTest {
 
 extension RequestSTTPermissionUseCaseTest {
     func test_리포지토리에러발생상태_권한요청시_unknown에러를던진다() async {
+        let authorityRepository = MockSTTPermissionRepository()
+        let sut = DefaultRequestSTTPermissionUseCase(repository: authorityRepository)
+
         // Given
         struct DummyError: Error {}
         let expectedError = DummyError()
@@ -82,9 +76,9 @@ extension RequestSTTPermissionUseCaseTest {
 
 extension RequestSTTPermissionUseCaseTest {
     func test_태스크취소상태_권한요청시_cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let authorityRepository = MockSTTPermissionRepository()
+        let sut = DefaultRequestSTTPermissionUseCase(repository: authorityRepository)
+
         // Given
         await authorityRepository.expectRequestSTTPermission(callCount: 0)
 

--- a/Domain/Tests/UseCases/Authority/RequestSTTPermissionUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Authority/RequestSTTPermissionUseCaseTest.swift
@@ -75,7 +75,7 @@ extension RequestSTTPermissionUseCaseTest {
 // MARK: - 취소 케이스
 
 extension RequestSTTPermissionUseCaseTest {
-    func test_태스크취소상태_권한요청시_cancelled에러를던진다() async throws {
+    func test_태스크취소상태_권한요청시_cancelled에러를던진다() async {
         let authorityRepository = MockSTTPermissionRepository()
         let sut = DefaultRequestSTTPermissionUseCase(repository: authorityRepository)
 

--- a/Domain/Tests/UseCases/Folders/CreateFolderUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Folders/CreateFolderUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class CreateFolderUseCaseTest: XCTestCase {
-    private var repository: MockFolderRepository!
-    private var sut: DefaultCreateFolderUseCase!
-
-    override func setUp() {
-        super.setUp()
-        repository = MockFolderRepository()
-        sut = DefaultCreateFolderUseCase(repository: repository)
-    }
-
-    override func tearDown() {
-        repository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class CreateFolderUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension CreateFolderUseCaseTest {
     func test_정상상태_폴더생성시_생성된폴더를반환한다() async throws {
+        let repository = MockFolderRepository()
+        let sut = DefaultCreateFolderUseCase(repository: repository)
+
         // Given
         let expectedName = "New Folder"
         let expectedFolder = Folder.stub(name: expectedName)
@@ -42,13 +30,15 @@ extension CreateFolderUseCaseTest {
 // MARK: - 에러 케이스
 
 extension CreateFolderUseCaseTest {
-    func test_유효하지않은이름상태_폴더생성시_invalidName에러를던진다() async throws {
+    func test_유효하지않은이름상태_폴더생성시_invalidName에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultCreateFolderUseCase(repository: repository)
+
         // Given
         await repository.expectCreate(callCount: 0)
         let invalidNames = ["", " ", "  \n  ", " 새폴더", "새 폴더 ", "  새 폴더  "]
 
         // When & Then
-        let sut = try XCTUnwrap(sut)
         await withTaskGroup(of: Void.self) { group in
             for name in invalidNames {
                 group.addTask {
@@ -72,6 +62,9 @@ extension CreateFolderUseCaseTest {
     }
 
     func test_너무긴이름상태_폴더생성시_invalidLengthName에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultCreateFolderUseCase(repository: repository)
+
         // Given
         await repository.expectCreate(callCount: 0)
         let tooLongName = String(repeating: "a", count: 51)
@@ -92,6 +85,9 @@ extension CreateFolderUseCaseTest {
     }
 
     func test_중복된이름상태_폴더생성시_duplicateName에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultCreateFolderUseCase(repository: repository)
+
         // Given
         await repository.setCreateResult(.failure(.duplicateName))
         await repository.expectCreate(callCount: 1)
@@ -112,6 +108,9 @@ extension CreateFolderUseCaseTest {
     }
 
     func test_리포지토리생성실패상태_폴더생성시_createFailed에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultCreateFolderUseCase(repository: repository)
+
         // Given
         await repository.setCreateResult(.failure(.createFailed))
         await repository.expectCreate(callCount: 1)
@@ -132,6 +131,9 @@ extension CreateFolderUseCaseTest {
     }
 
     func test_리포지토리알수없는에러상태_폴더생성시_unknown에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultCreateFolderUseCase(repository: repository)
+
         // Given
         struct DummyError: Error {}
         let expectedError = DummyError()
@@ -165,6 +167,9 @@ extension CreateFolderUseCaseTest {
 
 extension CreateFolderUseCaseTest {
     func test_작업취소상태_폴더생성시_cancelled에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultCreateFolderUseCase(repository: repository)
+
         // Given
         await repository.setCreateResult(.failure(.cancelled))
         await repository.expectCreate(callCount: 1)
@@ -185,9 +190,9 @@ extension CreateFolderUseCaseTest {
     }
 
     func test_태스크이미취소상태_폴더생성시_즉시cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let repository = MockFolderRepository()
+        let sut = DefaultCreateFolderUseCase(repository: repository)
+
         // Given
         await repository.setCreateResult(
             .success(Folder.stub(name: "test"))

--- a/Domain/Tests/UseCases/Folders/CreateFolderUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Folders/CreateFolderUseCaseTest.swift
@@ -189,7 +189,7 @@ extension CreateFolderUseCaseTest {
         await repository.verify()
     }
 
-    func test_태스크이미취소상태_폴더생성시_즉시cancelled에러를던진다() async throws {
+    func test_태스크이미취소상태_폴더생성시_즉시cancelled에러를던진다() async {
         let repository = MockFolderRepository()
         let sut = DefaultCreateFolderUseCase(repository: repository)
 

--- a/Domain/Tests/UseCases/Folders/ReadFolderUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Folders/ReadFolderUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class ReadFolderUseCaseTest: XCTestCase {
-    private var repository: MockFolderRepository!
-    private var sut: DefaultReadFolderUseCase!
-
-    override func setUp() {
-        super.setUp()
-        repository = MockFolderRepository()
-        sut = DefaultReadFolderUseCase(repository: repository)
-    }
-
-    override func tearDown() {
-        repository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class ReadFolderUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension ReadFolderUseCaseTest {
     func test_정상상태_폴더조회시_전체폴더목록을반환한다() async throws {
+        let repository = MockFolderRepository()
+        let sut = DefaultReadFolderUseCase(repository: repository)
+
         // Given
         let expectedFolders = [
             Folder(name: "Folder 1"),
@@ -48,6 +36,9 @@ extension ReadFolderUseCaseTest {
 
 extension ReadFolderUseCaseTest {
     func test_리포지토리조회실패상태_폴더조회시_fetchFailed에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultReadFolderUseCase(repository: repository)
+
         // Given
         await repository.setFetchAllResult(.failure(.fetchFailed))
         await repository.expectFetchAll(callCount: 1)
@@ -68,6 +59,9 @@ extension ReadFolderUseCaseTest {
     }
 
     func test_폴더미존재상태_폴더조회시_notFound에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultReadFolderUseCase(repository: repository)
+
         // Given
         await repository.setFetchAllResult(.failure(.notFound))
         await repository.expectFetchAll(callCount: 1)
@@ -88,6 +82,9 @@ extension ReadFolderUseCaseTest {
     }
 
     func test_리포지토리알수없는에러상태_폴더조회시_unknown에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultReadFolderUseCase(repository: repository)
+
         // Given
         struct DummyError: Error {}
         let expectedError = DummyError()
@@ -121,6 +118,9 @@ extension ReadFolderUseCaseTest {
 
 extension ReadFolderUseCaseTest {
     func test_작업취소상태_폴더조회시_cancelled에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultReadFolderUseCase(repository: repository)
+
         // Given
         await repository.setFetchAllResult(.failure(.cancelled))
         await repository.expectFetchAll(callCount: 1)
@@ -141,9 +141,9 @@ extension ReadFolderUseCaseTest {
     }
 
     func test_태스크이미취소상태_폴더조회시_즉시cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let repository = MockFolderRepository()
+        let sut = DefaultReadFolderUseCase(repository: repository)
+
         // Given
         await repository.setFetchAllResult(.success([]))
         await repository.expectFetchAll(callCount: 0)

--- a/Domain/Tests/UseCases/Folders/ReadFolderUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Folders/ReadFolderUseCaseTest.swift
@@ -13,8 +13,8 @@ extension ReadFolderUseCaseTest {
 
         // Given
         let expectedFolders = [
-            Folder(name: "Folder 1"),
-            Folder(name: "Folder 2")
+            Folder.stub(name: "Folder 1"),
+            Folder.stub(name: "Folder 2")
         ]
         await repository.setFetchAllResult(.success(expectedFolders))
         await repository.expectFetchAll(callCount: 1)
@@ -140,7 +140,7 @@ extension ReadFolderUseCaseTest {
         await repository.verify()
     }
 
-    func test_태스크이미취소상태_폴더조회시_즉시cancelled에러를던진다() async throws {
+    func test_태스크이미취소상태_폴더조회시_즉시cancelled에러를던진다() async {
         let repository = MockFolderRepository()
         let sut = DefaultReadFolderUseCase(repository: repository)
 

--- a/Domain/Tests/UseCases/Folders/UpdateFolderUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Folders/UpdateFolderUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class UpdateFolderUseCaseTest: XCTestCase {
-    private var repository: MockFolderRepository!
-    private var sut: DefaultUpdateFolderUseCase!
-
-    override func setUp() {
-        super.setUp()
-        repository = MockFolderRepository()
-        sut = DefaultUpdateFolderUseCase(repository: repository)
-    }
-
-    override func tearDown() {
-        repository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class UpdateFolderUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension UpdateFolderUseCaseTest {
     func test_정상상태_폴더수정시_업데이트된폴더를반환한다() async throws {
+        let repository = MockFolderRepository()
+        let sut = DefaultUpdateFolderUseCase(repository: repository)
+
         // Given
         let originalFolder = Folder.stub(name: "Old Name")
         let updatedFolder = Folder.stub(
@@ -51,6 +39,9 @@ extension UpdateFolderUseCaseTest {
 
 extension UpdateFolderUseCaseTest {
     func test_너무긴이름상태_폴더수정시_invalidLengthName에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultUpdateFolderUseCase(repository: repository)
+
         // Given
         await repository.expectUpdate(callCount: 0)
         let tooLongName = String(repeating: "a", count: 51)
@@ -71,13 +62,15 @@ extension UpdateFolderUseCaseTest {
         await repository.verify()
     }
 
-    func test_유효하지않은이름상태_폴더수정시_invalidName에러를던진다() async throws {
+    func test_유효하지않은이름상태_폴더수정시_invalidName에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultUpdateFolderUseCase(repository: repository)
+
         // Given
         await repository.expectUpdate(callCount: 0)
         let invalidNames = ["", " ", "  \n  ", " 새폴더", "새 폴더 ", "  새 폴더  "]
 
         // When & Then
-        let sut = try XCTUnwrap(sut)
         await withTaskGroup(of: Void.self) { group in
             for name in invalidNames {
                 group.addTask {
@@ -102,6 +95,9 @@ extension UpdateFolderUseCaseTest {
     }
 
     func test_폴더미존재상태_폴더수정시_notFound에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultUpdateFolderUseCase(repository: repository)
+
         // Given
         let folder = Folder(name: "Any")
         await repository.setUpdateResult(.failure(.notFound))
@@ -123,6 +119,9 @@ extension UpdateFolderUseCaseTest {
     }
 
     func test_중복된이름상태_폴더수정시_duplicateName에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultUpdateFolderUseCase(repository: repository)
+
         // Given
         let folder = Folder(name: "New Name")
         await repository.setUpdateResult(.failure(.duplicateName))
@@ -144,6 +143,9 @@ extension UpdateFolderUseCaseTest {
     }
 
     func test_리포지토리수정실패상태_폴더수정시_updateFailed에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultUpdateFolderUseCase(repository: repository)
+
         // Given
         let folder = Folder(name: "Any")
         await repository.setUpdateResult(.failure(.updateFailed))
@@ -165,6 +167,9 @@ extension UpdateFolderUseCaseTest {
     }
 
     func test_리포지토리알수없는에러상태_폴더수정시_unknown에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultUpdateFolderUseCase(repository: repository)
+
         // Given
         let folder = Folder(name: "Any")
         struct DummyError: Error {}
@@ -199,6 +204,9 @@ extension UpdateFolderUseCaseTest {
 
 extension UpdateFolderUseCaseTest {
     func test_작업취소상태_폴더수정시_cancelled에러를던진다() async {
+        let repository = MockFolderRepository()
+        let sut = DefaultUpdateFolderUseCase(repository: repository)
+
         // Given
         let folder = Folder(name: "Any")
         await repository.setUpdateResult(.failure(.cancelled))
@@ -220,9 +228,9 @@ extension UpdateFolderUseCaseTest {
     }
 
     func test_태스크이미취소상태_폴더수정시_즉시cancelled에러를던진다() async {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let repository = MockFolderRepository()
+        let sut = DefaultUpdateFolderUseCase(repository: repository)
+
         // Given
         let folder = Folder(name: "Any")
         await repository.setUpdateResult(.success(folder))

--- a/Domain/Tests/UseCases/Languages/FetchLanguageUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Languages/FetchLanguageUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class FetchLanguageUseCaseTest: XCTestCase {
-    private var repository: MockLanguageRepository!
-    private var sut: DefaultFetchLanguageUseCase!
-
-    override func setUp() {
-        super.setUp()
-        repository = MockLanguageRepository()
-        sut = DefaultFetchLanguageUseCase(repository: repository)
-    }
-
-    override func tearDown() {
-        repository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class FetchLanguageUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension FetchLanguageUseCaseTest {
     func test_정상상태_언어조회시_설정된Language를반환한다() async throws {
+        let repository = MockLanguageRepository()
+        let sut = DefaultFetchLanguageUseCase(repository: repository)
+
         // Given
         let expectedLanguage: Language = .ko
         await repository.setFetchResult(.success(expectedLanguage))
@@ -41,6 +29,9 @@ extension FetchLanguageUseCaseTest {
 
 extension FetchLanguageUseCaseTest {
     func test_데이터미존재상태_언어조회시_notFound에러를던진다() async {
+        let repository = MockLanguageRepository()
+        let sut = DefaultFetchLanguageUseCase(repository: repository)
+
         // Given
         await repository.setFetchResult(.failure(.notFound))
         await repository.expectFetch(callCount: 1)
@@ -60,6 +51,9 @@ extension FetchLanguageUseCaseTest {
     }
 
     func test_알수없는에러발생상태_언어조회시_unknown에러를던진다() async {
+        let repository = MockLanguageRepository()
+        let sut = DefaultFetchLanguageUseCase(repository: repository)
+
         // Given
         struct DummyError: Error {}
         await repository.setFetchResult(.failure(.unknown(DummyError())))
@@ -85,6 +79,9 @@ extension FetchLanguageUseCaseTest {
 
 extension FetchLanguageUseCaseTest {
     func test_조회중취소상태_언어조회시_cancelled에러를던진다() async {
+        let repository = MockLanguageRepository()
+        let sut = DefaultFetchLanguageUseCase(repository: repository)
+
         // Given
         await repository.setFetchResult(.failure(.cancelled))
         await repository.expectFetch(callCount: 1)
@@ -104,9 +101,9 @@ extension FetchLanguageUseCaseTest {
     }
 
     func test_태스크이미취소상태_언어조회시_즉시cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let repository = MockLanguageRepository()
+        let sut = DefaultFetchLanguageUseCase(repository: repository)
+
         // Given
         let expectedLanguage: Language = .ko
         await repository.setFetchResult(.success(expectedLanguage))

--- a/Domain/Tests/UseCases/Languages/FetchLanguageUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Languages/FetchLanguageUseCaseTest.swift
@@ -100,7 +100,7 @@ extension FetchLanguageUseCaseTest {
         await repository.verify()
     }
 
-    func test_태스크이미취소상태_언어조회시_즉시cancelled에러를던진다() async throws {
+    func test_태스크이미취소상태_언어조회시_즉시cancelled에러를던진다() async {
         let repository = MockLanguageRepository()
         let sut = DefaultFetchLanguageUseCase(repository: repository)
 

--- a/Domain/Tests/UseCases/Languages/SelectLanguageUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Languages/SelectLanguageUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class SelectLanguageUseCaseTest: XCTestCase {
-    private var repository: MockLanguageRepository!
-    private var sut: DefaultSelectLanguageUseCase!
-
-    override func setUp() {
-        super.setUp()
-        repository = MockLanguageRepository()
-        sut = DefaultSelectLanguageUseCase(repository: repository)
-    }
-
-    override func tearDown() {
-        repository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class SelectLanguageUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension SelectLanguageUseCaseTest {
     func test_정상상태_언어설정시_리포지토리의저장메서드를호출한다() async throws {
+        let repository = MockLanguageRepository()
+        let sut = DefaultSelectLanguageUseCase(repository: repository)
+
         // Given
         await repository.setSaveResult(.success(()))
         await repository.expectSave(language: .ko, callCount: 1)
@@ -39,6 +27,9 @@ extension SelectLanguageUseCaseTest {
 
 extension SelectLanguageUseCaseTest {
     func test_리포지토리저장실패상태_언어설정시_saveFailed에러를던진다() async {
+        let repository = MockLanguageRepository()
+        let sut = DefaultSelectLanguageUseCase(repository: repository)
+
         // Given
         await repository.setSaveResult(.failure(.saveFailed))
         await repository.expectSave(language: .ko, callCount: 1)
@@ -58,6 +49,9 @@ extension SelectLanguageUseCaseTest {
     }
 
     func test_알수없는에러발생상태_언어설정시_unknown에러를던진다() async {
+        let repository = MockLanguageRepository()
+        let sut = DefaultSelectLanguageUseCase(repository: repository)
+
         // Given
         struct DummyError: Error {}
         await repository.setSaveResult(.failure(.unknown(DummyError())))
@@ -83,6 +77,9 @@ extension SelectLanguageUseCaseTest {
 
 extension SelectLanguageUseCaseTest {
     func test_조회중취소상태_언어설정시_cancelled에러를던진다() async {
+        let repository = MockLanguageRepository()
+        let sut = DefaultSelectLanguageUseCase(repository: repository)
+
         // Given
         await repository.setSaveResult(.failure(.cancelled))
         await repository.expectSave(language: .ko, callCount: 1)
@@ -102,9 +99,9 @@ extension SelectLanguageUseCaseTest {
     }
 
     func test_태스크이미취소상태_언어설정시_즉시cancelled에러를던진다() async {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let repository = MockLanguageRepository()
+        let sut = DefaultSelectLanguageUseCase(repository: repository)
+
         // Given
         await repository.setSaveResult(.success(()))
         await repository.expectSave(callCount: 0)

--- a/Domain/Tests/UseCases/VoiceNotes/AudioToSummaryUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceNotes/AudioToSummaryUseCaseTest.swift
@@ -2,33 +2,19 @@
 import Core
 import XCTest
 
-final class AudioToSummaryUseCaseTest: XCTestCase {
-    private var sttRepository: MockSTTRepository!
-    private var summaryRepository: MockSummaryRepository!
-    private var sut: DefaultAudioToSummaryUseCase!
-
-    override func setUp() {
-        super.setUp()
-        sttRepository = MockSTTRepository()
-        summaryRepository = MockSummaryRepository()
-        sut = DefaultAudioToSummaryUseCase(
-            sttRepository: sttRepository,
-            summaryRepository: summaryRepository
-        )
-    }
-
-    override func tearDown() {
-        sttRepository = nil
-        summaryRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class AudioToSummaryUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension AudioToSummaryUseCaseTest {
     func test_정상상태_음성메모요약요청시_STT및요약결과를포함한객체를반환한다() async throws {
+        let sttRepository = MockSTTRepository()
+        let summaryRepository = MockSummaryRepository()
+        let sut = DefaultAudioToSummaryUseCase(
+            sttRepository: sttRepository,
+            summaryRepository: summaryRepository
+        )
+
         // Given
         let audioURL = URL(fileURLWithPath: "/test.m4a")
         let expectedTranscript = Transcript.stub()
@@ -62,6 +48,13 @@ extension AudioToSummaryUseCaseTest {
 
 extension AudioToSummaryUseCaseTest {
     func test_STT실패상태_음성메모요약요청시_transcribeFailed에러를던진다() async {
+        let sttRepository = MockSTTRepository()
+        let summaryRepository = MockSummaryRepository()
+        let sut = DefaultAudioToSummaryUseCase(
+            sttRepository: sttRepository,
+            summaryRepository: summaryRepository
+        )
+
         // Given
         let audioURL = URL(fileURLWithPath: "/test.m4a")
 
@@ -85,6 +78,13 @@ extension AudioToSummaryUseCaseTest {
     }
 
     func test_요약실패상태_음성메모요약요청시_summarizeFailed에러를던진다() async {
+        let sttRepository = MockSTTRepository()
+        let summaryRepository = MockSummaryRepository()
+        let sut = DefaultAudioToSummaryUseCase(
+            sttRepository: sttRepository,
+            summaryRepository: summaryRepository
+        )
+
         // Given
         let audioURL = URL(fileURLWithPath: "/test.m4a")
         let expectedTranscript = Transcript.stub()
@@ -113,6 +113,13 @@ extension AudioToSummaryUseCaseTest {
     }
 
     func test_알수없는에러발생상태_음성메모요약요청시_unknown에러를던진다() async {
+        let sttRepository = MockSTTRepository()
+        let summaryRepository = MockSummaryRepository()
+        let sut = DefaultAudioToSummaryUseCase(
+            sttRepository: sttRepository,
+            summaryRepository: summaryRepository
+        )
+
         // Given
         let audioURL = URL(fileURLWithPath: "/test.m4a")
         struct DummyError: Error {}
@@ -142,6 +149,13 @@ extension AudioToSummaryUseCaseTest {
 
 extension AudioToSummaryUseCaseTest {
     func test_작업취소상태_음성메모요약요청시_cancelled에러를던진다() async {
+        let sttRepository = MockSTTRepository()
+        let summaryRepository = MockSummaryRepository()
+        let sut = DefaultAudioToSummaryUseCase(
+            sttRepository: sttRepository,
+            summaryRepository: summaryRepository
+        )
+
         // Given
         let audioURL = URL(fileURLWithPath: "/test.m4a")
 
@@ -164,9 +178,13 @@ extension AudioToSummaryUseCaseTest {
     }
 
     func test_태스크이미취소상태_음성메모요약요청시_즉시cancelled에러를던진다() async {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let sttRepository = MockSTTRepository()
+        let summaryRepository = MockSummaryRepository()
+        let sut = DefaultAudioToSummaryUseCase(
+            sttRepository: sttRepository,
+            summaryRepository: summaryRepository
+        )
+
         // Given
         let audioURL = URL(fileURLWithPath: "/test.m4a")
 

--- a/Domain/Tests/UseCases/VoiceNotes/CreateVoiceNoteUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceNotes/CreateVoiceNoteUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class CreateVoiceNoteUseCaseTest: XCTestCase {
-    private var repository: MockVoiceNoteCreateRepository!
-    private var sut: DefaultCreateVoiceNoteUseCase!
-
-    override func setUp() {
-        super.setUp()
-        repository = MockVoiceNoteCreateRepository()
-        sut = DefaultCreateVoiceNoteUseCase(repository: repository)
-    }
-
-    override func tearDown() {
-        repository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class CreateVoiceNoteUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension CreateVoiceNoteUseCaseTest {
     func test_정상상태_음성메모생성시_생성된객체를반환한다() async throws {
+        let repository = MockVoiceNoteCreateRepository()
+        let sut = DefaultCreateVoiceNoteUseCase(repository: repository)
+
         // Given
         let voiceRecord = VoiceRecord.stub()
         let expectedVoiceNote = VoiceNote.stub(voiceRecord: voiceRecord)
@@ -44,6 +32,9 @@ extension CreateVoiceNoteUseCaseTest {
 
 extension CreateVoiceNoteUseCaseTest {
     func test_리포지토리생성실패상태_음성메모생성시_createFailed에러를던진다() async {
+        let repository = MockVoiceNoteCreateRepository()
+        let sut = DefaultCreateVoiceNoteUseCase(repository: repository)
+
         // Given
         let voiceRecord = VoiceRecord.stub()
 
@@ -63,6 +54,9 @@ extension CreateVoiceNoteUseCaseTest {
     }
 
     func test_알수없는에러발생상태_음성메모생성시_unknown에러를던진다() async {
+        let repository = MockVoiceNoteCreateRepository()
+        let sut = DefaultCreateVoiceNoteUseCase(repository: repository)
+
         // Given
         let voiceRecord = VoiceRecord.stub()
         struct DummyError: Error {}
@@ -85,6 +79,9 @@ extension CreateVoiceNoteUseCaseTest {
     }
 
     func test_작업취소상태_음성메모생성시_cancelled에러를던진다() async {
+        let repository = MockVoiceNoteCreateRepository()
+        let sut = DefaultCreateVoiceNoteUseCase(repository: repository)
+
         // Given
         let voiceRecord = VoiceRecord.stub()
 

--- a/Domain/Tests/UseCases/VoiceNotes/FetchVoiceNoteUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceNotes/FetchVoiceNoteUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class FetchVoiceNoteUseCaseTest: XCTestCase {
-    private var repository: MockVoiceNoteFetchRepository!
-    private var sut: DefaultFetchVoiceNoteUseCase!
-
-    override func setUp() {
-        super.setUp()
-        repository = MockVoiceNoteFetchRepository()
-        sut = DefaultFetchVoiceNoteUseCase(repository: repository)
-    }
-
-    override func tearDown() {
-        repository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class FetchVoiceNoteUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension FetchVoiceNoteUseCaseTest {
     func test_정상상태_특정폴더내음성메모조회시_리포지토리에서가져온목록을반환한다() async throws {
+        let repository = MockVoiceNoteFetchRepository()
+        let sut = DefaultFetchVoiceNoteUseCase(repository: repository)
+
         // Given
         let folderID = UUID()
         let expectedVoiceNotes = [VoiceNote.stub(folderID: folderID)]
@@ -40,6 +28,9 @@ extension FetchVoiceNoteUseCaseTest {
     }
 
     func test_정상상태_특정ID로음성메모조회시_리포지토리에서가져온객체를반환한다() async throws {
+        let repository = MockVoiceNoteFetchRepository()
+        let sut = DefaultFetchVoiceNoteUseCase(repository: repository)
+
         // Given
         let voiceNoteID = UUID()
         let expectedVoiceNote = VoiceNote.stub(id: voiceNoteID)
@@ -60,6 +51,9 @@ extension FetchVoiceNoteUseCaseTest {
 
 extension FetchVoiceNoteUseCaseTest {
     func test_리포지토리조회실패상태_음성메모조회시_fetchAllFailed에러를던진다() async {
+        let repository = MockVoiceNoteFetchRepository()
+        let sut = DefaultFetchVoiceNoteUseCase(repository: repository)
+
         // Given
         let folderID = UUID()
 
@@ -80,6 +74,9 @@ extension FetchVoiceNoteUseCaseTest {
     }
 
     func test_알수없는에러발생상태_음성메모조회시_unknown에러를던진다() async {
+        let repository = MockVoiceNoteFetchRepository()
+        let sut = DefaultFetchVoiceNoteUseCase(repository: repository)
+
         // Given
         let folderID = UUID()
         struct DummyError: Error {}
@@ -102,6 +99,9 @@ extension FetchVoiceNoteUseCaseTest {
     }
 
     func test_작업취소상태_음성메모조회시_cancelled에러를던진다() async {
+        let repository = MockVoiceNoteFetchRepository()
+        let sut = DefaultFetchVoiceNoteUseCase(repository: repository)
+
         // Given
         let folderID = UUID()
 

--- a/Domain/Tests/UseCases/VoiceNotes/UpdateVoiceNoteUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceNotes/UpdateVoiceNoteUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class UpdateVoiceNoteUseCaseTest: XCTestCase {
-    private var repository: MockVoiceNoteUpdateRepository!
-    private var sut: DefaultUpdateVoiceNoteUseCase!
-
-    override func setUp() {
-        super.setUp()
-        repository = MockVoiceNoteUpdateRepository()
-        sut = DefaultUpdateVoiceNoteUseCase(repository: repository)
-    }
-
-    override func tearDown() {
-        repository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class UpdateVoiceNoteUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension UpdateVoiceNoteUseCaseTest {
     func test_정상상태_음성메모업데이트시_업데이트된객체를반환한다() async throws {
+        let repository = MockVoiceNoteUpdateRepository()
+        let sut = DefaultUpdateVoiceNoteUseCase(repository: repository)
+
         // Given
         let expectedVoiceNote = VoiceNote.stub()
 
@@ -43,6 +31,9 @@ extension UpdateVoiceNoteUseCaseTest {
 
 extension UpdateVoiceNoteUseCaseTest {
     func test_리포지토리업데이트실패상태_음성메모업데이트시_updateFailed에러를던진다() async {
+        let repository = MockVoiceNoteUpdateRepository()
+        let sut = DefaultUpdateVoiceNoteUseCase(repository: repository)
+
         // Given
         let voiceNote = VoiceNote.stub()
 
@@ -62,6 +53,9 @@ extension UpdateVoiceNoteUseCaseTest {
     }
 
     func test_알수없는에러발생상태_음성메모업데이트시_unknown에러를던진다() async {
+        let repository = MockVoiceNoteUpdateRepository()
+        let sut = DefaultUpdateVoiceNoteUseCase(repository: repository)
+
         // Given
         let voiceNote = VoiceNote.stub()
         struct DummyError: Error {}
@@ -88,6 +82,9 @@ extension UpdateVoiceNoteUseCaseTest {
 
 extension UpdateVoiceNoteUseCaseTest {
     func test_작업취소상태_음성메모업데이트시_cancelled에러를던진다() async {
+        let repository = MockVoiceNoteUpdateRepository()
+        let sut = DefaultUpdateVoiceNoteUseCase(repository: repository)
+
         // Given
         let voiceNote = VoiceNote.stub()
 

--- a/Domain/Tests/UseCases/VoiceRecords/FinishRecordingUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceRecords/FinishRecordingUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Foundation
 import XCTest
 
-final class FinishRecordingUseCaseTest: XCTestCase {
-    private var recordingRepository: MockVoiceRecordFinishRepository!
-    private var sut: DefaultFinishRecordingUseCase!
-
-    override func setUp() {
-        super.setUp()
-        recordingRepository = MockVoiceRecordFinishRepository()
-        sut = DefaultFinishRecordingUseCase(recordingRepository: recordingRepository)
-    }
-
-    override func tearDown() {
-        recordingRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class FinishRecordingUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension FinishRecordingUseCaseTest {
     func test_정상상태_녹음종료시_생성된VoiceRecord를반환한다() async throws {
+        let recordingRepository = MockVoiceRecordFinishRepository()
+        let sut = DefaultFinishRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         let expectedRecord = VoiceRecord.stub()
         await recordingRepository.setResult(.success(expectedRecord))
@@ -43,6 +31,9 @@ extension FinishRecordingUseCaseTest {
 
 extension FinishRecordingUseCaseTest {
     func test_녹음중아닌상태_녹음종료시_notRecording에러를던진다() async {
+        let recordingRepository = MockVoiceRecordFinishRepository()
+        let sut = DefaultFinishRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         await recordingRepository.setResult(.failure(.notRecording))
         await recordingRepository.expectFinishRecording(callCount: 1)
@@ -61,6 +52,9 @@ extension FinishRecordingUseCaseTest {
     }
 
     func test_리포지토리종료실패상태_녹음종료시_finishFailed에러를던진다() async {
+        let recordingRepository = MockVoiceRecordFinishRepository()
+        let sut = DefaultFinishRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         await recordingRepository.setResult(.failure(.finishFailed))
         await recordingRepository.expectFinishRecording(callCount: 1)
@@ -79,6 +73,9 @@ extension FinishRecordingUseCaseTest {
     }
 
     func test_인코딩실패상태_녹음종료시_encodingFailed에러를던진다() async {
+        let recordingRepository = MockVoiceRecordFinishRepository()
+        let sut = DefaultFinishRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         await recordingRepository.setResult(.failure(.encodingFailed))
         await recordingRepository.expectFinishRecording(callCount: 1)
@@ -97,6 +94,9 @@ extension FinishRecordingUseCaseTest {
     }
 
     func test_알수없는에러발생상태_녹음종료시_unknown에러를던진다() async {
+        let recordingRepository = MockVoiceRecordFinishRepository()
+        let sut = DefaultFinishRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         let underlyingError = NSError(domain: "Test", code: 404)
         await recordingRepository.setResult(.failure(.unknown(underlyingError)))
@@ -117,9 +117,9 @@ extension FinishRecordingUseCaseTest {
     }
 
     func test_태스크취소상태_녹음종료시_cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let recordingRepository = MockVoiceRecordFinishRepository()
+        let sut = DefaultFinishRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         await recordingRepository.setResult(.success(.stub()))
         await recordingRepository.expectFinishRecording(callCount: 0)

--- a/Domain/Tests/UseCases/VoiceRecords/FinishRecordingUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceRecords/FinishRecordingUseCaseTest.swift
@@ -116,7 +116,7 @@ extension FinishRecordingUseCaseTest {
         await recordingRepository.verify()
     }
 
-    func test_태스크취소상태_녹음종료시_cancelled에러를던진다() async throws {
+    func test_태스크취소상태_녹음종료시_cancelled에러를던진다() async {
         let recordingRepository = MockVoiceRecordFinishRepository()
         let sut = DefaultFinishRecordingUseCase(recordingRepository: recordingRepository)
 

--- a/Domain/Tests/UseCases/VoiceRecords/PauseRecordingUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceRecords/PauseRecordingUseCaseTest.swift
@@ -1,27 +1,15 @@
 @testable import Domain
 import XCTest
 
-final class PauseRecordingUseCaseTest: XCTestCase {
-    private var recordingRepository: MockVoiceRecordPauseRepository!
-    private var sut: DefaultPauseRecordingUseCase!
-
-    override func setUp() {
-        super.setUp()
-        recordingRepository = MockVoiceRecordPauseRepository()
-        sut = DefaultPauseRecordingUseCase(recordingRepository: recordingRepository)
-    }
-
-    override func tearDown() {
-        recordingRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class PauseRecordingUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension PauseRecordingUseCaseTest {
     func test_정상상태_녹음일시정지시_리포지토리의일시정지메서드를호출한다() async throws {
+        let recordingRepository = MockVoiceRecordPauseRepository()
+        let sut = DefaultPauseRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         await recordingRepository.setResult(.success(()))
         await recordingRepository.expectPauseRecording(callCount: 1)
@@ -38,6 +26,9 @@ extension PauseRecordingUseCaseTest {
 
 extension PauseRecordingUseCaseTest {
     func test_녹음중아닌상태_녹음일시정지시_notRecording에러를던진다() async {
+        let recordingRepository = MockVoiceRecordPauseRepository()
+        let sut = DefaultPauseRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         await recordingRepository.setResult(.failure(.notRecording))
         await recordingRepository.expectPauseRecording(callCount: 1)
@@ -55,9 +46,9 @@ extension PauseRecordingUseCaseTest {
     }
 
     func test_태스크취소상태_녹음일시정지시_cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let recordingRepository = MockVoiceRecordPauseRepository()
+        let sut = DefaultPauseRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         await recordingRepository.expectPauseRecording(callCount: 0)
 

--- a/Domain/Tests/UseCases/VoiceRecords/PauseRecordingUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceRecords/PauseRecordingUseCaseTest.swift
@@ -45,7 +45,7 @@ extension PauseRecordingUseCaseTest {
         await recordingRepository.verify()
     }
 
-    func test_태스크취소상태_녹음일시정지시_cancelled에러를던진다() async throws {
+    func test_태스크취소상태_녹음일시정지시_cancelled에러를던진다() async {
         let recordingRepository = MockVoiceRecordPauseRepository()
         let sut = DefaultPauseRecordingUseCase(recordingRepository: recordingRepository)
 

--- a/Domain/Tests/UseCases/VoiceRecords/ResumeRecordingUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceRecords/ResumeRecordingUseCaseTest.swift
@@ -1,27 +1,15 @@
 @testable import Domain
 import XCTest
 
-final class ResumeRecordingUseCaseTest: XCTestCase {
-    private var recordingRepository: MockVoiceRecordResumeRepository!
-    private var sut: DefaultResumeRecordingUseCase!
-
-    override func setUp() {
-        super.setUp()
-        recordingRepository = MockVoiceRecordResumeRepository()
-        sut = DefaultResumeRecordingUseCase(recordingRepository: recordingRepository)
-    }
-
-    override func tearDown() {
-        recordingRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class ResumeRecordingUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension ResumeRecordingUseCaseTest {
     func test_정상상태_녹음재개시_리포지토리의재개메서드를호출한다() async throws {
+        let recordingRepository = MockVoiceRecordResumeRepository()
+        let sut = DefaultResumeRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         await recordingRepository.setResult(.success(()))
         await recordingRepository.expectResumeRecording(callCount: 1)
@@ -38,6 +26,9 @@ extension ResumeRecordingUseCaseTest {
 
 extension ResumeRecordingUseCaseTest {
     func test_일시정지상태아닌경우_녹음재개시_notPaused에러를던진다() async {
+        let recordingRepository = MockVoiceRecordResumeRepository()
+        let sut = DefaultResumeRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         await recordingRepository.setResult(.failure(.notPaused))
         await recordingRepository.expectResumeRecording(callCount: 1)
@@ -55,9 +46,9 @@ extension ResumeRecordingUseCaseTest {
     }
 
     func test_태스크취소상태_녹음재개시_cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let recordingRepository = MockVoiceRecordResumeRepository()
+        let sut = DefaultResumeRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         await recordingRepository.expectResumeRecording(callCount: 0)
 

--- a/Domain/Tests/UseCases/VoiceRecords/ResumeRecordingUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceRecords/ResumeRecordingUseCaseTest.swift
@@ -45,7 +45,7 @@ extension ResumeRecordingUseCaseTest {
         await recordingRepository.verify()
     }
 
-    func test_태스크취소상태_녹음재개시_cancelled에러를던진다() async throws {
+    func test_태스크취소상태_녹음재개시_cancelled에러를던진다() async {
         let recordingRepository = MockVoiceRecordResumeRepository()
         let sut = DefaultResumeRecordingUseCase(recordingRepository: recordingRepository)
 

--- a/Domain/Tests/UseCases/VoiceRecords/StartRecordingUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceRecords/StartRecordingUseCaseTest.swift
@@ -2,29 +2,15 @@
 import Core
 import XCTest
 
-final class StartRecordingUseCaseTest: XCTestCase {
-    private var recordingRepository: MockVoiceRecordStartRepository!
-    private var sut: DefaultStartRecordingUseCase!
-
-    override func setUp() {
-        super.setUp()
-        recordingRepository = MockVoiceRecordStartRepository()
-        sut = DefaultStartRecordingUseCase(
-            recordingRepository: recordingRepository
-        )
-    }
-
-    override func tearDown() {
-        recordingRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class StartRecordingUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension StartRecordingUseCaseTest {
     func test_정상상태_녹음시작시_파형스트림을반환한다() async throws {
+        let recordingRepository = MockVoiceRecordStartRepository()
+        let sut = DefaultStartRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         let expectedStream = AsyncStream<Waveform> { continuation in
             continuation.yield(.stub())
@@ -50,6 +36,9 @@ extension StartRecordingUseCaseTest {
 
 extension StartRecordingUseCaseTest {
     func test_리포지토리시작실패상태_녹음시작시_startFailed에러를던진다() async {
+        let recordingRepository = MockVoiceRecordStartRepository()
+        let sut = DefaultStartRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         await recordingRepository.setResult(.failure(.startFailed))
         await recordingRepository.expectStartRecording(callCount: 1)
@@ -70,6 +59,9 @@ extension StartRecordingUseCaseTest {
     }
 
     func test_리포지토리알수없는에러상태_녹음시작시_unknown에러를던진다() async {
+        let recordingRepository = MockVoiceRecordStartRepository()
+        let sut = DefaultStartRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         struct DummyError: Error {}
         let expectedError = DummyError()
@@ -97,9 +89,9 @@ extension StartRecordingUseCaseTest {
 
 extension StartRecordingUseCaseTest {
     func test_태스크취소상태_녹음시작시_cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let recordingRepository = MockVoiceRecordStartRepository()
+        let sut = DefaultStartRecordingUseCase(recordingRepository: recordingRepository)
+
         // Given
         await recordingRepository.expectStartRecording(callCount: 0)
 

--- a/Domain/Tests/UseCases/VoiceRecords/StartRecordingUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceRecords/StartRecordingUseCaseTest.swift
@@ -88,7 +88,7 @@ extension StartRecordingUseCaseTest {
 // MARK: - 취소 케이스
 
 extension StartRecordingUseCaseTest {
-    func test_태스크취소상태_녹음시작시_cancelled에러를던진다() async throws {
+    func test_태스크취소상태_녹음시작시_cancelled에러를던진다() async {
         let recordingRepository = MockVoiceRecordStartRepository()
         let sut = DefaultStartRecordingUseCase(recordingRepository: recordingRepository)
 

--- a/Domain/Tests/UseCases/WasteBaskets/DeleteWasteBasketUseCaseTest.swift
+++ b/Domain/Tests/UseCases/WasteBaskets/DeleteWasteBasketUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class DeleteWasteBasketUseCaseTest: XCTestCase {
-    private var wasteBasketRepository: MockWasteBasketRepository!
-    private var sut: DefaultDeleteWasteBasketUseCase!
-
-    override func setUp() {
-        super.setUp()
-        wasteBasketRepository = MockWasteBasketRepository()
-        sut = DefaultDeleteWasteBasketUseCase(repository: wasteBasketRepository)
-    }
-
-    override func tearDown() {
-        wasteBasketRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class DeleteWasteBasketUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension DeleteWasteBasketUseCaseTest {
     func test_정상상태_휴지통비우기시_리포지토리의비우기메서드를호출한다() async throws {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultDeleteWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         await wasteBasketRepository.setDeleteResult(.success(()))
         await wasteBasketRepository.expectAllClear(callCount: 1)
@@ -35,6 +23,9 @@ extension DeleteWasteBasketUseCaseTest {
     }
 
     func test_정상상태_휴지통다중삭제시_리포지토리의다중삭제메서드를호출한다() async throws {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultDeleteWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         let items: [WasteBasketItem] = [
             .folder(id: UUID()),
@@ -51,6 +42,9 @@ extension DeleteWasteBasketUseCaseTest {
     }
 
     func test_정상상태_휴지통단일삭제시_리포지토리의단일삭제메서드를호출한다() async throws {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultDeleteWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         let item: WasteBasketItem = .folder(id: UUID())
         await wasteBasketRepository.setDeleteResult(.success(()))
@@ -68,6 +62,9 @@ extension DeleteWasteBasketUseCaseTest {
 
 extension DeleteWasteBasketUseCaseTest {
     func test_리포지토리비우기실패상태_휴지통비우기시_deleteFailed에러를던진다() async {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultDeleteWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         let method = DeleteWasteBasketMethod.all
         await wasteBasketRepository.setDeleteResult(.failure(.deleteFailed(method)))
@@ -87,6 +84,9 @@ extension DeleteWasteBasketUseCaseTest {
     }
 
     func test_리포지토리단일삭제실패상태_휴지통단일삭제시_deleteFailed에러를던진다() async {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultDeleteWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         let item = WasteBasketItem.folder(id: UUID())
         let method = DeleteWasteBasketMethod.single(item: item)
@@ -107,6 +107,9 @@ extension DeleteWasteBasketUseCaseTest {
     }
 
     func test_리포지토리다중삭제실패상태_휴지통다중삭제시_deleteFailed에러를던진다() async {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultDeleteWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         let items: [WasteBasketItem] = [.folder(id: UUID())]
         let method = DeleteWasteBasketMethod.multiple(items: items)
@@ -127,6 +130,9 @@ extension DeleteWasteBasketUseCaseTest {
     }
 
     func test_리포지토리알수없는에러상태_휴지통삭제시_unknown에러를던진다() async {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultDeleteWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         struct DummyError: Error {}
         let expectedError = DummyError()
@@ -151,6 +157,9 @@ extension DeleteWasteBasketUseCaseTest {
 
 extension DeleteWasteBasketUseCaseTest {
     func test_작업취소상태_휴지통삭제시_cancelled에러를던진다() async {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultDeleteWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         await wasteBasketRepository.setDeleteResult(.failure(.cancelled))
         await wasteBasketRepository.expectAllClear(callCount: 1)
@@ -168,9 +177,9 @@ extension DeleteWasteBasketUseCaseTest {
     }
 
     func test_태스크이미취소상태_휴지통삭제시_즉시cancelled에러를던진다() async {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultDeleteWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         await wasteBasketRepository.setDeleteResult(.success(()))
         await wasteBasketRepository.expectAllClear(callCount: 0)

--- a/Domain/Tests/UseCases/WasteBaskets/FetchWasteBasketFolderUseCaseTest.swift
+++ b/Domain/Tests/UseCases/WasteBaskets/FetchWasteBasketFolderUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class FetchWasteBasketFolderUseCaseTest: XCTestCase {
-    private var wasteBasketRepository: MockWasteBasketRepository!
-    private var sut: DefaultFetchWasteBasketFolderUseCase!
-
-    override func setUp() {
-        super.setUp()
-        wasteBasketRepository = MockWasteBasketRepository()
-        sut = DefaultFetchWasteBasketFolderUseCase(repository: wasteBasketRepository)
-    }
-
-    override func tearDown() {
-        wasteBasketRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class FetchWasteBasketFolderUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension FetchWasteBasketFolderUseCaseTest {
     func test_정상상태_휴지통항목조회시_전체항목목록을반환한다() async throws {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultFetchWasteBasketFolderUseCase(repository: wasteBasketRepository)
+
         // Given
         let expectedItems: [WasteBasketItem] = [
             .folder(id: UUID()),
@@ -40,6 +28,9 @@ extension FetchWasteBasketFolderUseCaseTest {
     }
 
     func test_데이터미존재상태_휴지통항목조회시_빈배열을반환한다() async throws {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultFetchWasteBasketFolderUseCase(repository: wasteBasketRepository)
+
         // Given
         await wasteBasketRepository.setFetchAllResult(.success([]))
         await wasteBasketRepository.expectFetchAll(callCount: 1)
@@ -57,6 +48,9 @@ extension FetchWasteBasketFolderUseCaseTest {
 
 extension FetchWasteBasketFolderUseCaseTest {
     func test_리포지토리조회실패상태_휴지통항목조회시_fetchFailed에러를던진다() async {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultFetchWasteBasketFolderUseCase(repository: wasteBasketRepository)
+
         // Given
         await wasteBasketRepository.setFetchAllResult(.failure(.fetchFailed))
         await wasteBasketRepository.expectFetchAll(callCount: 1)
@@ -76,6 +70,9 @@ extension FetchWasteBasketFolderUseCaseTest {
     }
 
     func test_리포지토리알수없는에러상태_휴지통항목조회시_unknown에러를던진다() async {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultFetchWasteBasketFolderUseCase(repository: wasteBasketRepository)
+
         // Given
         struct DummyError: Error {}
         let expectedError = DummyError()
@@ -103,6 +100,9 @@ extension FetchWasteBasketFolderUseCaseTest {
 
 extension FetchWasteBasketFolderUseCaseTest {
     func test_작업취소상태_휴지통항목조회시_cancelled에러를던진다() async {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultFetchWasteBasketFolderUseCase(repository: wasteBasketRepository)
+
         // Given
         await wasteBasketRepository.setFetchAllResult(.failure(.cancelled))
         await wasteBasketRepository.expectFetchAll(callCount: 1)
@@ -122,9 +122,9 @@ extension FetchWasteBasketFolderUseCaseTest {
     }
 
     func test_태스크이미취소상태_휴지통항목조회시_즉시cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultFetchWasteBasketFolderUseCase(repository: wasteBasketRepository)
+
         // Given
         await wasteBasketRepository.setFetchAllResult(.success([]))
         await wasteBasketRepository.expectFetchAll(callCount: 0)

--- a/Domain/Tests/UseCases/WasteBaskets/FetchWasteBasketFolderUseCaseTest.swift
+++ b/Domain/Tests/UseCases/WasteBaskets/FetchWasteBasketFolderUseCaseTest.swift
@@ -121,7 +121,7 @@ extension FetchWasteBasketFolderUseCaseTest {
         await wasteBasketRepository.verify()
     }
 
-    func test_태스크이미취소상태_휴지통항목조회시_즉시cancelled에러를던진다() async throws {
+    func test_태스크이미취소상태_휴지통항목조회시_즉시cancelled에러를던진다() async {
         let wasteBasketRepository = MockWasteBasketRepository()
         let sut = DefaultFetchWasteBasketFolderUseCase(repository: wasteBasketRepository)
 

--- a/Domain/Tests/UseCases/WasteBaskets/MoveWasteBasketUseCaseTest.swift
+++ b/Domain/Tests/UseCases/WasteBaskets/MoveWasteBasketUseCaseTest.swift
@@ -107,7 +107,7 @@ extension MoveWasteBasketUseCaseTest {
 // MARK: - 취소 케이스
 
 extension MoveWasteBasketUseCaseTest {
-    func test_태스크이미취소상태_항목을휴지통으로이동시_즉시cancelled에러를던진다() async throws {
+    func test_태스크이미취소상태_항목을휴지통으로이동시_즉시cancelled에러를던진다() async {
         let wasteBasketRepository = MockWasteBasketRepository()
         let sut = DefaultMoveWasteBasketUseCase(repository: wasteBasketRepository)
 

--- a/Domain/Tests/UseCases/WasteBaskets/MoveWasteBasketUseCaseTest.swift
+++ b/Domain/Tests/UseCases/WasteBaskets/MoveWasteBasketUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class MoveWasteBasketUseCaseTest: XCTestCase {
-    private var wasteBasketRepository: MockWasteBasketRepository!
-    private var sut: DefaultMoveWasteBasketUseCase!
-
-    override func setUp() {
-        super.setUp()
-        wasteBasketRepository = MockWasteBasketRepository()
-        sut = DefaultMoveWasteBasketUseCase(repository: wasteBasketRepository)
-    }
-
-    override func tearDown() {
-        wasteBasketRepository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class MoveWasteBasketUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension MoveWasteBasketUseCaseTest {
     func test_정상상태_항목을휴지통으로이동시_리포지토리의이동메서드를호출한다() async throws {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultMoveWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         let item: WasteBasketItem = .folder(id: UUID())
         await wasteBasketRepository.setMoveResult(.success(()))
@@ -40,6 +28,9 @@ extension MoveWasteBasketUseCaseTest {
 
 extension MoveWasteBasketUseCaseTest {
     func test_리포지토리이동실패상태_항목을휴지통으로이동시_moveFailed에러를던진다() async {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultMoveWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         let item: WasteBasketItem = .folder(id: UUID())
         let method = MoveWasteBasketMethod.single(item: item)
@@ -62,6 +53,9 @@ extension MoveWasteBasketUseCaseTest {
     }
 
     func test_리포지토리알수없는에러상태_항목을휴지통으로이동시_unknown에러를던진다() async {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultMoveWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         let item: WasteBasketItem = .folder(id: UUID())
         let method = MoveWasteBasketMethod.single(item: item)
@@ -86,6 +80,9 @@ extension MoveWasteBasketUseCaseTest {
     }
 
     func test_작업취소상태_항목을휴지통으로이동시_cancelled에러를던진다() async {
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultMoveWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         let item: WasteBasketItem = .folder(id: UUID())
         let method = MoveWasteBasketMethod.single(item: item)
@@ -111,9 +108,9 @@ extension MoveWasteBasketUseCaseTest {
 
 extension MoveWasteBasketUseCaseTest {
     func test_태스크이미취소상태_항목을휴지통으로이동시_즉시cancelled에러를던진다() async throws {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let wasteBasketRepository = MockWasteBasketRepository()
+        let sut = DefaultMoveWasteBasketUseCase(repository: wasteBasketRepository)
+
         // Given
         let item: WasteBasketItem = .folder(id: UUID())
         let method = MoveWasteBasketMethod.single(item: item)

--- a/Domain/Tests/UseCases/WorkSpace/FetchBasicFolderUseCaseTest.swift
+++ b/Domain/Tests/UseCases/WorkSpace/FetchBasicFolderUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class FetchBasicFolderUseCaseTest: XCTestCase {
-    private var repository: MockWorkSpaceRepository!
-    private var sut: DefaultFetchBasicFolderUseCase!
-
-    override func setUp() {
-        super.setUp()
-        repository = MockWorkSpaceRepository()
-        sut = DefaultFetchBasicFolderUseCase(repository: repository)
-    }
-
-    override func tearDown() {
-        repository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class FetchBasicFolderUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension FetchBasicFolderUseCaseTest {
     func test_정상상태_기본폴더조회시_기대하는Folder를반환한다() async throws {
+        let repository = MockWorkSpaceRepository()
+        let sut = DefaultFetchBasicFolderUseCase(repository: repository)
+
         // Given
         let expectedFolder = Folder(name: "Basic Folder")
         await repository.setBasicFolderResult(.success(expectedFolder))
@@ -42,6 +30,9 @@ extension FetchBasicFolderUseCaseTest {
 
 extension FetchBasicFolderUseCaseTest {
     func test_기본폴더미존재상태_기본폴더조회시_notFound에러를던진다() async {
+        let repository = MockWorkSpaceRepository()
+        let sut = DefaultFetchBasicFolderUseCase(repository: repository)
+
         // Given
         await repository.setBasicFolderResult(.failure(.notFound))
         await repository.expectFetchOrCreateBasicFolder(callCount: 1)
@@ -61,6 +52,9 @@ extension FetchBasicFolderUseCaseTest {
     }
 
     func test_폴더생성실패상태_기본폴더조회시_createFailed에러를던진다() async {
+        let repository = MockWorkSpaceRepository()
+        let sut = DefaultFetchBasicFolderUseCase(repository: repository)
+
         // Given
         await repository.setBasicFolderResult(.failure(.createFailed))
         await repository.expectFetchOrCreateBasicFolder(callCount: 1)
@@ -80,6 +74,9 @@ extension FetchBasicFolderUseCaseTest {
     }
 
     func test_알수없는에러발생상태_기본폴더조회시_unknown에러를던진다() async {
+        let repository = MockWorkSpaceRepository()
+        let sut = DefaultFetchBasicFolderUseCase(repository: repository)
+
         // Given
         struct DummyError: Error {}
         let dummyError = DummyError()
@@ -102,6 +99,9 @@ extension FetchBasicFolderUseCaseTest {
     }
 
     func test_조회중취소상태_기본폴더조회시_cancelled에러를던진다() async {
+        let repository = MockWorkSpaceRepository()
+        let sut = DefaultFetchBasicFolderUseCase(repository: repository)
+
         // Given
         await repository.setBasicFolderResult(.failure(.cancelled))
         await repository.expectFetchOrCreateBasicFolder(callCount: 1)
@@ -121,9 +121,9 @@ extension FetchBasicFolderUseCaseTest {
     }
 
     func test_태스크이미취소상태_기본폴더조회시_즉시cancelled에러를던진다() async {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let repository = MockWorkSpaceRepository()
+        let sut = DefaultFetchBasicFolderUseCase(repository: repository)
+
         // Given
         await repository.setBasicFolderResult(
             .success(Folder(name: "test"))

--- a/Domain/Tests/UseCases/WorkSpace/FetchRootUrlUseCaseTest.swift
+++ b/Domain/Tests/UseCases/WorkSpace/FetchRootUrlUseCaseTest.swift
@@ -2,27 +2,15 @@
 import Core
 import XCTest
 
-final class FetchRootUrlUseCaseTest: XCTestCase {
-    private var repository: MockWorkSpaceRepository!
-    private var sut: DefaultFetchRootUrlUseCase!
-
-    override func setUp() {
-        super.setUp()
-        repository = MockWorkSpaceRepository()
-        sut = DefaultFetchRootUrlUseCase(repository: repository)
-    }
-
-    override func tearDown() {
-        repository = nil
-        sut = nil
-        super.tearDown()
-    }
-}
+final class FetchRootUrlUseCaseTest: XCTestCase {}
 
 // MARK: - 성공 케이스
 
 extension FetchRootUrlUseCaseTest {
     func test_정상상태_루트URL조회시_기대하는URL을반환한다() async throws {
+        let repository = MockWorkSpaceRepository()
+        let sut = DefaultFetchRootUrlUseCase(repository: repository)
+
         // Given
         let expectedURL = URL.applicationSupportDirectory
         await repository.setRootURLResult(.success(expectedURL))
@@ -41,6 +29,9 @@ extension FetchRootUrlUseCaseTest {
 
 extension FetchRootUrlUseCaseTest {
     func test_알수없는에러발생상태_루트URL조회시_unknown에러를던진다() async {
+        let repository = MockWorkSpaceRepository()
+        let sut = DefaultFetchRootUrlUseCase(repository: repository)
+
         // Given
         struct DummyError: Error {}
         await repository.setRootURLResult(.failure(.unknown(DummyError())))
@@ -66,6 +57,9 @@ extension FetchRootUrlUseCaseTest {
 
 extension FetchRootUrlUseCaseTest {
     func test_조회중취소상태_루트URL조회시_cancelled에러를던진다() async {
+        let repository = MockWorkSpaceRepository()
+        let sut = DefaultFetchRootUrlUseCase(repository: repository)
+
         // Given
         await repository.setRootURLResult(.failure(.cancelled))
         await repository.expectFetchRootURL(callCount: 1)
@@ -85,9 +79,9 @@ extension FetchRootUrlUseCaseTest {
     }
 
     func test_태스크이미취소상태_루트URL조회시_즉시cancelled에러를던진다() async {
-        guard let sut else {
-            return XCTFail("sut가 초기화되지 않았습니다.")
-        }
+        let repository = MockWorkSpaceRepository()
+        let sut = DefaultFetchRootUrlUseCase(repository: repository)
+
         // Given
         let testURL: URL = .applicationSupportDirectory
         await repository.setRootURLResult(.success(testURL))


### PR DESCRIPTION
## ✨ 작업 요약
> 한 줄로 무엇을 추가/변경했는지

- Domain, Core 계층 테스트 코드의 `setUp`/`tearDown` 제거 및 로컬 `sut` 객체 생성 패턴 적용 (`Data` 계층 테스트 패턴과 일치)

## 📋 구체적인 내용
- 추가/변경된 동작:
  - 전역 스코프(`XCTestCase` 클래스 프로퍼티)로 선언되어 있던 `sut`와 `mock` 리포지토리 변수 제거
  - `setUp()`으로 인한 테스트 상태 공유를 제거하고 개별 테스트(`test_...`) 함수 내부에서 객체 라이프사이클을 생성·소멸하게 변경
  - 테스트 간 완전히 독립적인 실행을 통해 단위 테스트의 고립성 향상
  - `AppLoggerProtocolTests`(Core 계층)의 `MockLogger.reset()`을 각 테스트 내부로 이동
- 영향 받는 화면/모듈:
  - `DomainTests` 전반 리팩터링 처리 (Authority, VoiceRecords, VoiceNotes, Folders, WorkSpace, WasteBaskets, Languages 사용 예제 총 17개 파일)
  - `CoreTests` 리팩터링 처리 (`AppLoggerProtocolTests` 파일)

---

## 🔗 연관 이슈

- closed #123 

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
  - **테스트 메서드 내 지역 변수 인스턴스 초기화**
  - 기존 Data 계층의 테스트 코드 형식(각 메서드 내에서 `sut`, `repository` 초기화)을 Domain 및 Core 영역으로 일관되게 확장했습니다. 각 단위 테스트가 다른 테스트의 잔여 상태에 영향을 받지 않아 사이드 이펙트 우려를 가장 확실하게 차단합니다.
- **고려했다가 제외한 방식**
  - **`setUp` 및 `tearDown` 유지 방식**
  - 코드는 다소 간결해질 수 있으나, 비동기(`async`) 테스트가 복잡해질 때 공유 객체(mock)의 상태 오염 가능성과 가독성이 떨어지는 이슈가 있어 제외했습니다.

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [x] 정상 플로우 동작 확인 (`tuist test DomainTests`, `CoreTests` 모든 로컬 테스트 실행 및 100% 통과 확인)
- [x] 엣지 케이스 / 빈 값·에러 처리 확인 (의도 된 모든 에러 throw 로직 정상 동작)
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [ ] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성 (Data 계층의 테스트 구성과의 통일성 검토)
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- `sut` 인스턴스 및 Mock 객체 초기화가 각 테스트 메서드 내에서 적절히 이루어졌는지 확인 부탁드립니다.