### PR TITLE
전체 UseCase 테스트 할 수 있는 UITable을 구현합니다.

### DIFF
--- a/App/Sources/Sandbox/DefaultSandboxDependency.swift
+++ b/App/Sources/Sandbox/DefaultSandboxDependency.swift
@@ -1,0 +1,53 @@
+import Data
+import Domain
+import Presentation
+
+actor DefaultSandboxDependency: SandboxDependency {
+    // Authority
+    let checkFirstLaunchUseCase: any CheckFirstLaunchUseCase
+    let checkMicrophonePermissionUseCase: any CheckMicrophonePermissionUseCase
+    let checkSTTPermissionUseCase: any CheckSTTPermissionUseCase
+    let requestMicrophonePermissionUseCase: any RequestMicrophonePermissionUseCase
+    let requestSTTPermissionUseCase: any RequestSTTPermissionUseCase
+    // Language
+    let fetchLanguageUseCase: any FetchLanguageUseCase
+    let selectLanguageUseCase: any SelectLanguageUseCase
+    // Folder
+    let createFolderUseCase: any Domain.CreateFolderUseCase
+    let readFolderUseCase: any Domain.ReadFolderUseCase
+    let updateFolderUseCase: any Domain.UpdateFolderUseCase
+    // Recording
+    let startRecordingUseCase: any Domain.StartRecordingUseCase
+    let pauseRecordingUseCase: any Domain.PauseRecordingUseCase
+    let resumeRecordingUseCase: any Domain.ResumeRecordingUseCase
+
+    init(
+        checkFirstLaunchUseCase: any CheckFirstLaunchUseCase,
+        checkMicrophonePermissionUseCase: any CheckMicrophonePermissionUseCase,
+        checkSTTPermissionUseCase: any CheckSTTPermissionUseCase,
+        requestMicrophonePermissionUseCase: any RequestMicrophonePermissionUseCase,
+        requestSTTPermissionUseCase: any RequestSTTPermissionUseCase,
+        fetchLanguageUseCase: any FetchLanguageUseCase,
+        selectLanguageUseCase: any SelectLanguageUseCase,
+        createFolderUseCase: any Domain.CreateFolderUseCase,
+        readFolderUseCase: any Domain.ReadFolderUseCase,
+        updateFolderUseCase: any Domain.UpdateFolderUseCase,
+        startRecordingUseCase: any Domain.StartRecordingUseCase,
+        pauseRecordingUseCase: any Domain.PauseRecordingUseCase,
+        resumeRecordingUseCase: any Domain.ResumeRecordingUseCase
+    ) {
+        self.checkFirstLaunchUseCase = checkFirstLaunchUseCase
+        self.checkMicrophonePermissionUseCase = checkMicrophonePermissionUseCase
+        self.checkSTTPermissionUseCase = checkSTTPermissionUseCase
+        self.requestMicrophonePermissionUseCase = requestMicrophonePermissionUseCase
+        self.requestSTTPermissionUseCase = requestSTTPermissionUseCase
+        self.fetchLanguageUseCase = fetchLanguageUseCase
+        self.selectLanguageUseCase = selectLanguageUseCase
+        self.createFolderUseCase = createFolderUseCase
+        self.readFolderUseCase = readFolderUseCase
+        self.updateFolderUseCase = updateFolderUseCase
+        self.startRecordingUseCase = startRecordingUseCase
+        self.pauseRecordingUseCase = pauseRecordingUseCase
+        self.resumeRecordingUseCase = resumeRecordingUseCase
+    }
+}

--- a/App/Sources/Sandbox/DependencyProvider.swift
+++ b/App/Sources/Sandbox/DependencyProvider.swift
@@ -1,0 +1,123 @@
+import Core
+import Data
+import Domain
+import Foundation
+import Presentation
+
+public actor DependencyProvider {
+    /// 모든 UseCase
+    private var dependency: SandboxDependency?
+    // infrastructure
+    private var audioService: AudioRecorderService?
+    private var folderDB: CoreDataLocalDataBase<FolderEntity>?
+    private var firstlaunchService: FirstLaunchService?
+    private var microphonePermissionService: MicrophonePermissionService?
+    private var sttPermissionService: STTPermissionService?
+    private var languageService: LanguageService?
+    // repository
+    private var checkFirstLaunchRepository: CheckFirstLaunchRepository?
+    private var microphonePermissionRepository: MicrophonePermissionRepository?
+    private var sttPermissionRepository: STTPermissionRepository?
+    private var languageRepository: LanguageRepository?
+    private var folderRepository: FolderRepository?
+
+    private var recordStartRepository: VoiceRecordStartRepository?
+    private var recordPauseRepository: VoiceRecordPauseRepository?
+    private var recordResumeRepository: VoiceRecordResumeRepository?
+
+    public init() {}
+
+    /// 의존성을 안전하게 가져오는 헬퍼. 없으면 생성 후 반환.
+    public func getDependency() async -> SandboxDependency? {
+        if dependency == nil {
+            await makeDependency()
+        }
+        return dependency
+    }
+}
+
+// MARK: - 내부 은닉화된 함수들
+
+extension DependencyProvider {
+    /// 실 구현에 필요한 InfraStructure 주입
+    private func makeInfrastructure() async throws {
+        folderDB = try await CoreDataLocalDataBase<FolderEntity>(inMemory: true)
+        audioService = AudioService()
+        firstlaunchService = DefaultFirstLaunchService()
+        microphonePermissionService = AudioService()
+        sttPermissionService = SpeechService()
+        languageService = LanguageSettingService()
+    }
+
+    /// 리포지토리 만드는 함수
+    private func makeRepository() async throws {
+        guard
+            let folderDB,
+            let audioService,
+            let firstlaunchService,
+            let microphonePermissionService,
+            let sttPermissionService,
+            let languageService
+        else {
+            throw NSError(domain: "리포지토리를 못 만들었습니다.", code: -1)
+        }
+        checkFirstLaunchRepository = DefaultCheckFirstLaunchRepository(service: firstlaunchService)
+        microphonePermissionRepository = DefaultMicrophonePermissionRepository(service: microphonePermissionService)
+        sttPermissionRepository = DefaultSTTPermissionRepository(service: sttPermissionService)
+        languageRepository = DefaultLanguageRepository(service: languageService)
+        folderRepository = DefaultFolderRepository(database: folderDB)
+        recordStartRepository = DefaultVoiceRecordStartRepository(service: audioService)
+        recordPauseRepository = DefaultVoiceRecordPauseRepository(service: audioService)
+        recordResumeRepository = DefaultVoiceRecordResumeRepository(service: audioService)
+    }
+
+    /// 외부에서 의존성 주입을 트리거하는 함수
+    private func makeDependency() async {
+        do {
+            // infrastructure 주입
+            try await makeInfrastructure()
+            // 리포지토리 주입
+            try await makeRepository()
+            // dependency 생성
+            guard let checkFirstLaunchRepository,
+                  let microphonePermissionRepository,
+                  let sttPermissionRepository,
+                  let languageRepository,
+                  let folderRepository,
+                  let recordStartRepository,
+                  let recordPauseRepository,
+                  let recordResumeRepository
+            else {
+                throw NSError(domain: "의존성 생성에 필요한 리포지토리가 없습니다.", code: -2)
+            }
+
+            dependency = DefaultSandboxDependency(
+                checkFirstLaunchUseCase: DefaultCheckFirstLaunchUseCase(
+                    repository: checkFirstLaunchRepository
+                ),
+                checkMicrophonePermissionUseCase: DefaultCheckMicrophonePermissionUseCase(
+                    repository: microphonePermissionRepository
+                ),
+                checkSTTPermissionUseCase: DefaultCheckSTTPermissionUseCase(
+                    repository: sttPermissionRepository
+                ),
+                requestMicrophonePermissionUseCase: DefaultRequestMicrophonePermissionUseCase(
+                    repository: microphonePermissionRepository
+                ),
+                requestSTTPermissionUseCase: DefaultRequestSTTPermissionUseCase(
+                    repository: sttPermissionRepository
+                ),
+                fetchLanguageUseCase: DefaultFetchLanguageUseCase(repository: languageRepository),
+                selectLanguageUseCase: DefaultSelectLanguageUseCase(repository: languageRepository),
+                createFolderUseCase: DefaultCreateFolderUseCase(repository: folderRepository),
+                readFolderUseCase: DefaultReadFolderUseCase(repository: folderRepository),
+                updateFolderUseCase: DefaultUpdateFolderUseCase(repository: folderRepository),
+                startRecordingUseCase: DefaultStartRecordingUseCase(recordingRepository: recordStartRepository),
+                pauseRecordingUseCase: DefaultPauseRecordingUseCase(recordingRepository: recordPauseRepository),
+                resumeRecordingUseCase: DefaultResumeRecordingUseCase(recordingRepository: recordResumeRepository)
+            )
+        } catch {
+            AppLogger.error(error)
+        }
+    }
+}

--- a/App/Sources/SceneDelegate.swift
+++ b/App/Sources/SceneDelegate.swift
@@ -1,7 +1,11 @@
+import Data
+import Domain
 import Presentation
 import UIKit
 
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    private var dependency: SandboxDependency?
+
     var window: UIWindow?
 
     func scene(
@@ -10,9 +14,18 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         options connectionOptions: UIScene.ConnectionOptions
     ) {
         guard let windowScene = scene as? UIWindowScene else { return }
+        let window = UIWindow(windowScene: windowScene)
+        self.window = window
+        window.makeKeyAndVisible()
 
-        window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = ContentViewController()
-        window?.makeKeyAndVisible()
+        Task {
+            let provider: DependencyProvider = .init()
+            guard let dependency: SandboxDependency = await provider.getDependency() else {
+                fatalError("dependency가 생성이 되지 않았습니다!!")
+            }
+            window.rootViewController = SandBoxTestViewController(
+                dependency: dependency
+            )
+        }
     }
 }

--- a/Data/Sources/Infrastructure/OnBoarding/DefaultFirstLaunchService.swift
+++ b/Data/Sources/Infrastructure/OnBoarding/DefaultFirstLaunchService.swift
@@ -2,6 +2,8 @@ import Domain
 import Foundation
 
 public final class DefaultFirstLaunchService: FirstLaunchService {
+    public init() {}
+
     public func markAsLaunched() {
         UserDefaults.standard.set(true, forKey: Policy.isExistingUserKey)
     }

--- a/Presentation/Sources/Sandbox/SandboxDependency.swift
+++ b/Presentation/Sources/Sandbox/SandboxDependency.swift
@@ -1,0 +1,33 @@
+import Domain
+import Foundation
+
+/// Sandbox UI에서 테스트할 UseCase들을 주입받기 위한 프로토콜입니다.
+/// App 레이어의 Dependency Injection 단계에서 실제 구현체 또는 Mock을 주입합니다.
+public protocol SandboxDependency: Sendable {
+    // WorkSpace (구현체 미 구현)
+
+    // Authority (Check , Request)
+    var checkFirstLaunchUseCase: CheckFirstLaunchUseCase { get }
+    var checkMicrophonePermissionUseCase: CheckMicrophonePermissionUseCase { get }
+    var checkSTTPermissionUseCase: CheckSTTPermissionUseCase { get }
+
+    var requestMicrophonePermissionUseCase: RequestMicrophonePermissionUseCase { get }
+    var requestSTTPermissionUseCase: RequestSTTPermissionUseCase { get }
+
+    // WasteBasket (구현체 미 구현)
+
+    // VoiceNote (구현체 미 구현)
+
+    // Language
+    var fetchLanguageUseCase: FetchLanguageUseCase { get }
+    var selectLanguageUseCase: SelectLanguageUseCase { get }
+    // Folders UseCase
+    var createFolderUseCase: CreateFolderUseCase { get }
+    var readFolderUseCase: ReadFolderUseCase { get }
+    var updateFolderUseCase: UpdateFolderUseCase { get }
+
+    // Recoding UseCase
+    var startRecordingUseCase: StartRecordingUseCase { get }
+    var pauseRecordingUseCase: PauseRecordingUseCase { get }
+    var resumeRecordingUseCase: ResumeRecordingUseCase { get }
+}

--- a/Presentation/Sources/Sandbox/SendBoxTestViewController.swift
+++ b/Presentation/Sources/Sandbox/SendBoxTestViewController.swift
@@ -1,0 +1,214 @@
+import Domain
+import UIKit
+
+/// UseCase 통합 테스트를 위한 샌드박스 목록 화면입니다.
+public final class SandBoxTestViewController: UIViewController {
+    private let dependency: SandboxDependency
+    private let tableView = UITableView(frame: .zero, style: .insetGrouped)
+    private var folder: Folder?
+
+    public init(dependency: SandboxDependency) {
+        self.dependency = dependency
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+
+    private func setupUI() {
+        title = "UseCase Sandbox"
+        view.backgroundColor = .systemGroupedBackground
+
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(UseCaseTestCell.self, forCellReuseIdentifier: UseCaseTestCell.identifier)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    private func runTestCase(_ item: TestItem) {
+        Task {
+            do {
+                let result = try await item.action(dependency)
+                await showAlert(title: "성공", message: result)
+            } catch {
+                await showAlert(title: "실패", message: "\(error)")
+            }
+        }
+    }
+
+    private func showAlert(title: String, message: String) async {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - Section 구조 (권한, 언어, 폴더, 녹음, 기타 등등 추가 가능)
+
+extension SandBoxTestViewController {
+    /// Category 분류
+    private enum Section: Int, CaseIterable {
+        case authority = 0
+        case language
+        case folders
+        case recording
+
+        var title: String {
+            switch self {
+            case .authority: return "권한"
+            case .language: return "언어"
+            case .folders: return "폴더"
+            case .recording: return "녹음"
+            }
+        }
+    }
+}
+
+// MARK: - Items 구조 (권한, 언어, 폴더, 녹음, 기타 등등 추가 가능)
+
+extension SandBoxTestViewController {
+    private struct TestItem {
+        let title: String
+        let action: (SandboxDependency) async throws -> String
+    }
+
+    private var authorityItems: [TestItem] {
+        [
+            TestItem(title: "첫 진입 여부 확인", action: { dep in
+                let result = dep.checkFirstLaunchUseCase.execute()
+                return "첫 진입 여부: \(result)"
+            }),
+            TestItem(title: "마이크 권한 상태 확인", action: { dep in
+                let status = try await dep.checkMicrophonePermissionUseCase.execute()
+                return "현재 상태: \(status)"
+            }),
+            TestItem(title: "마이크 권한 요청", action: { dep in
+                let status = try await dep.requestMicrophonePermissionUseCase.execute()
+                return "요청 결과: \(status)"
+            }),
+            TestItem(title: "STT 권한 상태 확인", action: { dep in
+                let status = try await dep.checkSTTPermissionUseCase.execute()
+                return "현재 상태: \(status)"
+            }),
+            TestItem(title: "STT 권한 요청", action: { dep in
+                let status = try await dep.requestSTTPermissionUseCase.execute()
+                return "요청 결과: \(status)"
+            })
+        ]
+    }
+
+    private var languageItems: [TestItem] {
+        [
+            TestItem(title: "현재 언어 설정 조회", action: { dep in
+                let lang = try await dep.fetchLanguageUseCase.execute()
+                return "현재 언어: \(lang)"
+            }),
+            TestItem(title: "언어 변경 (임시: EN)", action: { dep in
+                try await dep.selectLanguageUseCase.execute(lang: .en)
+                return "영어로 변경 완료"
+            }),
+            TestItem(title: "언어 변경 (임시: KO)", action: { dep in
+                try await dep.selectLanguageUseCase.execute(lang: .ko)
+                return "한국어로 변경 완료"
+            })
+        ]
+    }
+
+    private var folderItems: [TestItem] {
+        [
+            TestItem(title: "새 폴더 '테스트 폴더' 생성", action: { dep in
+                self.folder = try await dep.createFolderUseCase.execute(name: "테스트 폴더")
+                return "생성됨: \(self.folder!.name)"
+            }),
+
+            TestItem(title: "모든 폴더 목록 조회", action: { dep in
+                let folders = try await dep.readFolderUseCase.execute()
+                return "총 \(folders.count)개의 폴더 발견"
+            }),
+
+            TestItem(title: "새 폴더 '테스트 폴더' 수정", action: { dep in
+                let folder = try await dep.updateFolderUseCase.execute(self.folder!)
+                return "수정됨: \(folder.name)"
+            })
+        ]
+    }
+
+    private var recordingItems: [TestItem] {
+        [
+            TestItem(title: "녹음 시작 (Start)", action: { dep in
+                _ = try await dep.startRecordingUseCase.execute()
+                return "녹음 스트림 시작됨"
+            }),
+
+            TestItem(title: "녹음 중지 (Stop)", action: { dep in
+                try await dep.pauseRecordingUseCase.execute()
+                return "녹음 스트림 중지됨"
+            }),
+
+            TestItem(title: "녹음 재시작 (Resume)", action: { dep in
+                try await dep.resumeRecordingUseCase.execute()
+                return "녹음 스트림 재개됨"
+            })
+        ]
+    }
+}
+
+extension SandBoxTestViewController: UITableViewDataSource, UITableViewDelegate {
+    public func numberOfSections(in tableView: UITableView) -> Int {
+        return Section.allCases.count
+    }
+
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard let sectionType = Section(rawValue: section) else { return 0 }
+        switch sectionType {
+        case .authority: return authorityItems.count
+        case .language: return languageItems.count
+        case .folders: return folderItems.count
+        case .recording: return recordingItems.count
+        }
+    }
+
+    public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return Section(rawValue: section)?.title
+    }
+
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: UseCaseTestCell.identifier,
+            for: indexPath
+        ) as? UseCaseTestCell,
+            let sectionType = Section(rawValue: indexPath.section)
+        else {
+            return UITableViewCell()
+        }
+
+        let item: TestItem = switch sectionType {
+        case .authority: authorityItems[indexPath.row]
+        case .language: languageItems[indexPath.row]
+        case .folders: folderItems[indexPath.row]
+        case .recording: recordingItems[indexPath.row]
+        }
+
+        cell.configure(with: item.title)
+        cell.onRunTapped = { [weak self] in
+            self?.runTestCase(item)
+        }
+
+        return cell
+    }
+}

--- a/Presentation/Sources/Sandbox/UseCaseTestCell.swift
+++ b/Presentation/Sources/Sandbox/UseCaseTestCell.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+final class UseCaseTestCell: UITableViewCell {
+    static let identifier = "UseCaseTestCell"
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16, weight: .medium)
+        return label
+    }()
+
+    private let runButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("실행", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 14, weight: .bold)
+        button.backgroundColor = .systemBlue
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        return button
+    }()
+
+    var onRunTapped: (() -> Void)?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        runButton.translatesAutoresizingMaskIntoConstraints = false
+
+        runButton.addTarget(self, action: #selector(runTapped), for: .touchUpInside)
+
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(runButton)
+
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: runButton.leadingAnchor, constant: -8),
+
+            runButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            runButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            runButton.widthAnchor.constraint(equalToConstant: 60),
+            runButton.heightAnchor.constraint(equalToConstant: 32)
+        ])
+    }
+
+    func configure(with title: String) {
+        titleLabel.text = title
+    }
+
+    @objc
+    private func runTapped() {
+        onRunTapped?()
+    }
+}


### PR DESCRIPTION
## ✨ 작업 요약
> Sandbox UI 통합 테스트 환경 구축 및 UseCase 연동 완료

## 📋 구체적인 내용
- **추가/변경된 동작**:
    - **Sandbox UI 확장**: `SandBoxTestViewController`에 권한(Authority) 및 언어(Language) 섹션 추가. 총 13개의 UseCase 테스트 아이템 연동.
    - **의존성 주입 구조 개편**: `DependencyProvider` (actor)를 도입하여 인프라(CoreData, Audio, Speech) 및 리포지토리의 초기화 책임을 집중화.
    - **SandboxDependency 구현**: `DefaultSandboxDependency` (actor)를 통해 스레드 안전한 의존성 관리 및 주입 체계 마련.
    - **SceneDelegate 연동**: 앱 진입 시 `DependencyProvider`를 통해 샌드박스 환경을 자동으로 구성하도록 수정.
    - **DefaultFirstLaunchService 설정 누락**: public init 누락을 수정하였습니다.
    - **영향 받는 화면/모듈**:
    - `Presentation` (SandBoxTestViewController)
    - `App` (SceneDelegate, DependencyProvider, DefaultSandboxDependency)
---

## 연관 이슈
closed #134 

## 🧩 설계·구현 노트
- **선택한 방식**
    - `DependencyProvider` actor를 사용하여 비동기적으로 인프라를 초기화하고, `SandboxDependency` 프로토콜을 구현한 컨테이너를 UI에 전달하는 방식을 사용했습니다.
- **이유**
    - 샌드박스 환경은 In-memory CoreData 및 Mock/Real 혼합 설정이 필요하며, 초기화 순서가 복잡할 수 있어 이를 캡슐화하기 위함입니다.
    - `Presentation` 레이어는 구체적인 DI 로직을 알 필요 없이 프로토콜에만 의존하게 하여 결합도를 낮췄습니다.

---

## ✅ 확인 사항
- [x] 정상 플로우 동작 확인 (권한, 언어, 폴더, 녹음 섹션 별 테스트 실행)
- [x] 엣지 케이스 / 빈 값·에러 처리 확인 (Alert 창을 통한 결과 피드백 확인)
- [x] (로직 추가 시) 테스트 추가 여부 (Sandbox UI 자체가 통합 테스트의 역할을 수행함)

---

## 👀 리뷰 포인트
- [x] 설계·구조 적절성 (`DependencyProvider`의 역할 분담)
- [x] 로직·엣지 케이스 (UseCase 실행 시의 비동기 처리 및 에러 핸들링)
- [x] 예외/에러 핸들링 (Alert을 통한 사용자 피드백)
- [x] UI/UX (UITableView의 섹션 및 셀 구성)

**특히 봐줬으면 하는 부분**
- `DependencyProvider`에서 `MainActor`와 `Actor` 간의 상호작용이 적절한지 확인 부탁드립니다.
- `SelectLanguageUseCase` 등의 신규 연동 항목들이 의도대로 동작하는지 검토 부탁드립니다.

**참고**
- 전체 useCase가 적용되어 있지 않습니다..
- 아직 Infratructure가 정의 되지 않은 UseCase로 인해 주석 처리로 "미 구현" 추가해두었습니다
<img width="402" height="874" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-26 at 06 20 00" src="https://github.com/user-attachments/assets/6f040569-ecf7-41d9-84dc-914737b5f036" />
