### PR TITLE
CI/CD 브랜치 트리거 및 App Store 배포 워크플로우를 수정합니다.

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -2,7 +2,7 @@ name: Beta
 
 on:
   push:
-    branches: ["main"]
+    branches: ["dev"]
 
 jobs:
   beta:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,34 @@ permissions:
   pull-requests: read
 
 jobs:
-  release:
+  app-store:
+    name: Deploy to App Store
+    runs-on: macos-26
+    env:
+      TUIST_XDG_STATE_HOME: /tmp/tuist-state
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: jdx/mise-action@v4
+
+      - name: Tuist auth login
+        run: tuist auth login
+
+      - name: Tuist setup cache
+        run: tuist setup cache
+
+      - name: Deploy to App Store
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        run: bundle exec fastlane release
+
+  github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    needs: app-store
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## ✨ 작업 요약
> CI/CD 워크플로우의 브랜치 트리거와 App Store 배포 누락 문제를 수정합니다.

- `beta.yml` 트리거 브랜치: `main` → `dev`
- `release.yml`에 App Store 배포(`fastlane release`) job 추가
- `github-release` job이 App Store 배포 완료 후 실행되도록 `needs` 설정

## 📋 구체적인 내용
- 추가/변경된 동작:
  - `dev` push → TestFlight 베타 배포
  - `main` push → App Store 배포 → GitHub Release 생성
- 영향 받는 화면/모듈: CI/CD 워크플로우

---

## 🔗 연관 이슈

- closed #155

---

## 🧩 설계·구현 노트

- **선택한 방식**: `release.yml`에 `app-store` job을 추가하고 기존 `github-release` job이 `needs: app-store`로 순서를 보장
- **고려했다가 제외한 방식**: 별도 워크플로우 파일 분리 — 하나의 파일에서 배포 흐름을 관리하는 것이 가독성에 유리

---

## ✅ 확인 사항

- [ ] 정상 플로우 동작 확인
- [ ] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [ ] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [ ] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- `release.yml`의 `app-store` job 환경 설정이 `beta.yml`과 일관성 있는지

---

## 🗺 아키텍처 다이어그램

```mermaid
flowchart LR
    dev[dev push] --> beta[beta.yml]
    beta --> tf[TestFlight 배포]

    main[main push] --> release[release.yml]
    release --> as[app-store job\nfastlane release]
    as --> gr[github-release job\nGitHub Release 생성]
```