### PR TITLE
CI/CD 워크플로우 GitHub Actions 권한을 추가합니다.

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
   beta:

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["dev"]
 
+permissions:
+  id-token: write
+
 jobs:
   beta:
     runs-on: macos-26

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
 
 permissions:
+  id-token: write
   contents: write
   pull-requests: read
 


### PR DESCRIPTION
## ✨ 작업 요약
> CI/CD 워크플로우에 누락된 GitHub Actions 권한을 추가합니다.

- `beta.yml`, `release.yml`에 `permissions: id-token: write` 추가 (tuist auth login OIDC 인증)
- `beta.yml`에 `permissions: contents: read` 추가 (actions/checkout 동작)

## 📋 구체적인 내용
- 추가/변경된 동작:
  - `tuist auth login` 실패 문제 해결 (GitHub Actions OIDC 토큰 권한 누락)
  - `actions/checkout` 동작 보장 (`permissions` 명시 시 미지정 권한이 `none`으로 설정되는 문제)
- 영향 받는 화면/모듈: CI/CD 워크플로우 (beta, release)

---

## 🔗 연관 이슈

- closed #155

---

## 🧩 설계·구현 노트

- **선택한 방식**: workflow 레벨에서 `permissions` 블록 명시
- **고려했다가 제외한 방식**: job 레벨 권한 분리 — 각 job의 역할이 명확하지 않아 workflow 레벨로 통합

---

## ✅ 확인 사항

- [ ] 정상 플로우 동작 확인
- [ ] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [ ] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [ ] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- `release.yml`은 `github-release` job에서 `gh release create`를 사용하므로 `contents: write`가 이미 있어 별도 추가 불필요한 점

---

## 🗺 아키텍처 다이어그램

```mermaid
flowchart LR
    subgraph beta.yml
        B1[id-token: write\nOIDC 인증] --> B2[tuist auth login]
        B3[contents: read\ncheckout] --> B4[actions/checkout]
    end

    subgraph release.yml
        R1[id-token: write\nOIDC 인증] --> R2[tuist auth login]
        R3[contents: write\n기존 존재] --> R4[gh release create]
    end
```

---

## 📚 참고

- [GitHub Actions permissions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-can-do/assigning-permissions-to-jobs)