### PR TITLE
건너뛰기 동작 변경 및 코디네이터 패턴을 적용합니다.

### DIFF
--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -8,19 +8,17 @@ import UIKit
 /// 외부 라이브러리에 의존하지 않고 생성자 주입(Constructor Injection) 방식으로 객체를 조립합니다.
 @MainActor
 public final class AppDIContainer {
-    public static let shared = AppDIContainer()
-
     // 전역적으로 공유되어야 하는 네트워크 관련 객체 역이나 로컬 캐시, DB 레이어 등을 이곳에서 1번만 초기화하여 들고 있도록 구성할 수 있습니다.
     // 예: private lazy var networkService = DefaultNetworkService()
-
-    private init() {}
+    private lazy var store = UserDefaultsKeyValueStoreService()
+    public init() {}
 
     // MARK: - 온보딩 플로우 (Presentation)
 
     /// OnBoarding 화면을 시작할 때 호출될 Factory 메서드
-    public func makeOnBoardingViewController(onFinish: @escaping () -> Void) -> UIViewController {
+    public func makeOnBoardingViewController() -> OnBoardingViewController {
         // [1] InfraStructure (외부 환경/서비스)
-        let store = UserDefaultsKeyValueStoreService()
+
         let audioService = AudioService()
         let storageService = FileManagerStorageService()
 
@@ -30,6 +28,7 @@ public final class AppDIContainer {
             audioService: audioService,
             storageService: storageService
         )
+        let checkFirstLaunchRepository = DefaultCheckFirstLaunchRepository(store: store)
 
         // [3] UseCase (Domain Layer)
 
@@ -38,7 +37,7 @@ public final class AppDIContainer {
             DefaultCheckMicrophonePermissionUseCase(repository: voiceRecordRepository)
         let requestMicrophonePermissionUseCase =
             DefaultRequestMicrophonePermissionUseCase(repository: voiceRecordRepository)
-        let checkFirstLaunchUseCase = makeCheckFirstLaunchUseCase()
+        let checkFirstLaunchUseCase = DefaultCheckFirstLaunchUseCase(repository: checkFirstLaunchRepository)
 
         let viewModel = OnBoardingViewModel(
             selectLanguageUseCase: selectLanguageUseCase,
@@ -47,15 +46,12 @@ public final class AppDIContainer {
             checkFirstLaunchUseCase: checkFirstLaunchUseCase
         )
 
-        // viewModel에 클로저 주입
-        viewModel.onFinishOnBoarding = onFinish
-
         return OnBoardingViewController(vm: viewModel)
     }
 
     // MARK: - 메인 플로우
 
-    public func makeMainViewController() -> UIViewController {
+    public func makeMainViewController() -> MainViewController {
         // ContentViewController 생성에 필요한 DI
         return MainViewController()
     }
@@ -64,9 +60,10 @@ public final class AppDIContainer {
 public extension AppDIContainer {
     // MARK: - 공통 유즈케이스 (App)
 
-    func makeCheckFirstLaunchUseCase() -> CheckFirstLaunchUseCase {
-        let store = UserDefaultsKeyValueStoreService()
+    func checkFirstLaunchUser() -> Bool {
         let repository = DefaultCheckFirstLaunchRepository(store: store)
-        return DefaultCheckFirstLaunchUseCase(repository: repository)
+        let useCase = DefaultCheckFirstLaunchUseCase(repository: repository)
+
+        return useCase.checkIsFirstLaunch()
     }
 }

--- a/App/Sources/Coordinator/AppCoordinator.swift
+++ b/App/Sources/Coordinator/AppCoordinator.swift
@@ -1,0 +1,56 @@
+import Presentation
+import UIKit
+
+@MainActor
+final class AppCoordinator: BaseCoordinator<UINavigationController> {
+    let window: UIWindow
+    let dependencyContainer: AppDIContainer = .init()
+
+    init(window: UIWindow) {
+        self.window = window
+        let presenter = UINavigationController()
+        presenter.isToolbarHidden = true
+        presenter.isNavigationBarHidden = true
+
+        super.init(presenter: presenter)
+        self.window.rootViewController = presenter
+        self.window.makeKeyAndVisible()
+    }
+
+    override func start() {
+        let firstUser: Bool = dependencyContainer.checkFirstLaunchUser()
+        if firstUser {
+            startOnBoarding()
+        } else {
+            startMain()
+        }
+    }
+
+    private func startOnBoarding() {
+        let onBoardingVC = dependencyContainer.makeOnBoardingViewController()
+        onBoardingVC.vm.navDelegate = self
+        presenter.setViewControllers([onBoardingVC], animated: false)
+    }
+
+    private func startMain() {
+        let mainVC = dependencyContainer.makeMainViewController()
+        presenter.setViewControllers([mainVC], animated: false)
+    }
+}
+
+// MARK: - Navigation Delegate
+
+extension AppCoordinator: NavigationDelegate {
+    /// 온보딩 화면에서 메인 화면으로 넘어가는 Navigation 함수
+    func finishOnBoarding() {
+        startMain()
+
+        UIView.transition(
+            with: window,
+            duration: 0.3,
+            options: .transitionCrossDissolve,
+            animations: nil,
+            completion: nil
+        )
+    }
+}

--- a/App/Sources/Coordinator/AppCoordinator.swift
+++ b/App/Sources/Coordinator/AppCoordinator.swift
@@ -40,7 +40,7 @@ final class AppCoordinator: BaseCoordinator<UINavigationController> {
 
 // MARK: - Navigation Delegate
 
-extension AppCoordinator: NavigationDelegate {
+extension AppCoordinator: OnboardingCoordinatorDelegate {
     /// 온보딩 화면에서 메인 화면으로 넘어가는 Navigation 함수
     func finishOnBoarding() {
         startMain()

--- a/App/Sources/Coordinator/BaseCoordinator.swift
+++ b/App/Sources/Coordinator/BaseCoordinator.swift
@@ -1,0 +1,47 @@
+import UIKit
+
+@MainActor
+class BaseCoordinator<ControllerType: UIViewController>: Identifiable {
+    let id: UUID
+    private(set) var childCoordinators: [UUID: Any] = [:]
+    let presenter: ControllerType
+
+    init(id: UUID = UUID(), presenter: ControllerType) {
+        self.id = id
+        self.presenter = presenter
+    }
+
+    func start() {
+        preconditionFailure("Not implemented")
+    }
+}
+
+extension BaseCoordinator {
+    func store(coordinator: BaseCoordinator<some UIViewController>) {
+        let existCoordinator = childCoordinators.contains(where: { key, value -> Bool in
+            key == coordinator.id
+        })
+
+        if !existCoordinator {
+            childCoordinators[coordinator.id] = coordinator
+        }
+    }
+
+    func free(coordinator: BaseCoordinator<some UIViewController>) {
+        let existCoordinator = childCoordinators.contains(where: { key, value -> Bool in
+            key == coordinator.id
+        })
+
+        if existCoordinator {
+            childCoordinators[coordinator.id] = nil
+        }
+    }
+
+    func clearChildCoordinator() {
+        childCoordinators = [:]
+    }
+
+    func childCoordinator<T>(forKey key: UUID) -> T? {
+        return childCoordinators.first(where: { $0.key == key })?.value as? T
+    }
+}

--- a/App/Sources/SceneDelegate.swift
+++ b/App/Sources/SceneDelegate.swift
@@ -4,9 +4,7 @@ import Presentation
 import UIKit
 
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    var window: UIWindow?
-    /// DI 컨테이너를 공유 인스턴스로 사용합니다.
-    private let appDIContainer = AppDIContainer.shared
+    var appCoordinator: AppCoordinator!
 
     func scene(
         _ scene: UIScene,
@@ -15,26 +13,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let windowScene = scene as? UIWindowScene else { return }
         let window = UIWindow(windowScene: windowScene)
-        self.window = window
-
-        // DI Container를 통해 첫 실행 여부를 확인하고 진입 화면을 분기합니다.
-        let checkFirstLaunchUseCase = appDIContainer.makeCheckFirstLaunchUseCase()
-        let isFirstLaunch: Bool = checkFirstLaunchUseCase.checkIsFirstLaunch()
-
-        if isFirstLaunch {
-            window.rootViewController = appDIContainer.makeOnBoardingViewController(onFinish: { [
-                weak window
-            ] in
-                // 온보딩 완료 시 메인 뷰로 모드 전환
-                guard let window else { return }
-                window.rootViewController = AppDIContainer.shared.makeMainViewController()
-
-                UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve, animations: nil)
-            })
-        } else {
-            window.rootViewController = appDIContainer.makeMainViewController()
-        }
-
-        window.makeKeyAndVisible()
+        appCoordinator = .init(window: window)
+        appCoordinator.start()
     }
 }

--- a/Presentation/Sources/View/OnBoarding/OnBoardingViewController.swift
+++ b/Presentation/Sources/View/OnBoarding/OnBoardingViewController.swift
@@ -6,7 +6,7 @@ import UIKit
 public final class OnBoardingViewController: UIViewController {
     // MARK: - State
 
-    private let vm: OnBoardingViewModel
+    public let vm: OnBoardingViewModel
 
     public init(vm: OnBoardingViewModel) {
         self.vm = vm

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
@@ -4,7 +4,7 @@ import Foundation
 import Observation
 
 @MainActor
-public protocol NavigationDelegate: AnyObject {
+public protocol OnboardingCoordinatorDelegate: AnyObject {
     /// 온보딩 완료 시 화면 전환을 호출합니다.
     func finishOnBoarding()
 }
@@ -14,7 +14,7 @@ public protocol NavigationDelegate: AnyObject {
 public final class OnBoardingViewModel {
     // MARK: - Delegate
 
-    public weak var navDelegate: NavigationDelegate?
+    public weak var navDelegate: OnboardingCoordinatorDelegate?
 
     // MARK: - UseCase
 

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
@@ -3,9 +3,19 @@ import Domain
 import Foundation
 import Observation
 
+@MainActor
+public protocol NavigationDelegate: AnyObject {
+    /// 온보딩 완료 시 화면 전환을 호출합니다.
+    func finishOnBoarding()
+}
+
 @Observable
 @MainActor
 public final class OnBoardingViewModel {
+    // MARK: - Delegate
+
+    public weak var navDelegate: NavigationDelegate?
+
     // MARK: - UseCase
 
     let selectLanguageUseCase: SelectLanguageUseCase
@@ -26,10 +36,6 @@ public final class OnBoardingViewModel {
         self.requestMicrophonePermissionUseCase = requestMicrophonePermissionUseCase
         self.checkFirstLaunchUseCase = checkFirstLaunchUseCase
     }
-
-    // MARK: - Routing
-
-    public var onFinishOnBoarding: (() -> Void)?
 
     // MARK: - State
 
@@ -77,7 +83,11 @@ public final class OnBoardingViewModel {
     func getMaxIndex() -> Int {
         Step.allCases.count
     }
+}
 
+// MARK: - Button Actions
+
+extension OnBoardingViewModel {
     func primaryButtonAction(scrollAction: (Int) -> Void) {
         guard !isPaging else { return }
         switch currentStep {
@@ -86,7 +96,7 @@ public final class OnBoardingViewModel {
                 await finishOnBoarding()
                 _ = checkFirstLaunchUseCase.execute() // 기존 사용자 전환
                 // 모든 완료 작업이 끝났으므로 해당 클로저를 호출해 화면 전환을 알립니다.
-                onFinishOnBoarding?()
+                navDelegate?.finishOnBoarding()
             }
 
         default: // 다음
@@ -101,7 +111,7 @@ public final class OnBoardingViewModel {
         guard !isPaging else { return }
         switch currentStep {
         case .first: // 건너뛰기
-            let nextIndex = Step.finish.rawValue
+            let nextIndex = Step.micPermission.rawValue
             isPaging = true
             scrollAction(nextIndex)
         default: // 뒤로가기

--- a/Presentation/Tests/OnBoarding/OnBoardingViewModelTests.swift
+++ b/Presentation/Tests/OnBoarding/OnBoardingViewModelTests.swift
@@ -4,6 +4,17 @@ import DomainTests
 import XCTest
 
 @MainActor
+final class MockNavigationDelegate: NavigationDelegate {
+    var finishOnBoardingCalled = false
+    var finishOnBoardingExpectation: XCTestExpectation?
+
+    func finishOnBoarding() {
+        finishOnBoardingCalled = true
+        finishOnBoardingExpectation?.fulfill()
+    }
+}
+
+@MainActor
 final class OnBoardingViewModelTests: XCTestCase {
     // MARK: - Helpers
 
@@ -11,11 +22,13 @@ final class OnBoardingViewModelTests: XCTestCase {
         sut: OnBoardingViewModel,
         mockLanguageRepo: MockLanguageRepository,
         mockVoiceRecordRepo: MockVoiceRecordRepository,
-        mockCheckFirstLaunchRepo: MockCheckFirstLaunchRepository
+        mockCheckFirstLaunchRepo: MockCheckFirstLaunchRepository,
+        mockNavDelegate: MockNavigationDelegate
     ) {
         let mockLanguageRepo = MockLanguageRepository()
         let mockVoiceRecordRepo = MockVoiceRecordRepository()
         let mockCheckFirstLaunchRepo = MockCheckFirstLaunchRepository()
+        let mockNavDelegate = MockNavigationDelegate()
 
         let sut = OnBoardingViewModel(
             selectLanguageUseCase: DefaultSelectLanguageUseCase(repository: mockLanguageRepo),
@@ -27,14 +40,15 @@ final class OnBoardingViewModelTests: XCTestCase {
             ),
             checkFirstLaunchUseCase: DefaultCheckFirstLaunchUseCase(repository: mockCheckFirstLaunchRepo)
         )
+        sut.navDelegate = mockNavDelegate
 
-        return (sut, mockLanguageRepo, mockVoiceRecordRepo, mockCheckFirstLaunchRepo)
+        return (sut, mockLanguageRepo, mockVoiceRecordRepo, mockCheckFirstLaunchRepo, mockNavDelegate)
     }
 
     // MARK: - State Tests
 
     func test_뷰모델생성시_초기화된경우_초기값을확인한다() {
-        let (sut, _, _, _) = makeSUT()
+        let (sut, _, _, _, _) = makeSUT()
 
         XCTAssertEqual(sut.currentStep, .first)
         XCTAssertEqual(sut.steps.count, 4)
@@ -47,14 +61,14 @@ final class OnBoardingViewModelTests: XCTestCase {
     }
 
     func test_언어설정시_상태가_업데이트된다() {
-        let (sut, _, _, _) = makeSUT()
+        let (sut, _, _, _, _) = makeSUT()
 
         sut.setLanguage(.en)
         XCTAssertEqual(sut.language, .en)
     }
 
     func test_마지막스텝인경우_버튼타이틀과_상태가_변경된다() {
-        let (sut, _, _, _) = makeSUT()
+        let (sut, _, _, _, _) = makeSUT()
 
         sut.syncPageState(nextStep: Step.finish.rawValue) // 3
 
@@ -68,7 +82,7 @@ final class OnBoardingViewModelTests: XCTestCase {
     // MARK: - Action Tests
 
     func test_syncPageState호출시_마이크권한스텝이면_권한을_요청한다() async {
-        let (sut, _, mockVoiceRecordRepo, _) = makeSUT()
+        let (sut, _, mockVoiceRecordRepo, _, _) = makeSUT()
 
         await mockVoiceRecordRepo.setCheckPermissionResult(.success(.notDetermined))
         await mockVoiceRecordRepo.setRequestPermissionResult(.success(.authorized))
@@ -76,7 +90,7 @@ final class OnBoardingViewModelTests: XCTestCase {
         sut.syncPageState(nextStep: Step.micPermission.rawValue)
 
         // Task 내부 비동기 호출 대기 (안전하게 0.3초 대기)
-        try? await Task.sleep(nanoseconds: 500_000_000)
+        try? await Task.sleep(nanoseconds: 300_000_000)
 
         await mockVoiceRecordRepo.expectCheckPermission(callCount: 1)
         await mockVoiceRecordRepo.expectRequestPermission(callCount: 1)
@@ -84,7 +98,7 @@ final class OnBoardingViewModelTests: XCTestCase {
     }
 
     func test_primaryButtonAction_첫스텝에서_다음스텝으로_이동한다() {
-        let (sut, _, _, _) = makeSUT()
+        let (sut, _, _, _, _) = makeSUT()
 
         var scrolledIndex: Int?
         sut.primaryButtonAction { nextIndex in
@@ -95,25 +109,21 @@ final class OnBoardingViewModelTests: XCTestCase {
     }
 
     func test_primaryButtonAction_마지막스텝에서_온보딩을_완료하고_화면을_전환한다() async {
-        let (sut, mockLanguageRepo, _, mockCheckFirstLaunchRepo) = makeSUT()
+        let (sut, mockLanguageRepo, _, mockCheckFirstLaunchRepo, mockNavDelegate) = makeSUT()
 
         sut.syncPageState(nextStep: Step.finish.rawValue)
 
         await mockLanguageRepo.setSaveResult(.success(()))
         mockCheckFirstLaunchRepo.setReturnValue(true)
 
-        let expectation = XCTestExpectation(description: "onFinishOnBoarding 클로저 호출")
-        var isClosureCalled = false
-        sut.onFinishOnBoarding = {
-            isClosureCalled = true
-            expectation.fulfill()
-        }
+        let expectation = XCTestExpectation(description: "finishOnBoarding 호출")
+        mockNavDelegate.finishOnBoardingExpectation = expectation
 
         sut.primaryButtonAction { _ in }
 
         await fulfillment(of: [expectation], timeout: 1.0)
 
-        XCTAssertTrue(isClosureCalled)
+        XCTAssertTrue(mockNavDelegate.finishOnBoardingCalled)
 
         // 언어 저장 확인
         await mockLanguageRepo.expectSave(language: .ko, callCount: 1)
@@ -124,19 +134,19 @@ final class OnBoardingViewModelTests: XCTestCase {
         mockCheckFirstLaunchRepo.verify()
     }
 
-    func test_secondButtonAction_첫스텝에서_건너뛰기를_누르면_마지막스텝으로_이동한다() {
-        let (sut, _, _, _) = makeSUT()
+    func test_secondButtonAction_첫스텝에서_건너뛰기를_누르면_마이크권한화면으로_이동한다() {
+        let (sut, _, _, _, _) = makeSUT()
 
         var scrolledIndex: Int?
         sut.secondButtonAction { nextIndex in
             scrolledIndex = nextIndex
         }
 
-        XCTAssertEqual(scrolledIndex, Step.finish.rawValue)
+        XCTAssertEqual(scrolledIndex, Step.micPermission.rawValue)
     }
 
     func test_secondButtonAction_중간스텝에서_이전버튼을_누르면_이전스텝으로_이동한다() async {
-        let (sut, _, mockVoiceRecordRepo, _) = makeSUT()
+        let (sut, _, mockVoiceRecordRepo, _, _) = makeSUT()
 
         // Background Task가 실행되므로 미리 모의 객체(Mock) 응답을 세팅해 두어야 에러(미설정)가 나지 않습니다.
         await mockVoiceRecordRepo.setCheckPermissionResult(.success(.notDetermined))
@@ -145,7 +155,7 @@ final class OnBoardingViewModelTests: XCTestCase {
         sut.syncPageState(nextStep: Step.micPermission.rawValue)
 
         // 백그라운드 Task가 안전하게 완료될 수 있도록 약간의 딜레이 부여
-        try? await Task.sleep(nanoseconds: 500_000_000)
+        try? await Task.sleep(nanoseconds: 300_000_000)
 
         var scrolledIndex: Int?
         sut.secondButtonAction { nextIndex in

--- a/Presentation/Tests/OnBoarding/OnBoardingViewModelTests.swift
+++ b/Presentation/Tests/OnBoarding/OnBoardingViewModelTests.swift
@@ -4,7 +4,7 @@ import DomainTests
 import XCTest
 
 @MainActor
-final class MockNavigationDelegate: NavigationDelegate {
+final class MockNavigationDelegate: OnboardingCoordinatorDelegate {
     var finishOnBoardingCalled = false
     var finishOnBoardingExpectation: XCTestExpectation?
 


### PR DESCRIPTION
---

## ✨ 작업 요약
> 온보딩 화면 전환 로직을 Delegate 패턴으로 리팩토링하고 건너뛰기 동작을 수정했습니다.

## 📋 구체적인 내용
- 추가/변경된 동작:
    - `OnBoardingViewModel`의 화면 전환 로직을 클로저 방식에서 `NavigationDelegate` 패턴으로 변경 (Coordinator와의 결합도 해제)
    - 온보딩 '건너뛰기' 클릭 시, 마지막 페이지가 아닌 '마이크 권한 허용' 화면으로 바로 이동하도록 로직 수정
- 영향 받는 화면/모듈:
    - `Presentation` 모듈 (OnBoarding 플로우 관련 ViewModel 및 Test)

---

## 🔗 연관 이슈

- closed #154

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
    - `NavigationDelegate` 인터페이스를 통한 화면 전환 위임: ViewModel이 직접적인 Navigation 로직을 알 필요 없이 Coordinator에 처리를 맡길 수 있도록 설계했습니다.
    - `MockNavigationDelegate` 구현: 테스트 코드에서 비동기 화면 전환 함수가 정상적으로 호출되는지 `XCTestExpectation`을 활용해 검증하도록 개선했습니다.
- **고려했다가 제외한 방식**
    - 기존의 클로저 방식 유지: 코드량이 적고 간단하지만, Coordinator 패턴을 본격적으로 도입함에 따라 보다 명확한 인터페이스 정의를 위해 Delegate 패턴으로 선회했습니다.

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [x] 정상 플로우 동작 확인
- [x] 엣지 케이스 / 빈 값·에러 처리 확인
- [x] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [x] 로직·엣지 케이스
- [x] 예외/에러 핸들링

**특히 봐줬으면 하는 부분**
- 건너뛰기의 경우 마이크 권한 탭으로 이동이 맞는거 같습니다.
- `OnBoardingViewModel`에서 `navDelegate` 호출 부와  Coordinator의 의도와 잘 맞는지 확인 부탁드립니다.

---

## 📚 참고

- 없음