### PR TITLE
VoiceNote 생성/조회 및 휴지통 기능을 구현합니다.

### DIFF
--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -53,6 +53,9 @@ public final class AppDIContainer {
     private lazy var fetchVoiceNoteUseCase = DefaultFetchVoiceNoteUseCase(
         repository: voiceNoteFetchRepository
     )
+    private lazy var fetchRecentVoiceNoteUseCase = DefaultFetchRecentVoiceNoteUseCase(
+        repository: voiceNoteFetchRepository
+    )
     private lazy var fetchWasteBasketUseCase = DefaultFetchWasteBasketFolderUseCase(
         repository: wasteBasketRepository
     )
@@ -110,7 +113,8 @@ public final class AppDIContainer {
     public func makeMainViewModel() -> MainViewModel {
         return MainViewModel(
             fetchFolderUseCase: fetchFolderUseCase,
-            fetchVoiceNoteUseCase: fetchVoiceNoteUseCase
+            fetchVoiceNoteUseCase: fetchVoiceNoteUseCase,
+            fetchRecentVoiceNoteUseCase: fetchRecentVoiceNoteUseCase
         )
     }
 

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -53,6 +53,15 @@ public final class AppDIContainer {
     private lazy var fetchVoiceNoteUseCase = DefaultFetchVoiceNoteUseCase(
         repository: voiceNoteFetchRepository
     )
+    private lazy var fetchWasteBasketUseCase = DefaultFetchWasteBasketFolderUseCase(
+        repository: wasteBasketRepository
+    )
+    private lazy var deleteWasteBasketUseCase = DefaultDeleteWasteBasketUseCase(
+        repository: wasteBasketRepository
+    )
+    private lazy var moveWasteBasketUseCase = DefaultMoveWasteBasketUseCase(
+        repository: wasteBasketRepository
+    )
 
     public init() throws {
         localDataBase = try CoreDataLocalDataBase()

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -65,6 +65,9 @@ public final class AppDIContainer {
     private lazy var moveWasteBasketUseCase = DefaultMoveWasteBasketUseCase(
         repository: wasteBasketRepository
     )
+    private lazy var restoreWasteBasketUseCase = DefaultRestoreWasteBasketUseCase(
+        repository: wasteBasketRepository
+    )
 
     public init() throws {
         localDataBase = try CoreDataLocalDataBase()

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -129,7 +129,8 @@ public final class AppDIContainer {
         return FolderViewModel(
             category: category,
             createUseCase: createFolderUseCase,
-            updateUseCase: updateFolderUseCase
+            updateUseCase: updateFolderUseCase,
+            moveToTrashUseCase: moveWasteBasketUseCase
         )
     }
 }

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -25,6 +25,7 @@ public final class AppDIContainer {
     private lazy var folderRepository = DefaultFolderRepository(store: localDataBase)
     private lazy var voiceNoteCreateRepository = DefaultVoiceNoteCreateRepository(store: localDataBase)
     private lazy var voiceNoteFetchRepository = DefaultVoiceNoteFetchRepository(store: localDataBase)
+    private lazy var wasteBasketRepository = DefaultWasteBasketRepository(store: localDataBase)
 
     /// UseCase
     private lazy var selectLanguageUseCase = DefaultSelectLanguageUseCase(

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -121,6 +121,14 @@ public final class AppDIContainer {
         )
     }
 
+    public func makeTrashViewModel() -> TrashViewModel {
+        return TrashViewModel(
+            fetchUseCase: fetchWasteBasketUseCase,
+            deleteUseCase: deleteWasteBasketUseCase,
+            restoreUseCase: restoreWasteBasketUseCase
+        )
+    }
+
     public func makeTrashViewController() -> TrashViewController {
         return TrashViewController()
     }

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -23,6 +23,7 @@ public final class AppDIContainer {
     )
     private lazy var checkFirstLaunchRepository = DefaultCheckFirstLaunchRepository(store: store)
     private lazy var folderRepository = DefaultFolderRepository(store: localDataBase)
+    private lazy var voiceNoteCreateRepository = DefaultVoiceNoteCreateRepository(store: localDataBase)
 
     /// UseCase
     private lazy var selectLanguageUseCase = DefaultSelectLanguageUseCase(
@@ -43,6 +44,9 @@ public final class AppDIContainer {
     private lazy var updateFolderUseCase = DefaultUpdateFolderUseCase(repository: folderRepository)
     private lazy var createDefaultFolderUseCase = DefaultCreateDefaultFolderUseCase(
         repository: folderRepository
+    )
+    private lazy var createVoiceNoteUseCase = DefaultCreateVoiceNoteUseCase(
+        repository: voiceNoteCreateRepository
     )
 
     public init() throws {
@@ -84,7 +88,8 @@ public final class AppDIContainer {
             ),
             cancelRecordingUseCase: DefaultCancelRecordingUseCase(
                 recordingRepository: voiceRecordRepository
-            )
+            ),
+            createVoiceNoteUseCase: createVoiceNoteUseCase
         )
     }
 

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -24,6 +24,7 @@ public final class AppDIContainer {
     private lazy var checkFirstLaunchRepository = DefaultCheckFirstLaunchRepository(store: store)
     private lazy var folderRepository = DefaultFolderRepository(store: localDataBase)
     private lazy var voiceNoteCreateRepository = DefaultVoiceNoteCreateRepository(store: localDataBase)
+    private lazy var voiceNoteFetchRepository = DefaultVoiceNoteFetchRepository(store: localDataBase)
 
     /// UseCase
     private lazy var selectLanguageUseCase = DefaultSelectLanguageUseCase(
@@ -47,6 +48,9 @@ public final class AppDIContainer {
     )
     private lazy var createVoiceNoteUseCase = DefaultCreateVoiceNoteUseCase(
         repository: voiceNoteCreateRepository
+    )
+    private lazy var fetchVoiceNoteUseCase = DefaultFetchVoiceNoteUseCase(
+        repository: voiceNoteFetchRepository
     )
 
     public init() throws {
@@ -95,7 +99,8 @@ public final class AppDIContainer {
 
     public func makeMainViewModel() -> MainViewModel {
         return MainViewModel(
-            fetchFolderUseCase: fetchFolderUseCase
+            fetchFolderUseCase: fetchFolderUseCase,
+            fetchVoiceNoteUseCase: fetchVoiceNoteUseCase
         )
     }
 

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -30,7 +30,7 @@ extension MainCoordinator: RecordingCoordinating {
         presenter.dismiss(animated: true)
     }
 
-    func finishRecording(voiceRecord: VoiceRecord) {
+    func finishRecording(voiceNote: VoiceNote) {
         presenter.dismiss(animated: true)
     }
 }

--- a/Data/Sources/Repositories/VoiceNotes/DefaultVoiceNoteCreateRepository.swift
+++ b/Data/Sources/Repositories/VoiceNotes/DefaultVoiceNoteCreateRepository.swift
@@ -1,0 +1,36 @@
+import Core
+import Domain
+
+/// VoiceNote 생성 리포지토리 구현체.
+/// 항상 기본 폴더(`isDeletable: false`)에 음성 메모를 생성합니다.
+public struct DefaultVoiceNoteCreateRepository: VoiceNoteCreateRepository {
+    private let store: CoreDataLocalDataBase
+
+    public init(store: CoreDataLocalDataBase) {
+        self.store = store
+    }
+
+    public func create(_ voiceRecord: VoiceRecord) async throws(VoiceNoteCreateRepositoryError) -> VoiceNote {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            let folders = try await store.fetchAll(FolderEntity.self)
+
+            guard let defaultFolder = folders.first(where: { !$0.isDeletable }) else {
+                AppLogger.error(VoiceNoteCreateRepositoryError.createFailed)
+                throw VoiceNoteCreateRepositoryError.createFailed
+            }
+
+            let voiceNote = VoiceNote(
+                title: voiceRecord.audioFilePath.deletingPathExtension().lastPathComponent,
+                folderID: defaultFolder.id,
+                voiceRecord: voiceRecord
+            )
+
+            return try await store.create(voiceNote, as: VoiceNoteEntity.self)
+        } catch {
+            AppLogger.error(error)
+            throw .createFailed
+        }
+    }
+}

--- a/Data/Sources/Repositories/VoiceNotes/DefaultVoiceNoteFetchRepository.swift
+++ b/Data/Sources/Repositories/VoiceNotes/DefaultVoiceNoteFetchRepository.swift
@@ -1,0 +1,53 @@
+import Core
+import Domain
+import Foundation
+
+/// VoiceNote 조회 리포지토리 구현체.
+public struct DefaultVoiceNoteFetchRepository: VoiceNoteFetchRepository {
+    private let store: CoreDataLocalDataBase
+
+    public init(store: CoreDataLocalDataBase) {
+        self.store = store
+    }
+
+    public func fetchAllFromDefaultFolder() async throws(VoiceNoteFetchRepositoryError) -> [VoiceNote] {
+        if Task.isCancelled { throw .cancelled }
+
+        let folders: [Folder]
+        do {
+            folders = try await store.fetchAll(FolderEntity.self)
+        } catch {
+            AppLogger.error(error)
+            throw VoiceNoteFetchRepositoryError(error)
+        }
+
+        guard let defaultFolder = folders.first(where: { !$0.isDeletable }) else {
+            throw .defaultFolderNotFound
+        }
+
+        return try await fetchAll(folderID: defaultFolder.id)
+    }
+
+    public func fetchAll(folderID: UUID) async throws(VoiceNoteFetchRepositoryError) -> [VoiceNote] {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            return try await store.fetchAll(VoiceNoteEntity.self)
+                .filter { $0.folderID == folderID }
+        } catch {
+            AppLogger.error(error)
+            throw .fetchAllFailed(folderID: folderID)
+        }
+    }
+
+    public func fetch(byId id: UUID) async throws(VoiceNoteFetchRepositoryError) -> VoiceNote {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            return try await store.fetch(byID: id, as: VoiceNoteEntity.self)
+        } catch {
+            AppLogger.error(error)
+            throw .fetchFailed(id: id)
+        }
+    }
+}

--- a/Data/Sources/Repositories/VoiceNotes/DefaultVoiceNoteFetchRepository.swift
+++ b/Data/Sources/Repositories/VoiceNotes/DefaultVoiceNoteFetchRepository.swift
@@ -50,4 +50,19 @@ public struct DefaultVoiceNoteFetchRepository: VoiceNoteFetchRepository {
             throw .fetchFailed(id: id)
         }
     }
+
+    public func fetchRecent(limit: Int) async throws(VoiceNoteFetchRepositoryError) -> [VoiceNote] {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            return try await store.fetchAll(VoiceNoteEntity.self)
+                .filter { $0.deletedAt == nil }
+                .sorted { $0.createdAt > $1.createdAt }
+                .prefix(limit)
+                .map(\.self)
+        } catch {
+            AppLogger.error(error)
+            throw .fetchRecentFailed
+        }
+    }
 }

--- a/Data/Sources/Repositories/VoiceNotes/VoiceNoteFetchRepositoryError+Mapping.swift
+++ b/Data/Sources/Repositories/VoiceNotes/VoiceNoteFetchRepositoryError+Mapping.swift
@@ -1,0 +1,14 @@
+import Domain
+
+extension VoiceNoteFetchRepositoryError {
+    init(_ error: CoreDataStorageError) {
+        switch error {
+        case .fetchFailed:
+            self = .unknown(error)
+        case .fetchAllFailed:
+            self = .unknown(error)
+        default:
+            self = .unknown(error)
+        }
+    }
+}

--- a/Data/Sources/Repositories/WasteBasket/DefaultWasteBasketRepository.swift
+++ b/Data/Sources/Repositories/WasteBasket/DefaultWasteBasketRepository.swift
@@ -1,0 +1,171 @@
+import Core
+import Domain
+import Foundation
+
+/// 휴지통 리포지토리 구현체.
+/// Soft Delete(`deletedAt` 설정) 및 영구 삭제를 담당합니다.
+public struct DefaultWasteBasketRepository: WasteBasketRepository {
+    private let store: CoreDataLocalDataBase
+
+    public init(store: CoreDataLocalDataBase) {
+        self.store = store
+    }
+
+    // MARK: - Fetch
+
+    public func fetchAll() async throws(FetchWasteBasketRepositoryError) -> [WasteBasketItem] {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            async let voiceNoteItems = store.fetchAll(VoiceNoteEntity.self)
+                .filter { $0.deletedAt != nil }
+                .map { WasteBasketItem.voiceNote(id: $0.id) }
+
+            async let folderItems = store.fetchAll(FolderEntity.self)
+                .filter { $0.deletedAt != nil }
+                .map { WasteBasketItem.folder(id: $0.id) }
+
+            return try await voiceNoteItems + folderItems
+        } catch {
+            AppLogger.error(error)
+            throw FetchWasteBasketRepositoryError(error)
+        }
+    }
+
+    // MARK: - Delete
+
+    public func allClear() async throws(DeleteWasteBasketRepositoryError) {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            let voiceNotes = try await store.fetchAll(VoiceNoteEntity.self)
+                .filter { $0.deletedAt != nil }
+            for voiceNote in voiceNotes {
+                _ = try await store.delete(byID: voiceNote.id, as: VoiceNoteEntity.self)
+            }
+
+            let folders = try await store.fetchAll(FolderEntity.self)
+                .filter { $0.deletedAt != nil }
+            for folder in folders {
+                _ = try await store.delete(byID: folder.id, as: FolderEntity.self)
+            }
+        } catch {
+            AppLogger.error(error)
+            throw .deleteFailed(.all)
+        }
+    }
+
+    public func delete(item: WasteBasketItem) async throws(DeleteWasteBasketRepositoryError) {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            switch item {
+            case .voiceNote(let id):
+                _ = try await store.delete(byID: id, as: VoiceNoteEntity.self)
+            case .folder(let id):
+                _ = try await store.delete(byID: id, as: FolderEntity.self)
+            }
+        } catch {
+            AppLogger.error(error)
+            throw .deleteFailed(.single(item: item))
+        }
+    }
+
+    public func deleteAll(items: [WasteBasketItem]) async throws(DeleteWasteBasketRepositoryError) {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            for item in items {
+                switch item {
+                case .voiceNote(let id):
+                    _ = try await store.delete(byID: id, as: VoiceNoteEntity.self)
+                case .folder(let id):
+                    _ = try await store.delete(byID: id, as: FolderEntity.self)
+                }
+            }
+        } catch {
+            AppLogger.error(error)
+            throw .deleteFailed(.multiple(items: items))
+        }
+    }
+
+    // MARK: - Move
+
+    public func moveToWasteBasket(item: WasteBasketItem) async throws(MoveWasteBasketRepositoryError) {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            switch item {
+            case .voiceNote(let id):
+                let voiceNote = try await store.fetch(byID: id, as: VoiceNoteEntity.self)
+                let updated = VoiceNote(
+                    id: voiceNote.id,
+                    title: voiceNote.title,
+                    createdAt: voiceNote.createdAt,
+                    updatedAt: .now,
+                    folderID: voiceNote.folderID,
+                    voiceRecord: voiceNote.voiceRecord,
+                    keywords: voiceNote.keywords,
+                    transcript: voiceNote.transcript,
+                    summary: voiceNote.summary,
+                    deletedAt: .now
+                )
+                _ = try await store.update(updated, as: VoiceNoteEntity.self)
+
+            case .folder(let id):
+                let folder = try await store.fetch(byID: id, as: FolderEntity.self)
+                let updated = Folder(
+                    id: folder.id,
+                    name: folder.name,
+                    createdAt: folder.createdAt,
+                    isDeletable: folder.isDeletable,
+                    deletedAt: .now
+                )
+                _ = try await store.update(updated, as: FolderEntity.self)
+            }
+        } catch {
+            AppLogger.error(error)
+            throw .moveFailed(.single(item: item))
+        }
+    }
+
+    public func moveAllToWasteBasket(items: [WasteBasketItem]) async throws(MoveWasteBasketRepositoryError) {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            for item in items {
+                switch item {
+                case .voiceNote(let id):
+                    let voiceNote = try await store.fetch(byID: id, as: VoiceNoteEntity.self)
+                    let updated = VoiceNote(
+                        id: voiceNote.id,
+                        title: voiceNote.title,
+                        createdAt: voiceNote.createdAt,
+                        updatedAt: .now,
+                        folderID: voiceNote.folderID,
+                        voiceRecord: voiceNote.voiceRecord,
+                        keywords: voiceNote.keywords,
+                        transcript: voiceNote.transcript,
+                        summary: voiceNote.summary,
+                        deletedAt: .now
+                    )
+                    _ = try await store.update(updated, as: VoiceNoteEntity.self)
+
+                case .folder(let id):
+                    let folder = try await store.fetch(byID: id, as: FolderEntity.self)
+                    let updated = Folder(
+                        id: folder.id,
+                        name: folder.name,
+                        createdAt: folder.createdAt,
+                        isDeletable: folder.isDeletable,
+                        deletedAt: .now
+                    )
+                    _ = try await store.update(updated, as: FolderEntity.self)
+                }
+            }
+        } catch {
+            AppLogger.error(error)
+            throw .moveFailed(.multiple(items: items))
+        }
+    }
+}

--- a/Data/Sources/Repositories/WasteBasket/DefaultWasteBasketRepository.swift
+++ b/Data/Sources/Repositories/WasteBasket/DefaultWasteBasketRepository.swift
@@ -168,4 +168,84 @@ public struct DefaultWasteBasketRepository: WasteBasketRepository {
             throw .moveFailed(.multiple(items: items))
         }
     }
+
+    // MARK: - Restore
+
+    public func restore(item: WasteBasketItem) async throws(RestoreWasteBasketRepositoryError) {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            switch item {
+            case .voiceNote(let id):
+                let voiceNote = try await store.fetch(byID: id, as: VoiceNoteEntity.self)
+                let updated = VoiceNote(
+                    id: voiceNote.id,
+                    title: voiceNote.title,
+                    createdAt: voiceNote.createdAt,
+                    updatedAt: .now,
+                    folderID: voiceNote.folderID,
+                    voiceRecord: voiceNote.voiceRecord,
+                    keywords: voiceNote.keywords,
+                    transcript: voiceNote.transcript,
+                    summary: voiceNote.summary,
+                    deletedAt: nil
+                )
+                _ = try await store.update(updated, as: VoiceNoteEntity.self)
+
+            case .folder(let id):
+                let folder = try await store.fetch(byID: id, as: FolderEntity.self)
+                let updated = Folder(
+                    id: folder.id,
+                    name: folder.name,
+                    createdAt: folder.createdAt,
+                    isDeletable: folder.isDeletable,
+                    deletedAt: nil
+                )
+                _ = try await store.update(updated, as: FolderEntity.self)
+            }
+        } catch {
+            AppLogger.error(error)
+            throw .restoreFailed(.single(item: item))
+        }
+    }
+
+    public func restoreAll(items: [WasteBasketItem]) async throws(RestoreWasteBasketRepositoryError) {
+        if Task.isCancelled { throw .cancelled }
+
+        do {
+            for item in items {
+                switch item {
+                case .voiceNote(let id):
+                    let voiceNote = try await store.fetch(byID: id, as: VoiceNoteEntity.self)
+                    let updated = VoiceNote(
+                        id: voiceNote.id,
+                        title: voiceNote.title,
+                        createdAt: voiceNote.createdAt,
+                        updatedAt: .now,
+                        folderID: voiceNote.folderID,
+                        voiceRecord: voiceNote.voiceRecord,
+                        keywords: voiceNote.keywords,
+                        transcript: voiceNote.transcript,
+                        summary: voiceNote.summary,
+                        deletedAt: nil
+                    )
+                    _ = try await store.update(updated, as: VoiceNoteEntity.self)
+
+                case .folder(let id):
+                    let folder = try await store.fetch(byID: id, as: FolderEntity.self)
+                    let updated = Folder(
+                        id: folder.id,
+                        name: folder.name,
+                        createdAt: folder.createdAt,
+                        isDeletable: folder.isDeletable,
+                        deletedAt: nil
+                    )
+                    _ = try await store.update(updated, as: FolderEntity.self)
+                }
+            }
+        } catch {
+            AppLogger.error(error)
+            throw .restoreFailed(.multiple(items: items))
+        }
+    }
 }

--- a/Data/Sources/Repositories/WasteBasket/FetchWasteBasketRepositoryError+Mapping.swift
+++ b/Data/Sources/Repositories/WasteBasket/FetchWasteBasketRepositoryError+Mapping.swift
@@ -1,10 +1,7 @@
 import Domain
 
 extension FetchWasteBasketRepositoryError {
-    init(_ error: CoreDataStorageError) {
-        switch error {
-        default:
-            self = .fetchFailed
-        }
+    init(_ error: any Error) {
+        self = .fetchFailed
     }
 }

--- a/Data/Sources/Repositories/WasteBasket/FetchWasteBasketRepositoryError+Mapping.swift
+++ b/Data/Sources/Repositories/WasteBasket/FetchWasteBasketRepositoryError+Mapping.swift
@@ -1,0 +1,10 @@
+import Domain
+
+extension FetchWasteBasketRepositoryError {
+    init(_ error: CoreDataStorageError) {
+        switch error {
+        default:
+            self = .fetchFailed
+        }
+    }
+}

--- a/Domain/Sources/Entities/WasteBasketItem.swift
+++ b/Domain/Sources/Entities/WasteBasketItem.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum WasteBasketItem: Equatable, Sendable {
+public enum WasteBasketItem: Equatable, Hashable, Sendable {
     case folder(id: UUID)
     case voiceNote(id: UUID)
 }

--- a/Domain/Sources/Errors/VoiceNotes/Repositories/VoiceNoteFetchRepositoryError.swift
+++ b/Domain/Sources/Errors/VoiceNotes/Repositories/VoiceNoteFetchRepositoryError.swift
@@ -10,6 +10,8 @@ public enum VoiceNoteFetchRepositoryError: LocalizedError, Sendable {
     case fetchFailed(id: UUID)
     /// 기본 폴더를 찾을 수 없음.
     case defaultFolderNotFound
+    /// 최근 기록 조회 실패.
+    case fetchRecentFailed
     /// 취소됨.
     case cancelled
     /// 예측할 수 없는 오류.
@@ -19,6 +21,8 @@ public enum VoiceNoteFetchRepositoryError: LocalizedError, Sendable {
         switch self {
         case .fetchAllFailed:
             return "음성 메모 목록 조회에 실패했습니다."
+        case .fetchRecentFailed:
+            return "최근 기록 조회에 실패했습니다."
         case .defaultFolderNotFound:
             return "기본 폴더를 찾을 수 없습니다."
         case .recordNotFound:

--- a/Domain/Sources/Errors/VoiceNotes/Repositories/VoiceNoteFetchRepositoryError.swift
+++ b/Domain/Sources/Errors/VoiceNotes/Repositories/VoiceNoteFetchRepositoryError.swift
@@ -8,6 +8,8 @@ public enum VoiceNoteFetchRepositoryError: LocalizedError, Sendable {
     case recordNotFound(id: UUID)
     /// 단건 조회 실패.
     case fetchFailed(id: UUID)
+    /// 기본 폴더를 찾을 수 없음.
+    case defaultFolderNotFound
     /// 취소됨.
     case cancelled
     /// 예측할 수 없는 오류.
@@ -17,6 +19,8 @@ public enum VoiceNoteFetchRepositoryError: LocalizedError, Sendable {
         switch self {
         case .fetchAllFailed:
             return "음성 메모 목록 조회에 실패했습니다."
+        case .defaultFolderNotFound:
+            return "기본 폴더를 찾을 수 없습니다."
         case .recordNotFound:
             return "해당 음성 메모를 찾을 수 없습니다."
         case .fetchFailed:

--- a/Domain/Sources/Errors/VoiceNotes/UseCases/FetchRecentVoiceNoteUseCaseError.swift
+++ b/Domain/Sources/Errors/VoiceNotes/UseCases/FetchRecentVoiceNoteUseCaseError.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// 최근 기록 VoiceNote 조회 유스케이스에서 발생할 수 있는 에러.
+public enum FetchRecentVoiceNoteUseCaseError: LocalizedError, Sendable {
+    /// 취소됨.
+    case cancelled
+    /// 조회 실패.
+    case fetchFailed
+    /// 예측할 수 없는 오류.
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .cancelled:
+            return nil
+        case .fetchFailed:
+            return "최근 기록 조회에 실패했습니다."
+        case .unknown(let error):
+            return error.localizedDescription
+        }
+    }
+
+    init(_ error: VoiceNoteFetchRepositoryError) {
+        switch error {
+        case .cancelled:
+            self = .cancelled
+        case .fetchRecentFailed, .fetchAllFailed, .fetchFailed, .defaultFolderNotFound, .recordNotFound:
+            self = .fetchFailed
+        case .unknown(let error):
+            self = .unknown(error)
+        }
+    }
+}

--- a/Domain/Sources/Errors/VoiceNotes/UseCases/FetchVoiceNoteUseCaseError.swift
+++ b/Domain/Sources/Errors/VoiceNotes/UseCases/FetchVoiceNoteUseCaseError.swift
@@ -42,6 +42,8 @@ public enum FetchVoiceNoteUseCaseError: LocalizedError, Sendable {
             self = .fetchFailed(id: id)
         case .defaultFolderNotFound:
             self = .defaultFolderNotFound
+        case .fetchRecentFailed:
+            self = .unknown(VoiceNoteFetchRepositoryError.fetchRecentFailed)
         case .cancelled:
             self = .cancelled
         case .unknown(let error):

--- a/Domain/Sources/Errors/VoiceNotes/UseCases/FetchVoiceNoteUseCaseError.swift
+++ b/Domain/Sources/Errors/VoiceNotes/UseCases/FetchVoiceNoteUseCaseError.swift
@@ -8,6 +8,8 @@ public enum FetchVoiceNoteUseCaseError: LocalizedError, Sendable {
     case recordNotFound(id: UUID)
     /// 단건 조회 실패.
     case fetchFailed(id: UUID)
+    /// 기본 폴더를 찾을 수 없음.
+    case defaultFolderNotFound
     /// 취소됨.
     case cancelled
     /// 예측할 수 없는 오류.
@@ -17,6 +19,8 @@ public enum FetchVoiceNoteUseCaseError: LocalizedError, Sendable {
         switch self {
         case .fetchAllFailed:
             return "음성 메모 목록 조회에 실패했습니다."
+        case .defaultFolderNotFound:
+            return "기본 폴더를 찾을 수 없습니다."
         case .recordNotFound:
             return "해당 음성 메모를 찾을 수 없습니다."
         case .fetchFailed:
@@ -36,6 +40,8 @@ public enum FetchVoiceNoteUseCaseError: LocalizedError, Sendable {
             self = .recordNotFound(id: id)
         case .fetchFailed(let id):
             self = .fetchFailed(id: id)
+        case .defaultFolderNotFound:
+            self = .defaultFolderNotFound
         case .cancelled:
             self = .cancelled
         case .unknown(let error):

--- a/Domain/Sources/Errors/WasteBasket/Repositories/RestoreWasteBasketRepositoryError.swift
+++ b/Domain/Sources/Errors/WasteBasket/Repositories/RestoreWasteBasketRepositoryError.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public enum RestoreWasteBasketRepositoryError: LocalizedError, Sendable {
+    /// 사용자가 작업을 취소한 경우
+    case cancelled
+    /// 복원 실패
+    case restoreFailed(RestoreWasteBasketMethod)
+    /// 알 수 없는 오류 (내부 에러 포함)
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .cancelled:
+            return nil
+        case .restoreFailed(let method):
+            switch method {
+            case .single:
+                return "항목 복원에 실패했습니다."
+            case .multiple:
+                return "다수 항목 복원에 실패했습니다."
+            }
+        case .unknown(let error):
+            return error.localizedDescription
+        }
+    }
+}
+
+public enum RestoreWasteBasketMethod: Equatable, Sendable {
+    case single(item: WasteBasketItem)
+    case multiple(items: [WasteBasketItem])
+}

--- a/Domain/Sources/Errors/WasteBasket/UseCases/RestoreWasteBasketUseCaseError.swift
+++ b/Domain/Sources/Errors/WasteBasket/UseCases/RestoreWasteBasketUseCaseError.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// 휴지통 복원 유스케이스에서 발생할 수 있는 오류들을 정의합니다.
+public enum RestoreWasteBasketUseCaseError: LocalizedError, Sendable {
+    /// 사용자가 작업을 취소한 경우
+    case cancelled
+    /// 복원 실패
+    case restoreFailed(RestoreWasteBasketMethod)
+    /// 알 수 없는 에러 (내부 에러 포함)
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .cancelled:
+            return nil
+        case .restoreFailed(let method):
+            switch method {
+            case .single:
+                return "항목 복원에 실패했습니다."
+            case .multiple:
+                return "다수 항목 복원에 실패했습니다."
+            }
+        case .unknown(let error):
+            return error.localizedDescription
+        }
+    }
+
+    init(_ error: RestoreWasteBasketRepositoryError) {
+        switch error {
+        case .cancelled:
+            self = .cancelled
+        case .restoreFailed(let method):
+            self = .restoreFailed(method)
+        case .unknown(let error):
+            self = .unknown(error)
+        }
+    }
+}

--- a/Domain/Sources/Interfaces/VoiceNotes/VoiceNoteFetchRepository.swift
+++ b/Domain/Sources/Interfaces/VoiceNotes/VoiceNoteFetchRepository.swift
@@ -2,6 +2,11 @@ import Foundation
 
 /// 음성 메모 조회(목록/단건) 리포지토리 프로토콜.
 public protocol VoiceNoteFetchRepository: Sendable {
+    /// 기본 폴더의 모든 음성 메모를 조회합니다.
+    /// - Returns: 기본 폴더에 저장된 음성 메모 배열
+    /// - Throws: `VoiceNoteFetchRepositoryError.defaultFolderNotFound`, `.fetchAllFailed`
+    func fetchAllFromDefaultFolder() async throws(VoiceNoteFetchRepositoryError) -> [VoiceNote]
+
     /// 특정 폴더의 모든 음성 메모를 조회합니다.
     /// - Parameter folderID: 조회할 폴더의 ID
     /// - Returns: 조회된 음성 메모 배열

--- a/Domain/Sources/Interfaces/VoiceNotes/VoiceNoteFetchRepository.swift
+++ b/Domain/Sources/Interfaces/VoiceNotes/VoiceNoteFetchRepository.swift
@@ -18,4 +18,10 @@ public protocol VoiceNoteFetchRepository: Sendable {
     /// - Returns: 조회된 음성 메모 엔티티
     /// - Throws: `VoiceNoteFetchRepositoryError.recordNotFound`, `VoiceNoteFetchRepositoryError.fetchFailed`
     func fetch(byId id: UUID) async throws(VoiceNoteFetchRepositoryError) -> VoiceNote
+
+    /// 전체 폴더에서 최근 생성된 음성 메모를 조회합니다. (deletedAt이 없는 항목만, 생성일 내림차순)
+    /// - Parameter limit: 가져올 최대 개수
+    /// - Returns: 최근 생성된 음성 메모 배열
+    /// - Throws: `VoiceNoteFetchRepositoryError.fetchRecentFailed`
+    func fetchRecent(limit: Int) async throws(VoiceNoteFetchRepositoryError) -> [VoiceNote]
 }

--- a/Domain/Sources/Interfaces/WasteBasket/WasteBasketRepository.swift
+++ b/Domain/Sources/Interfaces/WasteBasket/WasteBasketRepository.swift
@@ -31,4 +31,14 @@ public protocol WasteBasketRepository: Sendable {
     /// - Returns: (Folder 또는 VoiceNote) 의 배열
     /// - Throws: 조회 실패 시
     func fetchAll() async throws(FetchWasteBasketRepositoryError) -> [WasteBasketItem]
+
+    /// 특정 항목을 휴지통에서 복원합니다. (deletedAt → nil)
+    /// - Parameter item: 복원할 휴지통 항목
+    /// - Throws: 복원 중 오류 발생 시
+    func restore(item: WasteBasketItem) async throws(RestoreWasteBasketRepositoryError)
+
+    /// 다수의 항목을 휴지통에서 복원합니다. (deletedAt → nil)
+    /// - Parameter items: 복원할 휴지통 항목 리스트
+    /// - Throws: 복원 중 오류 발생 시
+    func restoreAll(items: [WasteBasketItem]) async throws(RestoreWasteBasketRepositoryError)
 }

--- a/Domain/Sources/Policy.swift
+++ b/Domain/Sources/Policy.swift
@@ -24,4 +24,7 @@ public enum Policy {
 
     /// UI 파형 스트림의 최대 대기 개수 (초과 시 최신값 유지)
     public static let waveformStreamBufferLimit: Int = 8
+
+    /// 최근 기록 탭에서 표시할 최대 VoiceNote 개수
+    public static let recentVoiceNoteLimit: Int = 5
 }

--- a/Domain/Sources/UseCases/VoiceNotes/FetchRecentVoiceNoteUseCase.swift
+++ b/Domain/Sources/UseCases/VoiceNotes/FetchRecentVoiceNoteUseCase.swift
@@ -1,0 +1,28 @@
+import Core
+import Foundation
+
+/// 최근 기록 VoiceNote 조회 유스케이스 프로토콜.
+public protocol FetchRecentVoiceNoteUseCase: Sendable {
+    /// 전체 폴더에서 최근 생성된 VoiceNote를 조회합니다. (Policy.recentVoiceNoteLimit개 제한)
+    /// - Returns: 최근 생성된 `VoiceNote` 배열
+    /// - Throws: `FetchRecentVoiceNoteUseCaseError`
+    func execute() async throws(FetchRecentVoiceNoteUseCaseError) -> [VoiceNote]
+}
+
+public struct DefaultFetchRecentVoiceNoteUseCase: FetchRecentVoiceNoteUseCase {
+    private let repository: any VoiceNoteFetchRepository
+
+    public init(repository: any VoiceNoteFetchRepository) {
+        self.repository = repository
+    }
+
+    public func execute() async throws(FetchRecentVoiceNoteUseCaseError) -> [VoiceNote] {
+        if Task.isCancelled { throw .cancelled }
+        do {
+            return try await repository.fetchRecent(limit: Policy.recentVoiceNoteLimit)
+        } catch {
+            AppLogger.error(error)
+            throw FetchRecentVoiceNoteUseCaseError(error)
+        }
+    }
+}

--- a/Domain/Sources/UseCases/VoiceNotes/FetchVoiceNoteUseCase.swift
+++ b/Domain/Sources/UseCases/VoiceNotes/FetchVoiceNoteUseCase.swift
@@ -3,6 +3,11 @@ import Foundation
 
 /// 음성 메모 조회 유스케이스 프로토콜.
 public protocol FetchVoiceNoteUseCase: Sendable {
+    /// 기본 폴더의 모든 음성 메모를 조회합니다.
+    /// - Returns: 기본 폴더에 저장된 음성 메모 배열
+    /// - Throws: `FetchVoiceNoteUseCaseError`
+    func execute() async throws(FetchVoiceNoteUseCaseError) -> [VoiceNote]
+
     /// 특정 폴더의 모든 음성 메모를 조회합니다.
     /// - Parameter folderID: 조회할 폴더의 ID
     /// - Returns: 조회된 `VoiceNote` 배열
@@ -21,6 +26,16 @@ public struct DefaultFetchVoiceNoteUseCase: FetchVoiceNoteUseCase {
 
     public init(repository: VoiceNoteFetchRepository) {
         self.repository = repository
+    }
+
+    public func execute() async throws(FetchVoiceNoteUseCaseError) -> [VoiceNote] {
+        if Task.isCancelled { throw .cancelled }
+        do {
+            return try await repository.fetchAllFromDefaultFolder()
+        } catch {
+            AppLogger.error(error)
+            throw FetchVoiceNoteUseCaseError(error)
+        }
     }
 
     public func execute(folderID: UUID) async throws(FetchVoiceNoteUseCaseError) -> [VoiceNote] {

--- a/Domain/Sources/UseCases/WasteBaskets/DeleteWasteBasketUseCase.swift
+++ b/Domain/Sources/UseCases/WasteBaskets/DeleteWasteBasketUseCase.swift
@@ -10,9 +10,9 @@ public protocol DeleteWasteBasketUseCase: Sendable {
 }
 
 public struct DefaultDeleteWasteBasketUseCase: DeleteWasteBasketUseCase {
-    private let repository: WasteBasketRepository
+    private let repository: any WasteBasketRepository
 
-    public init(repository: WasteBasketRepository) {
+    public init(repository: any WasteBasketRepository) {
         self.repository = repository
     }
 

--- a/Domain/Sources/UseCases/WasteBaskets/FetchWasteBasketFolderUseCase.swift
+++ b/Domain/Sources/UseCases/WasteBaskets/FetchWasteBasketFolderUseCase.swift
@@ -11,9 +11,9 @@ public protocol FetchWasteBasketFolderUseCase: Sendable {
 }
 
 public struct DefaultFetchWasteBasketFolderUseCase: FetchWasteBasketFolderUseCase {
-    private let repository: WasteBasketRepository
+    private let repository: any WasteBasketRepository
 
-    public init(repository: WasteBasketRepository) {
+    public init(repository: any WasteBasketRepository) {
         self.repository = repository
     }
 

--- a/Domain/Sources/UseCases/WasteBaskets/MoveWasteBasketUseCase.swift
+++ b/Domain/Sources/UseCases/WasteBaskets/MoveWasteBasketUseCase.swift
@@ -10,9 +10,9 @@ public protocol MoveWasteBasketUseCase: Sendable {
 }
 
 public struct DefaultMoveWasteBasketUseCase: MoveWasteBasketUseCase {
-    private let repository: WasteBasketRepository
+    private let repository: any WasteBasketRepository
 
-    public init(repository: WasteBasketRepository) {
+    public init(repository: any WasteBasketRepository) {
         self.repository = repository
     }
 

--- a/Domain/Sources/UseCases/WasteBaskets/RestoreWasteBasketUseCase.swift
+++ b/Domain/Sources/UseCases/WasteBaskets/RestoreWasteBasketUseCase.swift
@@ -1,0 +1,33 @@
+import Core
+import Foundation
+
+/// 휴지통 항목 복원 유스케이스 프로토콜.
+public protocol RestoreWasteBasketUseCase: Sendable {
+    /// 복원 방식(개별, 다수)에 따라 deletedAt을 nil로 복원합니다.
+    /// - Parameter method: 복원 방식 (`RestoreWasteBasketMethod` 참조)
+    /// - Throws: 복원 실패 또는 작업 취소 시 (`RestoreWasteBasketUseCaseError`)
+    func execute(method: RestoreWasteBasketMethod) async throws(RestoreWasteBasketUseCaseError)
+}
+
+public struct DefaultRestoreWasteBasketUseCase: RestoreWasteBasketUseCase {
+    private let repository: any WasteBasketRepository
+
+    public init(repository: any WasteBasketRepository) {
+        self.repository = repository
+    }
+
+    public func execute(method: RestoreWasteBasketMethod) async throws(RestoreWasteBasketUseCaseError) {
+        if Task.isCancelled { throw .cancelled }
+        do {
+            switch method {
+            case .single(let item):
+                try await repository.restore(item: item)
+            case .multiple(let items):
+                try await repository.restoreAll(items: items)
+            }
+        } catch {
+            AppLogger.error(error)
+            throw RestoreWasteBasketUseCaseError(error)
+        }
+    }
+}

--- a/Domain/Tests/Entities/Stubs/VoiceNote+Stub.swift
+++ b/Domain/Tests/Entities/Stubs/VoiceNote+Stub.swift
@@ -1,7 +1,7 @@
 @testable import Domain
 import Foundation
 
-extension VoiceNote {
+public extension VoiceNote {
     static func stub(
         id: UUID = UUID(),
         title: String = "Test Voice Note",

--- a/Domain/Tests/Interfaces/Mocks/VoiceNote/MockVoiceNoteCreateRepository.swift
+++ b/Domain/Tests/Interfaces/Mocks/VoiceNote/MockVoiceNoteCreateRepository.swift
@@ -2,7 +2,7 @@
 import Foundation
 import XCTest
 
-actor MockVoiceNoteCreateRepository: VoiceNoteCreateRepository {
+public actor MockVoiceNoteCreateRepository: VoiceNoteCreateRepository {
     private var result: Result<VoiceNote, VoiceNoteCreateRepositoryError>?
 
     private var createCallCount = 0
@@ -11,16 +11,18 @@ actor MockVoiceNoteCreateRepository: VoiceNoteCreateRepository {
     private var expectedCreateCallCount: Int?
     private var expectedVoiceRecordID: UUID?
 
-    func setResult(_ result: Result<VoiceNote, VoiceNoteCreateRepositoryError>) {
+    public init() {}
+
+    public func setResult(_ result: Result<VoiceNote, VoiceNoteCreateRepositoryError>) {
         self.result = result
     }
 
-    func expectCreate(callCount: Int, voiceRecordID: UUID? = nil) {
+    public func expectCreate(callCount: Int, voiceRecordID: UUID? = nil) {
         expectedCreateCallCount = callCount
         expectedVoiceRecordID = voiceRecordID
     }
 
-    func verify(file: StaticString = #filePath, line: UInt = #line) {
+    public func verify(file: StaticString = #filePath, line: UInt = #line) {
         if let expected = expectedCreateCallCount {
             XCTAssertEqual(
                 createCallCount,
@@ -41,9 +43,7 @@ actor MockVoiceNoteCreateRepository: VoiceNoteCreateRepository {
         }
     }
 
-    func create(_ voiceRecord: VoiceRecord) async throws(VoiceNoteCreateRepositoryError)
-        -> VoiceNote
-    {
+    public func create(_ voiceRecord: VoiceRecord) async throws(VoiceNoteCreateRepositoryError) -> VoiceNote {
         createCallCount += 1
         actualVoiceRecord = voiceRecord
 

--- a/Domain/Tests/Interfaces/Mocks/VoiceNote/MockVoiceNoteFetchRepository.swift
+++ b/Domain/Tests/Interfaces/Mocks/VoiceNote/MockVoiceNoteFetchRepository.swift
@@ -5,6 +5,7 @@ import XCTest
 public actor MockVoiceNoteFetchRepository: VoiceNoteFetchRepository {
     private var fetchAllResult: Result<[VoiceNote], VoiceNoteFetchRepositoryError>?
     private var fetchByIdResult: Result<VoiceNote, VoiceNoteFetchRepositoryError>?
+    private var fetchRecentResult: Result<[VoiceNote], VoiceNoteFetchRepositoryError>?
 
     public init() {}
 
@@ -15,11 +16,15 @@ public actor MockVoiceNoteFetchRepository: VoiceNoteFetchRepository {
     private var actualFetchAllFolderID: UUID?
     private var fetchByIdCallCount = 0
     private var actualFetchByIdID: UUID?
+    private var fetchRecentCallCount = 0
+    private var actualFetchRecentLimit: Int?
 
     private var expectedFetchAllCallCount: Int?
     private var expectedFetchAllFolderID: UUID?
     private var expectedFetchByIdCallCount: Int?
     private var expectedFetchByIdID: UUID?
+    private var expectedFetchRecentCallCount: Int?
+    private var expectedFetchRecentLimit: Int?
 
     public func setFetchAllResult(_ result: Result<[VoiceNote], VoiceNoteFetchRepositoryError>) {
         fetchAllResult = result
@@ -27,6 +32,10 @@ public actor MockVoiceNoteFetchRepository: VoiceNoteFetchRepository {
 
     public func setFetchByIdResult(_ result: Result<VoiceNote, VoiceNoteFetchRepositoryError>) {
         fetchByIdResult = result
+    }
+
+    public func setFetchRecentResult(_ result: Result<[VoiceNote], VoiceNoteFetchRepositoryError>) {
+        fetchRecentResult = result
     }
 
     public func expectFetchAllFromDefaultFolder(callCount: Int) {
@@ -43,50 +52,64 @@ public actor MockVoiceNoteFetchRepository: VoiceNoteFetchRepository {
         expectedFetchByIdID = id
     }
 
+    public func expectFetchRecent(callCount: Int, limit: Int? = nil) {
+        expectedFetchRecentCallCount = callCount
+        expectedFetchRecentLimit = limit
+    }
+
     public func verify(file: StaticString = #filePath, line: UInt = #line) {
+        verifyFetchAll(file: file, line: line)
+        verifyFetchById(file: file, line: line)
+        verifyFetchRecent(file: file, line: line)
+    }
+
+    private func verifyFetchAll(file: StaticString, line: UInt) {
         if let expected = expectedDefaultFetchCallCount {
             XCTAssertEqual(
-                fetchAllFromDefaultFolderCallCount,
-                expected,
-                "기본 폴더 전체 조회 호출 횟수가 일치하지 않습니다.",
-                file: file,
-                line: line
+                fetchAllFromDefaultFolderCallCount, expected,
+                "기본 폴더 전체 조회 호출 횟수가 일치하지 않습니다.", file: file, line: line
             )
         }
         if let expected = expectedFetchAllCallCount {
             XCTAssertEqual(
-                fetchAllCallCount,
-                expected,
-                "전체 조회 호출 횟수가 일치하지 않습니다.",
-                file: file,
-                line: line
+                fetchAllCallCount, expected,
+                "전체 조회 호출 횟수가 일치하지 않습니다.", file: file, line: line
             )
         }
         if let expectedFolderID = expectedFetchAllFolderID {
             XCTAssertEqual(
-                actualFetchAllFolderID,
-                expectedFolderID,
-                "전체 조회 폴더 ID가 일치하지 않습니다.",
-                file: file,
-                line: line
+                actualFetchAllFolderID, expectedFolderID,
+                "전체 조회 폴더 ID가 일치하지 않습니다.", file: file, line: line
             )
         }
+    }
+
+    private func verifyFetchById(file: StaticString, line: UInt) {
         if let expected = expectedFetchByIdCallCount {
             XCTAssertEqual(
-                fetchByIdCallCount,
-                expected,
-                "ID별 조회 호출 횟수가 일치하지 않습니다.",
-                file: file,
-                line: line
+                fetchByIdCallCount, expected,
+                "ID별 조회 호출 횟수가 일치하지 않습니다.", file: file, line: line
             )
         }
         if let expectedID = expectedFetchByIdID {
             XCTAssertEqual(
-                actualFetchByIdID,
-                expectedID,
-                "ID별 조회 ID가 일치하지 않습니다.",
-                file: file,
-                line: line
+                actualFetchByIdID, expectedID,
+                "ID별 조회 ID가 일치하지 않습니다.", file: file, line: line
+            )
+        }
+    }
+
+    private func verifyFetchRecent(file: StaticString, line: UInt) {
+        if let expected = expectedFetchRecentCallCount {
+            XCTAssertEqual(
+                fetchRecentCallCount, expected,
+                "최근 기록 조회 호출 횟수가 일치하지 않습니다.", file: file, line: line
+            )
+        }
+        if let expectedLimit = expectedFetchRecentLimit {
+            XCTAssertEqual(
+                actualFetchRecentLimit, expectedLimit,
+                "최근 기록 조회 limit이 일치하지 않습니다.", file: file, line: line
             )
         }
     }
@@ -134,6 +157,21 @@ public actor MockVoiceNoteFetchRepository: VoiceNoteFetchRepository {
             throw .unknown(
                 NSError(domain: "MockVoiceNoteFetchRepository.fetchByIdResult", code: -1)
             )
+        }
+    }
+
+    public func fetchRecent(limit: Int) async throws(VoiceNoteFetchRepositoryError) -> [VoiceNote] {
+        fetchRecentCallCount += 1
+        actualFetchRecentLimit = limit
+
+        switch fetchRecentResult {
+        case .success(let success):
+            return success
+        case .failure(let failure):
+            throw failure
+        case .none:
+            XCTFail("MockVoiceNoteFetchRepository.fetchRecentResult 가 설정되지 않았습니다.")
+            throw .unknown(NSError(domain: "MockVoiceNoteFetchRepository.fetchRecentResult", code: -1))
         }
     }
 }

--- a/Domain/Tests/Interfaces/Mocks/VoiceNote/MockVoiceNoteFetchRepository.swift
+++ b/Domain/Tests/Interfaces/Mocks/VoiceNote/MockVoiceNoteFetchRepository.swift
@@ -2,9 +2,14 @@
 import Foundation
 import XCTest
 
-actor MockVoiceNoteFetchRepository: VoiceNoteFetchRepository {
+public actor MockVoiceNoteFetchRepository: VoiceNoteFetchRepository {
     private var fetchAllResult: Result<[VoiceNote], VoiceNoteFetchRepositoryError>?
     private var fetchByIdResult: Result<VoiceNote, VoiceNoteFetchRepositoryError>?
+
+    public init() {}
+
+    private var fetchAllFromDefaultFolderCallCount = 0
+    private var expectedDefaultFetchCallCount: Int?
 
     private var fetchAllCallCount = 0
     private var actualFetchAllFolderID: UUID?
@@ -16,25 +21,38 @@ actor MockVoiceNoteFetchRepository: VoiceNoteFetchRepository {
     private var expectedFetchByIdCallCount: Int?
     private var expectedFetchByIdID: UUID?
 
-    func setFetchAllResult(_ result: Result<[VoiceNote], VoiceNoteFetchRepositoryError>) {
+    public func setFetchAllResult(_ result: Result<[VoiceNote], VoiceNoteFetchRepositoryError>) {
         fetchAllResult = result
     }
 
-    func setFetchByIdResult(_ result: Result<VoiceNote, VoiceNoteFetchRepositoryError>) {
+    public func setFetchByIdResult(_ result: Result<VoiceNote, VoiceNoteFetchRepositoryError>) {
         fetchByIdResult = result
     }
 
-    func expectFetchAll(callCount: Int, folderID: UUID? = nil) {
+    public func expectFetchAllFromDefaultFolder(callCount: Int) {
+        expectedDefaultFetchCallCount = callCount
+    }
+
+    public func expectFetchAll(callCount: Int, folderID: UUID? = nil) {
         expectedFetchAllCallCount = callCount
         expectedFetchAllFolderID = folderID
     }
 
-    func expectFetchById(callCount: Int, id: UUID? = nil) {
+    public func expectFetchById(callCount: Int, id: UUID? = nil) {
         expectedFetchByIdCallCount = callCount
         expectedFetchByIdID = id
     }
 
-    func verify(file: StaticString = #filePath, line: UInt = #line) {
+    public func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expected = expectedDefaultFetchCallCount {
+            XCTAssertEqual(
+                fetchAllFromDefaultFolderCallCount,
+                expected,
+                "기본 폴더 전체 조회 호출 횟수가 일치하지 않습니다.",
+                file: file,
+                line: line
+            )
+        }
         if let expected = expectedFetchAllCallCount {
             XCTAssertEqual(
                 fetchAllCallCount,
@@ -73,7 +91,21 @@ actor MockVoiceNoteFetchRepository: VoiceNoteFetchRepository {
         }
     }
 
-    func fetchAll(folderID: UUID) async throws(VoiceNoteFetchRepositoryError) -> [VoiceNote] {
+    public func fetchAllFromDefaultFolder() async throws(VoiceNoteFetchRepositoryError) -> [VoiceNote] {
+        fetchAllFromDefaultFolderCallCount += 1
+
+        switch fetchAllResult {
+        case .success(let success):
+            return success
+        case .failure(let failure):
+            throw failure
+        case .none:
+            XCTFail("MockVoiceNoteFetchRepository.fetchAllResult 가 설정되지 않았습니다.")
+            throw .unknown(NSError(domain: "MockVoiceNoteFetchRepository.fetchAllResult", code: -1))
+        }
+    }
+
+    public func fetchAll(folderID: UUID) async throws(VoiceNoteFetchRepositoryError) -> [VoiceNote] {
         fetchAllCallCount += 1
         actualFetchAllFolderID = folderID
 
@@ -88,7 +120,7 @@ actor MockVoiceNoteFetchRepository: VoiceNoteFetchRepository {
         }
     }
 
-    func fetch(byId id: UUID) async throws(VoiceNoteFetchRepositoryError) -> VoiceNote {
+    public func fetch(byId id: UUID) async throws(VoiceNoteFetchRepositoryError) -> VoiceNote {
         fetchByIdCallCount += 1
         actualFetchByIdID = id
 

--- a/Domain/Tests/Interfaces/Mocks/WasteBasket/MockWasteBasketRepository.swift
+++ b/Domain/Tests/Interfaces/Mocks/WasteBasket/MockWasteBasketRepository.swift
@@ -2,7 +2,7 @@
 import Foundation
 import XCTest
 
-actor MockWasteBasketRepository: WasteBasketRepository {
+public actor MockWasteBasketRepository: WasteBasketRepository {
     // Results
     private var deleteResult: Result<Void, DeleteWasteBasketRepositoryError>?
     private var moveResult: Result<Void, MoveWasteBasketRepositoryError>?
@@ -47,65 +47,67 @@ actor MockWasteBasketRepository: WasteBasketRepository {
 
     // MARK: - Setup
 
-    func setFetchAllResult(_ result: Result<[WasteBasketItem], FetchWasteBasketRepositoryError>) {
+    public init() {}
+
+    public func setFetchAllResult(_ result: Result<[WasteBasketItem], FetchWasteBasketRepositoryError>) {
         fetchAllResult = result
     }
 
-    func setMoveResult(_ result: Result<Void, MoveWasteBasketRepositoryError>) {
+    public func setMoveResult(_ result: Result<Void, MoveWasteBasketRepositoryError>) {
         moveResult = result
     }
 
-    func setDeleteResult(_ result: Result<Void, DeleteWasteBasketRepositoryError>) {
+    public func setDeleteResult(_ result: Result<Void, DeleteWasteBasketRepositoryError>) {
         deleteResult = result
     }
 
-    func setRestoreResult(_ result: Result<Void, RestoreWasteBasketRepositoryError>) {
+    public func setRestoreResult(_ result: Result<Void, RestoreWasteBasketRepositoryError>) {
         restoreResult = result
     }
 
     // MARK: - Expectations
 
-    func expectFetchAll(callCount: Int) {
+    public func expectFetchAll(callCount: Int) {
         expectedFetchAllCallCount = callCount
     }
 
-    func expectMoveToWasteBasket(item: WasteBasketItem? = nil, callCount: Int) {
+    public func expectMoveToWasteBasket(item: WasteBasketItem? = nil, callCount: Int) {
         expectedMoveToWasteBasketCallCount = callCount
         expectedLastMovedItem = item
     }
 
-    func expectMoveAllToWasteBasket(items: [WasteBasketItem]? = nil, callCount: Int) {
+    public func expectMoveAllToWasteBasket(items: [WasteBasketItem]? = nil, callCount: Int) {
         expectedMoveAllToWasteBasketCallCount = callCount
         expectedLastMovedItems = items
     }
 
-    func expectDelete(item: WasteBasketItem? = nil, callCount: Int) {
+    public func expectDelete(item: WasteBasketItem? = nil, callCount: Int) {
         expectedDeleteCallCount = callCount
         expectedLastDeletedItem = item
     }
 
-    func expectDeleteAll(items: [WasteBasketItem]? = nil, callCount: Int) {
+    public func expectDeleteAll(items: [WasteBasketItem]? = nil, callCount: Int) {
         expectedDeleteAllCallCount = callCount
         expectedLastDeletedItems = items
     }
 
-    func expectAllClear(callCount: Int) {
+    public func expectAllClear(callCount: Int) {
         expectedAllClearCallCount = callCount
     }
 
-    func expectRestore(item: WasteBasketItem? = nil, callCount: Int) {
+    public func expectRestore(item: WasteBasketItem? = nil, callCount: Int) {
         expectedRestoreCallCount = callCount
         expectedLastRestoredItem = item
     }
 
-    func expectRestoreAll(items: [WasteBasketItem]? = nil, callCount: Int) {
+    public func expectRestoreAll(items: [WasteBasketItem]? = nil, callCount: Int) {
         expectedRestoreAllCallCount = callCount
         expectedLastRestoredItems = items
     }
 
     // MARK: - Verification
 
-    func verify(file: StaticString = #filePath, line: UInt = #line) {
+    public func verify(file: StaticString = #filePath, line: UInt = #line) {
         verifyFetch(file: file, line: line)
         verifyMove(file: file, line: line)
         verifyDelete(file: file, line: line)
@@ -174,7 +176,7 @@ actor MockWasteBasketRepository: WasteBasketRepository {
 
     // MARK: - WasteBasketRepository (Fetch, Move, Delete)
 
-    func fetchAll() async throws(FetchWasteBasketRepositoryError) -> [WasteBasketItem] {
+    public func fetchAll() async throws(FetchWasteBasketRepositoryError) -> [WasteBasketItem] {
         fetchAllCallCount += 1
 
         switch fetchAllResult {
@@ -189,7 +191,7 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         }
     }
 
-    func moveToWasteBasket(item: WasteBasketItem) async throws(MoveWasteBasketRepositoryError) {
+    public func moveToWasteBasket(item: WasteBasketItem) async throws(MoveWasteBasketRepositoryError) {
         moveToWasteBasketCallCount += 1
         lastMovedItem = item
 
@@ -205,7 +207,7 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         }
     }
 
-    func moveAllToWasteBasket(items: [WasteBasketItem]) async throws(MoveWasteBasketRepositoryError) {
+    public func moveAllToWasteBasket(items: [WasteBasketItem]) async throws(MoveWasteBasketRepositoryError) {
         moveAllToWasteBasketCallCount += 1
         lastMovedItems = items
 
@@ -221,7 +223,7 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         }
     }
 
-    func delete(item: WasteBasketItem) async throws(DeleteWasteBasketRepositoryError) {
+    public func delete(item: WasteBasketItem) async throws(DeleteWasteBasketRepositoryError) {
         deleteCallCount += 1
         lastDeletedItem = item
 
@@ -237,7 +239,7 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         }
     }
 
-    func deleteAll(items: [WasteBasketItem]) async throws(DeleteWasteBasketRepositoryError) {
+    public func deleteAll(items: [WasteBasketItem]) async throws(DeleteWasteBasketRepositoryError) {
         deleteAllCallCount += 1
         lastDeletedItems = items
 
@@ -253,7 +255,7 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         }
     }
 
-    func allClear() async throws(DeleteWasteBasketRepositoryError) {
+    public func allClear() async throws(DeleteWasteBasketRepositoryError) {
         allClearCallCount += 1
 
         switch deleteResult {
@@ -268,7 +270,7 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         }
     }
 
-    func restore(item: WasteBasketItem) async throws(RestoreWasteBasketRepositoryError) {
+    public func restore(item: WasteBasketItem) async throws(RestoreWasteBasketRepositoryError) {
         restoreCallCount += 1
         lastRestoredItem = item
 
@@ -284,7 +286,7 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         }
     }
 
-    func restoreAll(items: [WasteBasketItem]) async throws(RestoreWasteBasketRepositoryError) {
+    public func restoreAll(items: [WasteBasketItem]) async throws(RestoreWasteBasketRepositoryError) {
         restoreAllCallCount += 1
         lastRestoredItems = items
 

--- a/Domain/Tests/Interfaces/Mocks/WasteBasket/MockWasteBasketRepository.swift
+++ b/Domain/Tests/Interfaces/Mocks/WasteBasket/MockWasteBasketRepository.swift
@@ -7,6 +7,7 @@ actor MockWasteBasketRepository: WasteBasketRepository {
     private var deleteResult: Result<Void, DeleteWasteBasketRepositoryError>?
     private var moveResult: Result<Void, MoveWasteBasketRepositoryError>?
     private var fetchAllResult: Result<[WasteBasketItem], FetchWasteBasketRepositoryError>?
+    private var restoreResult: Result<Void, RestoreWasteBasketRepositoryError>?
 
     // 호출 검증 Count
     private var fetchAllCallCount = 0
@@ -15,6 +16,8 @@ actor MockWasteBasketRepository: WasteBasketRepository {
     private var deleteCallCount = 0
     private var deleteAllCallCount = 0
     private var allClearCallCount = 0
+    private var restoreCallCount = 0
+    private var restoreAllCallCount = 0
 
     // Expected Call Counts
     private var expectedFetchAllCallCount: Int?
@@ -23,18 +26,24 @@ actor MockWasteBasketRepository: WasteBasketRepository {
     private var expectedDeleteCallCount: Int?
     private var expectedDeleteAllCallCount: Int?
     private var expectedAllClearCallCount: Int?
+    private var expectedRestoreCallCount: Int?
+    private var expectedRestoreAllCallCount: Int?
 
     // Expected Arguments
     private var expectedLastMovedItem: WasteBasketItem?
     private var expectedLastMovedItems: [WasteBasketItem]?
     private var expectedLastDeletedItem: WasteBasketItem?
     private var expectedLastDeletedItems: [WasteBasketItem]?
+    private var expectedLastRestoredItem: WasteBasketItem?
+    private var expectedLastRestoredItems: [WasteBasketItem]?
 
     // 받은 인자 기록 (Verification용)
     private var lastMovedItem: WasteBasketItem?
     private var lastMovedItems: [WasteBasketItem]?
     private var lastDeletedItem: WasteBasketItem?
     private var lastDeletedItems: [WasteBasketItem]?
+    private var lastRestoredItem: WasteBasketItem?
+    private var lastRestoredItems: [WasteBasketItem]?
 
     // MARK: - Setup
 
@@ -48,6 +57,10 @@ actor MockWasteBasketRepository: WasteBasketRepository {
 
     func setDeleteResult(_ result: Result<Void, DeleteWasteBasketRepositoryError>) {
         deleteResult = result
+    }
+
+    func setRestoreResult(_ result: Result<Void, RestoreWasteBasketRepositoryError>) {
+        restoreResult = result
     }
 
     // MARK: - Expectations
@@ -80,30 +93,51 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         expectedAllClearCallCount = callCount
     }
 
+    func expectRestore(item: WasteBasketItem? = nil, callCount: Int) {
+        expectedRestoreCallCount = callCount
+        expectedLastRestoredItem = item
+    }
+
+    func expectRestoreAll(items: [WasteBasketItem]? = nil, callCount: Int) {
+        expectedRestoreAllCallCount = callCount
+        expectedLastRestoredItems = items
+    }
+
     // MARK: - Verification
 
     func verify(file: StaticString = #filePath, line: UInt = #line) {
+        verifyFetch(file: file, line: line)
+        verifyMove(file: file, line: line)
+        verifyDelete(file: file, line: line)
+        verifyRestore(file: file, line: line)
+    }
+
+    private func verifyFetch(file: StaticString, line: UInt) {
         if let expected = expectedFetchAllCallCount {
             XCTAssertEqual(fetchAllCallCount, expected, "전체 조회 호출 횟수가 일치하지 않습니다.", file: file, line: line)
         }
+    }
+
+    private func verifyMove(file: StaticString, line: UInt) {
         if let expected = expectedMoveToWasteBasketCallCount {
             XCTAssertEqual(
-                moveToWasteBasketCallCount,
-                expected,
-                "휴지통으로 이동 호출 횟수가 일치하지 않습니다.",
-                file: file,
-                line: line
+                moveToWasteBasketCallCount, expected, "휴지통으로 이동 호출 횟수가 일치하지 않습니다.", file: file, line: line
             )
         }
         if let expected = expectedMoveAllToWasteBasketCallCount {
             XCTAssertEqual(
-                moveAllToWasteBasketCallCount,
-                expected,
-                "전체 휴지통으로 이동 호출 횟수가 일치하지 않습니다.",
-                file: file,
-                line: line
+                moveAllToWasteBasketCallCount, expected, "전체 휴지통으로 이동 호출 횟수가 일치하지 않습니다.", file: file, line: line
             )
         }
+        if let expected = expectedLastMovedItem {
+            XCTAssertEqual(lastMovedItem, expected, "마지막으로 이동된 항목이 일치하지 않습니다.", file: file, line: line)
+        }
+        if let expected = expectedLastMovedItems {
+            XCTAssertEqual(lastMovedItems, expected, "마지막으로 이동된 항목 목록이 일치하지 않습니다.", file: file, line: line)
+        }
+    }
+
+    private func verifyDelete(file: StaticString, line: UInt) {
         if let expected = expectedDeleteCallCount {
             XCTAssertEqual(deleteCallCount, expected, "삭제 호출 횟수가 일치하지 않습니다.", file: file, line: line)
         }
@@ -113,19 +147,28 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         if let expected = expectedAllClearCallCount {
             XCTAssertEqual(allClearCallCount, expected, "비우기 호출 횟수가 일치하지 않습니다.", file: file, line: line)
         }
-
-        // Argument Verification
-        if let expected = expectedLastMovedItem {
-            XCTAssertEqual(lastMovedItem, expected, "마지막으로 이동된 항목이 일치하지 않습니다.", file: file, line: line)
-        }
-        if let expected = expectedLastMovedItems {
-            XCTAssertEqual(lastMovedItems, expected, "마지막으로 이동된 항목 목록이 일치하지 않습니다.", file: file, line: line)
-        }
         if let expected = expectedLastDeletedItem {
             XCTAssertEqual(lastDeletedItem, expected, "마지막으로 삭제된 항목이 일치하지 않습니다.", file: file, line: line)
         }
         if let expected = expectedLastDeletedItems {
             XCTAssertEqual(lastDeletedItems, expected, "마지막으로 삭제된 항목 목록이 일치하지 않습니다.", file: file, line: line)
+        }
+    }
+
+    private func verifyRestore(file: StaticString, line: UInt) {
+        if let expected = expectedRestoreCallCount {
+            XCTAssertEqual(restoreCallCount, expected, "복원 호출 횟수가 일치하지 않습니다.", file: file, line: line)
+        }
+        if let expected = expectedRestoreAllCallCount {
+            XCTAssertEqual(restoreAllCallCount, expected, "전체 복원 호출 횟수가 일치하지 않습니다.", file: file, line: line)
+        }
+        if let expected = expectedLastRestoredItem {
+            XCTAssertEqual(lastRestoredItem, expected, "마지막으로 복원된 항목이 일치하지 않습니다.", file: file, line: line)
+        }
+        if let expected = expectedLastRestoredItems {
+            XCTAssertEqual(
+                lastRestoredItems, expected, "마지막으로 복원된 항목 목록이 일치하지 않습니다.", file: file, line: line
+            )
         }
     }
 
@@ -221,6 +264,38 @@ actor MockWasteBasketRepository: WasteBasketRepository {
         case .none:
             XCTFail("MockWasteBasketRepository.deleteResult 가 설정되지 않았습니다.")
             let error = NSError(domain: "MockWasteBasketRepository.deleteResult", code: 0)
+            throw .unknown(error)
+        }
+    }
+
+    func restore(item: WasteBasketItem) async throws(RestoreWasteBasketRepositoryError) {
+        restoreCallCount += 1
+        lastRestoredItem = item
+
+        switch restoreResult {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        case .none:
+            XCTFail("MockWasteBasketRepository.restoreResult 가 설정되지 않았습니다.")
+            let error = NSError(domain: "MockWasteBasketRepository.restoreResult", code: 0)
+            throw .unknown(error)
+        }
+    }
+
+    func restoreAll(items: [WasteBasketItem]) async throws(RestoreWasteBasketRepositoryError) {
+        restoreAllCallCount += 1
+        lastRestoredItems = items
+
+        switch restoreResult {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        case .none:
+            XCTFail("MockWasteBasketRepository.restoreResult 가 설정되지 않았습니다.")
+            let error = NSError(domain: "MockWasteBasketRepository.restoreResult", code: 0)
             throw .unknown(error)
         }
     }

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -221,7 +221,9 @@ public extension FolderViewController {
 
         let deleteAction = UIContextualAction(style: .destructive, title: "삭제") {
             [weak self] _, _, completion in
-            self?.vm.move()
+            if case .folder(let folder) = item {
+                self?.vm.move(folder: folder)
+            }
             completion(true)
         }
         deleteAction.image = UIImage(systemName: "trash.fill")

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -48,6 +48,11 @@ public final class MainViewController: UIViewController {
         floatingButtonConstraint()
     }
 
+    override public func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        vm.updateVoiceNoteCategory()
+    }
+
     override public func updateProperties() {
         super.updateProperties()
         vm.updateMyFolderCategory()

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -51,6 +51,7 @@ public final class MainViewController: UIViewController {
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         vm.updateVoiceNoteCategory()
+        vm.updateRecentCategory()
     }
 
     override public func updateProperties() {

--- a/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
@@ -16,17 +16,20 @@ public final class FolderViewModel {
 
     private let createUseCase: CreateFolderUseCase
     private let updateUseCase: UpdateFolderUseCase
+    private let moveToTrashUseCase: MoveWasteBasketUseCase
 
     // MARK: - Initialize
 
     public init(
         category: CategoryToggle,
         createUseCase: CreateFolderUseCase,
-        updateUseCase: UpdateFolderUseCase
+        updateUseCase: UpdateFolderUseCase,
+        moveToTrashUseCase: MoveWasteBasketUseCase
     ) {
         self.category = category
         self.createUseCase = createUseCase
         self.updateUseCase = updateUseCase
+        self.moveToTrashUseCase = moveToTrashUseCase
     }
 }
 
@@ -62,7 +65,6 @@ extension FolderViewModel {
     /// Domain.Folder를 생성하는 함수
     func create(name: String) {
         closeTextFieldView()
-        // TODO: Connect Folder UseCase
         Task {
             do {
                 let folder = try await createUseCase.execute(name: name)
@@ -104,8 +106,17 @@ extension FolderViewModel {
         }
     }
 
-    func move() {
-        AppLogger.info("Trash Move!!")
-        // TODO: Connect Folder UseCase
+    func move(folder: Folder) {
+        Task {
+            do {
+                try await moveToTrashUseCase.execute(method: .single(item: .folder(id: folder.id)))
+                category.items.removeAll {
+                    if case .folder(let item) = $0 { return item.id == folder.id }
+                    return false
+                }
+            } catch {
+                AppLogger.error(error)
+            }
+        }
     }
 }

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -40,14 +40,17 @@ public final class MainViewModel {
     // MARK: - UseCase
 
     let fetchFolderUseCase: ReadFolderUseCase
+    let fetchVoiceNoteUseCase: FetchVoiceNoteUseCase
 
     // TODO: 화면 전환
     public weak var mainCoordinator: MainViewCoordinatorDelegate?
 
     public init(
-        fetchFolderUseCase: ReadFolderUseCase
+        fetchFolderUseCase: ReadFolderUseCase,
+        fetchVoiceNoteUseCase: FetchVoiceNoteUseCase
     ) {
         self.fetchFolderUseCase = fetchFolderUseCase
+        self.fetchVoiceNoteUseCase = fetchVoiceNoteUseCase
     }
 }
 
@@ -117,6 +120,9 @@ extension MainViewModel {
 
     /// 기본 폴더(음성 노트) 업데이트 함수
     func updateVoiceNoteCategory() {
-        AppLogger.info("기본 폴더 생성 문제: 조회도 해야 하는데 어디서 할까요")
+        Task {
+            let voiceNotes: [VoiceNote] = await (try? fetchVoiceNoteUseCase.execute()) ?? []
+            categoryData[1].items = voiceNotes.map { .voiceNote($0) }
+        }
     }
 }

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -41,16 +41,19 @@ public final class MainViewModel {
 
     let fetchFolderUseCase: ReadFolderUseCase
     let fetchVoiceNoteUseCase: FetchVoiceNoteUseCase
+    let fetchRecentVoiceNoteUseCase: FetchRecentVoiceNoteUseCase
 
     // TODO: 화면 전환
     public weak var mainCoordinator: MainViewCoordinatorDelegate?
 
     public init(
         fetchFolderUseCase: ReadFolderUseCase,
-        fetchVoiceNoteUseCase: FetchVoiceNoteUseCase
+        fetchVoiceNoteUseCase: FetchVoiceNoteUseCase,
+        fetchRecentVoiceNoteUseCase: FetchRecentVoiceNoteUseCase
     ) {
         self.fetchFolderUseCase = fetchFolderUseCase
         self.fetchVoiceNoteUseCase = fetchVoiceNoteUseCase
+        self.fetchRecentVoiceNoteUseCase = fetchRecentVoiceNoteUseCase
     }
 }
 
@@ -123,6 +126,14 @@ extension MainViewModel {
         Task {
             let voiceNotes: [VoiceNote] = await (try? fetchVoiceNoteUseCase.execute()) ?? []
             categoryData[1].items = voiceNotes.map { .voiceNote($0) }
+        }
+    }
+
+    /// 최근 기록(전체 폴더 최신 5개) 업데이트 함수
+    func updateRecentCategory() {
+        Task {
+            let voiceNotes: [VoiceNote] = await (try? fetchRecentVoiceNoteUseCase.execute()) ?? []
+            categoryData[0].items = voiceNotes.map { .voiceNote($0) }
         }
     }
 }

--- a/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
@@ -4,7 +4,7 @@ import Foundation
 @MainActor
 public protocol RecordingCoordinating: AnyObject {
     func cancelRecording()
-    func finishRecording(voiceRecord: VoiceRecord)
+    func finishRecording(voiceNote: VoiceNote)
 }
 
 @MainActor
@@ -54,6 +54,7 @@ public final class RecordingViewModel {
     private let resumeRecordingUseCase: ResumeRecordingUseCase
     private let finishRecordingUseCase: FinishRecordingUseCase
     private let cancelRecordingUseCase: CancelRecordingUseCase
+    private let createVoiceNoteUseCase: CreateVoiceNoteUseCase
 
     public weak var coordinator: RecordingCoordinating?
 
@@ -66,13 +67,15 @@ public final class RecordingViewModel {
         pauseRecordingUseCase: PauseRecordingUseCase,
         resumeRecordingUseCase: ResumeRecordingUseCase,
         finishRecordingUseCase: FinishRecordingUseCase,
-        cancelRecordingUseCase: CancelRecordingUseCase
+        cancelRecordingUseCase: CancelRecordingUseCase,
+        createVoiceNoteUseCase: CreateVoiceNoteUseCase
     ) {
         self.startRecordingUseCase = startRecordingUseCase
         self.pauseRecordingUseCase = pauseRecordingUseCase
         self.resumeRecordingUseCase = resumeRecordingUseCase
         self.finishRecordingUseCase = finishRecordingUseCase
         self.cancelRecordingUseCase = cancelRecordingUseCase
+        self.createVoiceNoteUseCase = createVoiceNoteUseCase
     }
 
     public func send(_ action: Action) {
@@ -101,7 +104,8 @@ public final class RecordingViewModel {
                     waveformTask?.cancel()
                     waveformTask = nil
                     let voiceRecord = try await finishRecordingUseCase.execute()
-                    coordinator?.finishRecording(voiceRecord: voiceRecord)
+                    let voiceNote = try await createVoiceNoteUseCase.execute(voiceRecord)
+                    coordinator?.finishRecording(voiceNote: voiceNote)
                 } catch {
                     send(.errorOccurred(error))
                 }

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -1,0 +1,119 @@
+import Core
+import Domain
+import Foundation
+
+@MainActor
+@Observable
+public final class TrashViewModel {
+    // MARK: - State
+
+    private(set) var items: [WasteBasketItem] = []
+    private(set) var errorMessage: String?
+
+    var isEmpty: Bool {
+        items.isEmpty
+    }
+
+    // MARK: - UseCase
+
+    private let fetchUseCase: FetchWasteBasketFolderUseCase
+    private let deleteUseCase: DeleteWasteBasketUseCase
+    private let restoreUseCase: RestoreWasteBasketUseCase
+
+    // MARK: - Initialize
+
+    public init(
+        fetchUseCase: FetchWasteBasketFolderUseCase,
+        deleteUseCase: DeleteWasteBasketUseCase,
+        restoreUseCase: RestoreWasteBasketUseCase
+    ) {
+        self.fetchUseCase = fetchUseCase
+        self.deleteUseCase = deleteUseCase
+        self.restoreUseCase = restoreUseCase
+    }
+}
+
+// MARK: - Fetch
+
+extension TrashViewModel {
+    func fetchItems() {
+        Task {
+            do {
+                items = try await fetchUseCase.execute()
+            } catch {
+                AppLogger.error(error)
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}
+
+// MARK: - Delete
+
+extension TrashViewModel {
+    func deleteAll() {
+        Task {
+            do {
+                try await deleteUseCase.execute(method: .all)
+                items.removeAll()
+            } catch {
+                AppLogger.error(error)
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func delete(item: WasteBasketItem) {
+        Task {
+            do {
+                try await deleteUseCase.execute(method: .single(item: item))
+                items.removeAll { $0 == item }
+            } catch {
+                AppLogger.error(error)
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func delete(items deleteItems: [WasteBasketItem]) {
+        Task {
+            do {
+                try await deleteUseCase.execute(method: .multiple(items: deleteItems))
+                let deleteSet = Set(deleteItems)
+                items.removeAll { deleteSet.contains($0) }
+            } catch {
+                AppLogger.error(error)
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}
+
+// MARK: - Restore
+
+extension TrashViewModel {
+    func restore(item: WasteBasketItem) {
+        Task {
+            do {
+                try await restoreUseCase.execute(method: .single(item: item))
+                items.removeAll { $0 == item }
+            } catch {
+                AppLogger.error(error)
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func restore(items restoreItems: [WasteBasketItem]) {
+        Task {
+            do {
+                try await restoreUseCase.execute(method: .multiple(items: restoreItems))
+                let restoreSet = Set(restoreItems)
+                items.removeAll { restoreSet.contains($0) }
+            } catch {
+                AppLogger.error(error)
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/Presentation/Tests/Folder/FolderViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderViewModelTests.swift
@@ -10,11 +10,13 @@ final class FolderViewModelTests: XCTestCase {
     private struct SUT {
         let viewModel: FolderViewModel
         let mockFolderRepo: MockFolderRepository
+        let mockWasteBasketRepo: MockWasteBasketRepository
         let mockCoordinator: MockMainViewCoordinatorDelegate
     }
 
     private func makeSUT(initialItems: [Presentation.LibraryItem] = []) -> SUT {
         let mockFolderRepo = MockFolderRepository()
+        let mockWasteBasketRepo = MockWasteBasketRepository()
         let mockCoordinator = MockMainViewCoordinatorDelegate()
 
         let initialCategory = CategoryToggle(
@@ -26,13 +28,15 @@ final class FolderViewModelTests: XCTestCase {
         let viewModel = FolderViewModel(
             category: initialCategory,
             createUseCase: DefaultCreateFolderUseCase(repository: mockFolderRepo),
-            updateUseCase: DefaultUpdateFolderUseCase(repository: mockFolderRepo)
+            updateUseCase: DefaultUpdateFolderUseCase(repository: mockFolderRepo),
+            moveToTrashUseCase: DefaultMoveWasteBasketUseCase(repository: mockWasteBasketRepo)
         )
         viewModel.coordinator = mockCoordinator
 
         return SUT(
             viewModel: viewModel,
             mockFolderRepo: mockFolderRepo,
+            mockWasteBasketRepo: mockWasteBasketRepo,
             mockCoordinator: mockCoordinator
         )
     }
@@ -95,6 +99,22 @@ final class FolderViewModelTests: XCTestCase {
         await sut.mockFolderRepo.verify()
         XCTAssertEqual(sut.viewModel.category.items.count, 1)
         XCTAssertFalse(sut.viewModel.showAlert)
+    }
+
+    func test_move_성공시_리스트에서제거() async {
+        let folder = Folder(name: "이동 폴더")
+        let sut = makeSUT(initialItems: [.folder(folder)])
+
+        await sut.mockWasteBasketRepo.setMoveResult(.success(()))
+        await sut.mockWasteBasketRepo.expectMoveToWasteBasket(
+            item: .folder(id: folder.id), callCount: 1
+        )
+
+        sut.viewModel.move(folder: folder)
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        await sut.mockWasteBasketRepo.verify()
+        XCTAssertTrue(sut.viewModel.category.items.isEmpty)
     }
 
     func test_update_성공시_리스트항목교체() async {

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -48,7 +48,10 @@ final class MainViewModelTests: XCTestCase {
 
         let viewModel = MainViewModel(
             fetchFolderUseCase: DefaultReadFolderUseCase(repository: mockFolderRepo),
-            fetchVoiceNoteUseCase: DefaultFetchVoiceNoteUseCase(repository: mockVoiceNoteRepo)
+            fetchVoiceNoteUseCase: DefaultFetchVoiceNoteUseCase(repository: mockVoiceNoteRepo),
+            fetchRecentVoiceNoteUseCase: DefaultFetchRecentVoiceNoteUseCase(
+                repository: mockVoiceNoteRepo
+            )
         )
         viewModel.mainCoordinator = mockCoordinator
 
@@ -118,6 +121,27 @@ final class MainViewModelTests: XCTestCase {
         XCTAssertEqual(sut.viewModel.categoryData[1].items.count, 2)
         if case .voiceNote(let note) = sut.viewModel.categoryData[1].items[0] {
             XCTAssertEqual(note.title, "노트1")
+        } else {
+            XCTFail("VoiceNote 타입이 아닙니다.")
+        }
+    }
+
+    func test_updateRecentCategory_호출시_최근기록로드확인() async {
+        // Given
+        let sut = makeSUT()
+        let expectedNotes = [VoiceNote.stub(title: "최신1"), VoiceNote.stub(title: "최신2")]
+        await sut.mockVoiceNoteRepo.setFetchRecentResult(.success(expectedNotes))
+        await sut.mockVoiceNoteRepo.expectFetchRecent(callCount: 1, limit: Policy.recentVoiceNoteLimit)
+
+        // When
+        sut.viewModel.updateRecentCategory()
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        // Then
+        await sut.mockVoiceNoteRepo.verify()
+        XCTAssertEqual(sut.viewModel.categoryData[0].items.count, 2)
+        if case .voiceNote(let note) = sut.viewModel.categoryData[0].items[0] {
+            XCTAssertEqual(note.title, "최신1")
         } else {
             XCTFail("VoiceNote 타입이 아닙니다.")
         }

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -37,21 +37,25 @@ final class MainViewModelTests: XCTestCase {
     private struct SUT {
         let viewModel: MainViewModel
         let mockFolderRepo: MockFolderRepository
+        let mockVoiceNoteRepo: MockVoiceNoteFetchRepository
         let mockCoordinator: MockMainViewCoordinatorDelegate
     }
 
     private func makeSUT() -> SUT {
         let mockFolderRepo = MockFolderRepository()
+        let mockVoiceNoteRepo = MockVoiceNoteFetchRepository()
         let mockCoordinator = MockMainViewCoordinatorDelegate()
 
         let viewModel = MainViewModel(
-            fetchFolderUseCase: DefaultReadFolderUseCase(repository: mockFolderRepo)
+            fetchFolderUseCase: DefaultReadFolderUseCase(repository: mockFolderRepo),
+            fetchVoiceNoteUseCase: DefaultFetchVoiceNoteUseCase(repository: mockVoiceNoteRepo)
         )
         viewModel.mainCoordinator = mockCoordinator
 
         return SUT(
             viewModel: viewModel,
             mockFolderRepo: mockFolderRepo,
+            mockVoiceNoteRepo: mockVoiceNoteRepo,
             mockCoordinator: mockCoordinator
         )
     }
@@ -97,6 +101,27 @@ final class MainViewModelTests: XCTestCase {
     }
 
     // MARK: - Update Tests
+
+    func test_updateVoiceNoteCategory_호출시_기본폴더보이스노트로드확인() async {
+        // Given
+        let sut = makeSUT()
+        let expectedNotes = [VoiceNote.stub(title: "노트1"), VoiceNote.stub(title: "노트2")]
+        await sut.mockVoiceNoteRepo.setFetchAllResult(.success(expectedNotes))
+        await sut.mockVoiceNoteRepo.expectFetchAllFromDefaultFolder(callCount: 1)
+
+        // When
+        sut.viewModel.updateVoiceNoteCategory()
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        // Then
+        await sut.mockVoiceNoteRepo.verify()
+        XCTAssertEqual(sut.viewModel.categoryData[1].items.count, 2)
+        if case .voiceNote(let note) = sut.viewModel.categoryData[1].items[0] {
+            XCTAssertEqual(note.title, "노트1")
+        } else {
+            XCTFail("VoiceNote 타입이 아닙니다.")
+        }
+    }
 
     func test_updateMyFolderCategory_호출시_데이터로드확인() async {
         let sut = makeSUT()

--- a/Presentation/Tests/Recording/RecordingViewModelTests.swift
+++ b/Presentation/Tests/Recording/RecordingViewModelTests.swift
@@ -7,15 +7,15 @@ import XCTest
 final class MockRecordingCoordinator: RecordingCoordinating {
     private(set) var cancelRecordingCallCount = 0
     private(set) var finishRecordingCallCount = 0
-    private(set) var finishedVoiceRecord: VoiceRecord?
+    private(set) var finishedVoiceNote: VoiceNote?
 
     func cancelRecording() {
         cancelRecordingCallCount += 1
     }
 
-    func finishRecording(voiceRecord: VoiceRecord) {
+    func finishRecording(voiceNote: VoiceNote) {
         finishRecordingCallCount += 1
-        finishedVoiceRecord = voiceRecord
+        finishedVoiceNote = voiceNote
     }
 }
 
@@ -24,11 +24,13 @@ final class RecordingViewModelTests: XCTestCase {
     private struct SUT {
         let viewModel: RecordingViewModel
         let repository: MockVoiceRecordRepository
+        let voiceNoteRepository: MockVoiceNoteCreateRepository
         let coordinator: MockRecordingCoordinator
     }
 
     private func makeSUT() -> SUT {
         let repository = MockVoiceRecordRepository()
+        let voiceNoteRepository = MockVoiceNoteCreateRepository()
         let coordinator = MockRecordingCoordinator()
 
         let viewModel = RecordingViewModel(
@@ -36,11 +38,17 @@ final class RecordingViewModelTests: XCTestCase {
             pauseRecordingUseCase: DefaultPauseRecordingUseCase(recordingRepository: repository),
             resumeRecordingUseCase: DefaultResumeRecordingUseCase(recordingRepository: repository),
             finishRecordingUseCase: DefaultFinishRecordingUseCase(recordingRepository: repository),
-            cancelRecordingUseCase: DefaultCancelRecordingUseCase(recordingRepository: repository)
+            cancelRecordingUseCase: DefaultCancelRecordingUseCase(recordingRepository: repository),
+            createVoiceNoteUseCase: DefaultCreateVoiceNoteUseCase(repository: voiceNoteRepository)
         )
         viewModel.coordinator = coordinator
 
-        return SUT(viewModel: viewModel, repository: repository, coordinator: coordinator)
+        return SUT(
+            viewModel: viewModel,
+            repository: repository,
+            voiceNoteRepository: voiceNoteRepository,
+            coordinator: coordinator
+        )
     }
 }
 
@@ -200,11 +208,13 @@ extension RecordingViewModelTests {
 // MARK: - 완료
 
 extension RecordingViewModelTests {
-    func test_finishButtonTapped_녹음완료후coordinator의finishRecording을호출한다() async {
+    func test_finishButtonTapped_녹음완료후보이스노트를생성하고coordinator의finishRecording을호출한다() async {
         // Given
         let sut = makeSUT()
-        let stub = VoiceRecord.stub()
-        await sut.repository.setFinishResult(.success(stub))
+        let voiceRecordStub = VoiceRecord.stub()
+        let voiceNoteStub = VoiceNote.stub(voiceRecord: voiceRecordStub)
+        await sut.repository.setFinishResult(.success(voiceRecordStub))
+        await sut.voiceNoteRepository.setResult(.success(voiceNoteStub))
 
         // When
         sut.viewModel.send(.finishButtonTapped)
@@ -212,13 +222,28 @@ extension RecordingViewModelTests {
 
         // Then
         XCTAssertEqual(sut.coordinator.finishRecordingCallCount, 1)
-        XCTAssertEqual(sut.coordinator.finishedVoiceRecord?.id, stub.id)
+        XCTAssertEqual(sut.coordinator.finishedVoiceNote?.id, voiceNoteStub.id)
     }
 
-    func test_finishButtonTapped_완료실패시_coordinator를호출하지않고errorMessage를설정한다() async {
+    func test_finishButtonTapped_녹음완료실패시_coordinator를호출하지않고errorMessage를설정한다() async {
         // Given
         let sut = makeSUT()
         await sut.repository.setFinishResult(.failure(.finishFailed))
+
+        // When
+        sut.viewModel.send(.finishButtonTapped)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        XCTAssertEqual(sut.coordinator.finishRecordingCallCount, 0)
+        XCTAssertNotNil(sut.viewModel.state.errorMessage)
+    }
+
+    func test_finishButtonTapped_보이스노트생성실패시_coordinator를호출하지않고errorMessage를설정한다() async {
+        // Given
+        let sut = makeSUT()
+        await sut.repository.setFinishResult(.success(.stub()))
+        await sut.voiceNoteRepository.setResult(.failure(.createFailed))
 
         // When
         sut.viewModel.send(.finishButtonTapped)


### PR DESCRIPTION
## ✨ 작업 요약
> 녹음 완료 후 VoiceNote 영속화부터 메인 화면 표시, 휴지통 CRUD까지 전 흐름을 구현

- RecordingViewModel에서 녹음 완료 시 VoiceNote를 생성하고 DB에 저장
- MainViewModel에서 기본 폴더 VoiceNote 및 최근 기록(최대 5개)을 조회하여 화면에 표시
- FolderViewModel에서 폴더를 휴지통으로 이동
- 휴지통 조회·삭제·복원 UseCase 및 Repository 구현
- TrashViewModel로 휴지통 기능 전체 제공

## 📋 구체적인 내용
- **추가/변경된 동작:**
  - 녹음 완료 → `CreateVoiceNoteUseCase` 실행 → 기본 폴더에 VoiceNote 저장
  - `viewWillAppear` 시 기본 폴더 VoiceNote, 최근 기록 5개 자동 로드
  - 개인 폴더 스와이프 삭제 → `MoveWasteBasketUseCase`로 휴지통 이동
  - 휴지통: 전체/개별 영구 삭제, 전체/개별 복원(`deletedAt → nil`)
- **영향 받는 화면/모듈:** Domain, Data, Presentation, App

---

## 🔗 연관 이슈

- closed # 169

---

## 🧩 설계·구현 노트

- **선택한 방식**
  - 최근 기록은 별도 `FetchRecentVoiceNoteUseCase`로 분리 — 기본 폴더 조회와 목적이 다름(전체 폴더 대상, limit 적용)
  - `viewWillAppear`에서 데이터 갱신 — 화면 복귀 시마다 최신 상태 보장, 반응형 스트림은 향후 개선 과제로 분리
  - 복원은 `deletedAt = nil` 업데이트 방식 — 별도 테이블 없이 Soft Delete 패턴 일관 유지
  - `WasteBasketItem`에 `Hashable` 추가 — TrashViewModel의 Set 연산을 위해

- **고려했다가 제외한 방식**
  - `NSFetchedResultsController` 기반 반응형 스트림 — 아키텍처 복잡도 증가, 현 단계에서 over-engineering
  - ISP 적용한 WasteBasket 프로토콜 분리(`FetchWasteBasketRepository` 등) — 하나의 구현체가 모든 작업을 담당하므로 실익 없음

---

## ✅ 확인 사항

- [x] 정상 플로우 동작 확인
- [x] 엣지 케이스 / 빈 값·에러 처리 확인 (취소, 기본 폴더 미존재 등)
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [x] (로직 추가 시) 테스트 추가 여부 (144개 전부 통과)

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [x] 로직·엣지 케이스
- [x] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- `viewWillAppear`에서 매번 fetch 하는 방식이 현 시점에 적절한지 (반응형 전환 시점 의견)
- `DefaultVoiceNoteFetchRepository.fetchRecent`에서 메모리 내 정렬/필터 방식이 데이터 증가 시 성능에 문제가 없는지

---

## 📚 참고

---

## 🗺 아키텍처 다이어그램

### VoiceNote 생성 흐름

```mermaid
sequenceDiagram
    participant RVM as RecordingViewModel
    participant FinishUC as FinishRecordingUseCase
    participant CreateUC as CreateVoiceNoteUseCase
    participant Repo as DefaultVoiceNoteCreateRepository
    participant DB as CoreDataLocalDataBase

    RVM->>FinishUC: execute()
    FinishUC-->>RVM: VoiceRecord
    RVM->>CreateUC: execute(voiceRecord)
    CreateUC->>Repo: create(voiceRecord)
    Repo->>DB: fetchAll(FolderEntity) → 기본 폴더 탐색
    Repo->>DB: create(VoiceNote)
    DB-->>Repo: VoiceNote
    Repo-->>CreateUC: VoiceNote
    CreateUC-->>RVM: VoiceNote
    RVM->>Coordinator: finishRecording(voiceNote:)
```

### 휴지통 에러 변환 흐름

```mermaid
flowchart LR
    A[CoreDataStorageError] -->|Mapping init| B[FetchWasteBasketRepositoryError]
    B -->|init| C[FetchWasteBasketFolderUseCaseError]

    D[RestoreWasteBasketRepositoryError] -->|init| E[RestoreWasteBasketUseCaseError]
    F[DeleteWasteBasketRepositoryError] -->|init| G[DeleteWasteBasketUseCaseError]
```

### 모듈 의존 구조 (이번 PR 추가분)

```mermaid
graph TD
    App --> Presentation
    App --> Domain
    App --> Data

    Presentation --> Domain
    Data --> Domain

    Domain --> FetchRecentVoiceNoteUseCase
    Domain --> RestoreWasteBasketUseCase
    Domain --> WasteBasketRepository

    Data --> DefaultVoiceNoteCreateRepository
    Data --> DefaultVoiceNoteFetchRepository
    Data --> DefaultWasteBasketRepository

    Presentation --> RecordingViewModel
    Presentation --> MainViewModel
    Presentation --> FolderViewModel
    Presentation --> TrashViewModel
```
