### PR TITLE
음성 녹음 재생 기능 및 레포지토리를 구현합니다.

### DIFF
--- a/Data/Sources/Infrastructure/Audio/AudioPlaybackPlayerService.swift
+++ b/Data/Sources/Infrastructure/Audio/AudioPlaybackPlayerService.swift
@@ -27,7 +27,7 @@ public final class AudioPlaybackPlayerService: NSObject, AudioPlaybackService {
     }
 
     /// 새 파일을 준비하고 재생 상태 스트림을 반환합니다.
-    /// 파일 I/O는 백그라운드에서 수행하고, AVAudioPlayer 생성은 메인 액터에서 처리합니다.
+    /// `AVAudioPlayer(contentsOf:)`를 사용해 메모리 맵핑 방식으로 효율적으로 파일을 로드합니다.
     public func preparePlayback(at fileURL: URL) async throws(AudioPlaybackServiceError)
         -> AsyncStream<AudioPlaybackState>
     {
@@ -40,9 +40,7 @@ public final class AudioPlaybackPlayerService: NSObject, AudioPlaybackService {
 
         let player: AVAudioPlayer
         do {
-            // 파일 I/O를 백그라운드에서 수행 (AVAudioPlayer는 Sendable 미준수로 직접 전달 불가)
-            let data = try await Task.detached { try Data(contentsOf: fileURL) }.value
-            player = try AVAudioPlayer(data: data)
+            player = try AVAudioPlayer(contentsOf: fileURL)
         } catch {
             AppLogger.error(error)
             throw .prepareFailed

--- a/Data/Sources/Infrastructure/Audio/AudioPlaybackPlayerService.swift
+++ b/Data/Sources/Infrastructure/Audio/AudioPlaybackPlayerService.swift
@@ -1,0 +1,219 @@
+import AVFoundation
+import Core
+import Domain
+import Foundation
+
+/// AVAudioPlayer 기반 오디오 재생 서비스.
+///
+/// `@MainActor`로 격리되어 별도 동기화 없이 상태를 안전하게 관리하며,
+/// `AVAudioPlayerDelegate`를 직접 채택해 재생 완료·인터럽션 이벤트를 처리합니다.
+/// 재생 상태 변화는 `playbackStream`을 통해 스트리밍됩니다.
+@MainActor
+public final class AudioPlaybackPlayerService: NSObject, AudioPlaybackService {
+    private var player: AVAudioPlayer?
+    private var progressTask: Task<Void, Never>?
+    private var playbackStatus: AudioPlaybackState.Status = .idle
+    private var duration: TimeInterval = 0
+    private let _playback = AsyncStream<AudioPlaybackState>
+        .makeStream(bufferingPolicy: .bufferingNewest(Policy.playbackStateStreamBufferLimit))
+    private var isSessionActive = false
+
+    private var playbackStream: AsyncStream<AudioPlaybackState> {
+        _playback.stream
+    }
+
+    private var playbackContinuation: AsyncStream<AudioPlaybackState>.Continuation {
+        _playback.continuation
+    }
+
+    /// 새 파일을 준비하고 재생 상태 스트림을 반환합니다.
+    /// 파일 I/O는 백그라운드에서 수행하고, AVAudioPlayer 생성은 메인 액터에서 처리합니다.
+    public func preparePlayback(at fileURL: URL) async throws(AudioPlaybackServiceError)
+        -> AsyncStream<AudioPlaybackState>
+    {
+        // 이전 재생 세션 정리
+        player?.stop()
+        await stopProgressTask()
+        player?.delegate = nil
+        player = nil
+        deactivateSessionIfNeeded()
+
+        let player: AVAudioPlayer
+        do {
+            // 파일 I/O를 백그라운드에서 수행 (AVAudioPlayer는 Sendable 미준수로 직접 전달 불가)
+            let data = try await Task.detached { try Data(contentsOf: fileURL) }.value
+            player = try AVAudioPlayer(data: data)
+        } catch {
+            AppLogger.error(error)
+            throw .prepareFailed
+        }
+
+        player.delegate = self
+        guard player.prepareToPlay() else { throw .prepareFailed }
+
+        self.player = player
+        duration = player.duration
+        updateState(status: .idle, currentTime: 0, duration: player.duration)
+        return playbackStream
+    }
+
+    public func play() async throws(AudioPlaybackServiceError) {
+        guard let player else { throw .notPrepared }
+
+        // 끝까지 재생된 상태라면 처음부터 다시 시작
+        if player.currentTime >= player.duration {
+            player.currentTime = 0
+        }
+
+        try activateSession()
+        guard player.play() else { throw .playFailed }
+
+        startProgressTask()
+        updateState(status: .playing, currentTime: player.currentTime, duration: player.duration)
+    }
+
+    public func pause() async throws(AudioPlaybackServiceError) {
+        guard let player else { throw .notPrepared }
+        guard player.isPlaying else { throw .pauseFailed }
+
+        player.pause()
+        await stopProgressTask()
+        updateState(status: .paused, currentTime: player.currentTime, duration: player.duration)
+    }
+
+    public func seek(to time: TimeInterval) async throws(AudioPlaybackServiceError) {
+        guard let player else { throw .notPrepared }
+
+        let clampedTime = min(max(0, time), player.duration)
+        player.currentTime = clampedTime
+
+        // seek 후 상태는 재생 중 여부와 seek 위치로 결정
+        let status: AudioPlaybackState.Status = {
+            if player.isPlaying { return .playing }
+            if player.duration > 0, clampedTime >= player.duration { return .finished }
+            // 한 번도 재생하지 않은 상태에서 처음으로 seek하면 idle 유지
+            if playbackStatus == .idle, clampedTime == 0 { return .idle }
+            return .paused
+        }()
+
+        updateState(status: status, currentTime: clampedTime, duration: player.duration)
+    }
+
+    public func stop() async throws(AudioPlaybackServiceError) {
+        player?.stop()
+        player?.currentTime = 0
+        await stopProgressTask()
+        player?.delegate = nil
+        player = nil
+        // player 해제 후에도 duration을 유지해 UI가 총 길이를 표시할 수 있도록
+        updateState(status: .idle, currentTime: 0, duration: duration)
+        deactivateSessionIfNeeded()
+    }
+}
+
+// MARK: - AVAudioPlayerDelegate
+
+extension AudioPlaybackPlayerService: AVAudioPlayerDelegate {
+    /// AVAudioPlayerDelegate 콜백은 nonisolated 컨텍스트에서 호출되므로
+    /// Task를 통해 MainActor로 전환 후 처리
+    public nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor [weak self] in await self?.handlePlaybackFinished(successfully: flag) }
+    }
+
+    public nonisolated func audioPlayerBeginInterruption(_ player: AVAudioPlayer) {
+        Task { @MainActor [weak self] in await self?.handleInterruptionBegan() }
+    }
+
+    public nonisolated func audioPlayerEndInterruption(_ player: AVAudioPlayer, withOptions flags: Int) {
+        let shouldResume = AVAudioSession.InterruptionOptions(rawValue: UInt(flags)).contains(.shouldResume)
+        Task { @MainActor [weak self] in await self?.handleInterruptionEnded(shouldResume: shouldResume) }
+    }
+}
+
+// MARK: - Private
+
+private extension AudioPlaybackPlayerService {
+    func handlePlaybackFinished(successfully: Bool) async {
+        guard successfully, let player else { return }
+        await stopProgressTask()
+        // currentTime을 duration과 동일하게 설정해 UI가 끝 위치를 표시하도록
+        updateState(status: .finished, currentTime: player.duration, duration: player.duration)
+        deactivateSessionIfNeeded()
+    }
+
+    func handleInterruptionBegan() async {
+        guard let player else { return }
+        player.pause()
+        await stopProgressTask()
+        updateState(status: .paused, currentTime: player.currentTime, duration: player.duration)
+    }
+
+    func handleInterruptionEnded(shouldResume: Bool) async {
+        guard let player else { return }
+        if shouldResume {
+            try? activateSession()
+            _ = player.play()
+            startProgressTask()
+            updateState(status: .playing, currentTime: player.currentTime, duration: player.duration)
+        } else {
+            updateState(status: .paused, currentTime: player.currentTime, duration: player.duration)
+        }
+    }
+
+    func activateSession() throws(AudioPlaybackServiceError) {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playback, mode: .default)
+            try session.setActive(true)
+            isSessionActive = true
+        } catch {
+            AppLogger.error(error)
+            let code = AVAudioSession.ErrorCode(rawValue: (error as NSError).code)
+            switch code {
+            case .insufficientPriority: throw .sessionActivationFailed
+            case .mediaServicesFailed: throw .mediaServicesFailed
+            default: throw .unknown(error)
+            }
+        }
+    }
+
+    func deactivateSessionIfNeeded() {
+        guard isSessionActive else { return }
+        do {
+            // 다른 앱(음악 등)이 오디오를 재개할 수 있도록 알림 옵션 포함
+            try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+            isSessionActive = false
+        } catch {
+            AppLogger.error(error)
+        }
+    }
+
+    func startProgressTask() {
+        progressTask?.cancel()
+        progressTask = Task { [weak self] in await self?.streamProgress() }
+    }
+
+    /// 진행 중인 Task를 취소하고 실제 종료를 기다려 상태 업데이트 누락을 방지
+    func stopProgressTask() async {
+        let progressTask = progressTask
+        self.progressTask = nil
+        progressTask?.cancel()
+        await progressTask?.value
+    }
+
+    /// 재생 중 주기적으로 currentTime을 스트림에 방출
+    func streamProgress() async {
+        while !Task.isCancelled {
+            guard let player else { return }
+            if player.isPlaying {
+                updateState(status: .playing, currentTime: player.currentTime, duration: player.duration)
+            }
+            try? await Task.sleep(nanoseconds: Policy.playbackProgressUpdateInterval)
+        }
+    }
+
+    func updateState(status: AudioPlaybackState.Status, currentTime: TimeInterval, duration: TimeInterval) {
+        playbackStatus = status
+        playbackContinuation.yield(AudioPlaybackState(status: status, currentTime: currentTime, duration: duration))
+    }
+}

--- a/Data/Sources/Interfaces/AudioPlayback/AudioPlaybackService.swift
+++ b/Data/Sources/Interfaces/AudioPlayback/AudioPlaybackService.swift
@@ -1,0 +1,10 @@
+import Domain
+import Foundation
+
+public protocol AudioPlaybackService: Sendable {
+    func preparePlayback(at fileURL: URL) async throws(AudioPlaybackServiceError) -> AsyncStream<AudioPlaybackState>
+    func play() async throws(AudioPlaybackServiceError)
+    func pause() async throws(AudioPlaybackServiceError)
+    func seek(to time: TimeInterval) async throws(AudioPlaybackServiceError)
+    func stop() async throws(AudioPlaybackServiceError)
+}

--- a/Data/Sources/Interfaces/AudioPlayback/AudioPlaybackServiceError.swift
+++ b/Data/Sources/Interfaces/AudioPlayback/AudioPlaybackServiceError.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public enum AudioPlaybackServiceError: LocalizedError, Sendable {
+    case notPrepared
+    case sessionActivationFailed
+    case mediaServicesFailed
+    case prepareFailed
+    case playFailed
+    case pauseFailed
+    case seekFailed
+    case stopFailed
+    case unknown(any Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notPrepared:
+            return "재생할 오디오가 준비되지 않았습니다."
+        case .sessionActivationFailed:
+            return "오디오 세션 활성화에 실패했습니다."
+        case .mediaServicesFailed:
+            return "기기 미디어 서비스 상태에 문제가 있어 재생할 수 없습니다."
+        case .prepareFailed:
+            return "오디오 재생 준비에 실패했습니다."
+        case .playFailed:
+            return "오디오 재생을 시작할 수 없습니다."
+        case .pauseFailed:
+            return "오디오 재생을 일시정지할 수 없습니다."
+        case .seekFailed:
+            return "오디오 위치를 이동할 수 없습니다."
+        case .stopFailed:
+            return "오디오 재생을 중지할 수 없습니다."
+        case .unknown(let error):
+            return "알 수 없는 에러가 발생했습니다: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Data/Sources/Repositories/VoiceRecords/DefaultVoiceRecordPlaybackRepository.swift
+++ b/Data/Sources/Repositories/VoiceRecords/DefaultVoiceRecordPlaybackRepository.swift
@@ -1,0 +1,63 @@
+import Core
+import Domain
+import Foundation
+
+public struct DefaultVoiceRecordPlaybackRepository: VoiceRecordPlaybackRepository {
+    private let audioPlaybackService: any AudioPlaybackService
+
+    public init(audioPlaybackService: any AudioPlaybackService) {
+        self.audioPlaybackService = audioPlaybackService
+    }
+
+    public func prepare(audioFileURL: URL) async throws(VoiceRecordPlaybackRepositoryError)
+        -> AsyncStream<AudioPlaybackState>
+    {
+        if Task.isCancelled { throw .cancelled }
+        do {
+            return try await audioPlaybackService.preparePlayback(at: audioFileURL)
+        } catch {
+            AppLogger.error(error)
+            throw VoiceRecordPlaybackRepositoryError(error)
+        }
+    }
+
+    public func play() async throws(VoiceRecordPlaybackRepositoryError) {
+        if Task.isCancelled { throw .cancelled }
+        do {
+            try await audioPlaybackService.play()
+        } catch {
+            AppLogger.error(error)
+            throw VoiceRecordPlaybackRepositoryError(error)
+        }
+    }
+
+    public func pause() async throws(VoiceRecordPlaybackRepositoryError) {
+        if Task.isCancelled { throw .cancelled }
+        do {
+            try await audioPlaybackService.pause()
+        } catch {
+            AppLogger.error(error)
+            throw VoiceRecordPlaybackRepositoryError(error)
+        }
+    }
+
+    public func seek(to time: TimeInterval) async throws(VoiceRecordPlaybackRepositoryError) {
+        if Task.isCancelled { throw .cancelled }
+        do {
+            try await audioPlaybackService.seek(to: time)
+        } catch {
+            AppLogger.error(error)
+            throw VoiceRecordPlaybackRepositoryError(error)
+        }
+    }
+
+    public func stop() async throws(VoiceRecordPlaybackRepositoryError) {
+        if Task.isCancelled { throw .cancelled }
+        do {
+            try await audioPlaybackService.stop()
+        } catch {
+            AppLogger.error(error)
+            throw VoiceRecordPlaybackRepositoryError(error)
+        }
+    }
+}

--- a/Data/Sources/Repositories/VoiceRecords/VoiceRecordPlaybackRepositoryError+Mapping.swift
+++ b/Data/Sources/Repositories/VoiceRecords/VoiceRecordPlaybackRepositoryError+Mapping.swift
@@ -1,0 +1,32 @@
+import Domain
+
+extension VoiceRecordPlaybackRepositoryError {
+    init(_ error: AudioPlaybackServiceError) {
+        switch error {
+        case .notPrepared:
+            self = .notPrepared
+        case .prepareFailed:
+            self = .prepareFailed
+        case .sessionActivationFailed, .mediaServicesFailed, .playFailed:
+            self = .playFailed
+        case .pauseFailed:
+            self = .pauseFailed
+        case .seekFailed:
+            self = .seekFailed
+        case .stopFailed:
+            self = .stopFailed
+        case .unknown(let underlying):
+            self = .unknown(underlying)
+        }
+    }
+
+    init(_ error: Error) {
+        if let repositoryError = error as? VoiceRecordPlaybackRepositoryError {
+            self = repositoryError
+        } else if let serviceError = error as? AudioPlaybackServiceError {
+            self = .init(serviceError)
+        } else {
+            self = .unknown(error)
+        }
+    }
+}

--- a/Data/Tests/Interfaces/AudioPlayback/MockAudioPlaybackService.swift
+++ b/Data/Tests/Interfaces/AudioPlayback/MockAudioPlaybackService.swift
@@ -1,0 +1,132 @@
+@testable import Data
+import Domain
+import Foundation
+import XCTest
+
+actor MockAudioPlaybackService: AudioPlaybackService {
+    private var prepareResult: Result<AsyncStream<AudioPlaybackState>, AudioPlaybackServiceError>?
+    private var playResult: Result<Void, AudioPlaybackServiceError>?
+    private var pauseResult: Result<Void, AudioPlaybackServiceError>?
+    private var seekResult: Result<Void, AudioPlaybackServiceError>?
+    private var stopResult: Result<Void, AudioPlaybackServiceError>?
+
+    private var prepareCallCount = 0
+    private var playCallCount = 0
+    private var pauseCallCount = 0
+    private var seekCallCount = 0
+    private var stopCallCount = 0
+
+    private var expectedPrepareCallCount: Int?
+    private var expectedPlayCallCount: Int?
+    private var expectedPauseCallCount: Int?
+    private var expectedSeekCallCount: Int?
+    private var expectedStopCallCount: Int?
+
+    private(set) var preparedURL: URL?
+    private(set) var lastSeekTime: TimeInterval?
+
+    func setPrepareResult(_ result: Result<AsyncStream<AudioPlaybackState>, AudioPlaybackServiceError>) {
+        prepareResult = result
+    }
+
+    func setPlayResult(_ result: Result<Void, AudioPlaybackServiceError>) {
+        playResult = result
+    }
+
+    func setPauseResult(_ result: Result<Void, AudioPlaybackServiceError>) {
+        pauseResult = result
+    }
+
+    func setSeekResult(_ result: Result<Void, AudioPlaybackServiceError>) {
+        seekResult = result
+    }
+
+    func setStopResult(_ result: Result<Void, AudioPlaybackServiceError>) {
+        stopResult = result
+    }
+
+    func expectPrepare(callCount: Int) {
+        expectedPrepareCallCount = callCount
+    }
+
+    func expectPlay(callCount: Int) {
+        expectedPlayCallCount = callCount
+    }
+
+    func expectPause(callCount: Int) {
+        expectedPauseCallCount = callCount
+    }
+
+    func expectSeek(callCount: Int) {
+        expectedSeekCallCount = callCount
+    }
+
+    func expectStop(callCount: Int) {
+        expectedStopCallCount = callCount
+    }
+
+    func verify(file: StaticString = #filePath, line: UInt = #line) {
+        if let expectedPrepareCallCount {
+            XCTAssertEqual(prepareCallCount, expectedPrepareCallCount, file: file, line: line)
+        }
+        if let expectedPlayCallCount {
+            XCTAssertEqual(playCallCount, expectedPlayCallCount, file: file, line: line)
+        }
+        if let expectedPauseCallCount {
+            XCTAssertEqual(pauseCallCount, expectedPauseCallCount, file: file, line: line)
+        }
+        if let expectedSeekCallCount {
+            XCTAssertEqual(seekCallCount, expectedSeekCallCount, file: file, line: line)
+        }
+        if let expectedStopCallCount {
+            XCTAssertEqual(stopCallCount, expectedStopCallCount, file: file, line: line)
+        }
+    }
+
+    func preparePlayback(at fileURL: URL) async throws(AudioPlaybackServiceError) -> AsyncStream<AudioPlaybackState> {
+        prepareCallCount += 1
+        preparedURL = fileURL
+        guard let prepareResult else {
+            XCTFail("prepareResult가 설정되지 않았습니다.")
+            throw .prepareFailed
+        }
+        return try prepareResult.get()
+    }
+
+    func play() async throws(AudioPlaybackServiceError) {
+        playCallCount += 1
+        guard let playResult else {
+            XCTFail("playResult가 설정되지 않았습니다.")
+            throw .playFailed
+        }
+        _ = try playResult.get()
+    }
+
+    func pause() async throws(AudioPlaybackServiceError) {
+        pauseCallCount += 1
+        guard let pauseResult else {
+            XCTFail("pauseResult가 설정되지 않았습니다.")
+            throw .pauseFailed
+        }
+        _ = try pauseResult.get()
+    }
+
+    func seek(to time: TimeInterval) async throws(AudioPlaybackServiceError) {
+        seekCallCount += 1
+        lastSeekTime = time
+        guard let seekResult else {
+            XCTFail("seekResult가 설정되지 않았습니다.")
+            throw .seekFailed
+        }
+        _ = try seekResult.get()
+    }
+
+    func stop() async throws(AudioPlaybackServiceError) {
+        stopCallCount += 1
+        guard let stopResult else {
+            XCTFail("stopResult가 설정되지 않았습니다.")
+            throw .stopFailed
+        }
+        _ = try stopResult.get()
+    }
+}

--- a/Data/Tests/Repositories/VoiceRecords/DefaultVoiceRecordPlaybackRepositoryTests.swift
+++ b/Data/Tests/Repositories/VoiceRecords/DefaultVoiceRecordPlaybackRepositoryTests.swift
@@ -1,0 +1,59 @@
+@testable import Data
+import Domain
+import XCTest
+
+final class DefaultVoiceRecordPlaybackRepositoryTests: XCTestCase {}
+
+extension DefaultVoiceRecordPlaybackRepositoryTests {
+    func test_prepare호출시_servicePrepare를호출하고결과를반환한다() async throws {
+        let service = MockAudioPlaybackService()
+        let sut = DefaultVoiceRecordPlaybackRepository(audioPlaybackService: service)
+        let stream = AsyncStream<AudioPlaybackState> { continuation in
+            continuation.yield(.init(status: .idle, currentTime: 0, duration: 90))
+            continuation.finish()
+        }
+        let audioURL = URL(fileURLWithPath: "/tmp/playback.m4a")
+        await service.setPrepareResult(.success(stream))
+        await service.expectPrepare(callCount: 1)
+
+        let result = try await sut.prepare(audioFileURL: audioURL)
+        let preparedURL = await service.preparedURL
+        var iterator = result.makeAsyncIterator()
+        let initialState = await iterator.next()
+
+        XCTAssertEqual(initialState, .init(status: .idle, currentTime: 0, duration: 90))
+        XCTAssertEqual(preparedURL, audioURL)
+        await service.verify()
+    }
+
+    func test_play실패시_repositoryError로매핑한다() async {
+        let service = MockAudioPlaybackService()
+        let sut = DefaultVoiceRecordPlaybackRepository(audioPlaybackService: service)
+        await service.setPlayResult(.failure(.playFailed))
+        await service.expectPlay(callCount: 1)
+
+        do {
+            try await sut.play()
+            XCTFail("VoiceRecordPlaybackRepositoryError.playFailed 에러를 throw 해야 합니다.")
+        } catch {
+            guard case .playFailed = error else {
+                return XCTFail("예상한 에러와 다릅니다: \(error)")
+            }
+        }
+
+        await service.verify()
+    }
+
+    func test_seek호출시_serviceSeek를호출한다() async throws {
+        let service = MockAudioPlaybackService()
+        let sut = DefaultVoiceRecordPlaybackRepository(audioPlaybackService: service)
+        await service.setSeekResult(.success(()))
+        await service.expectSeek(callCount: 1)
+
+        try await sut.seek(to: 15)
+        let lastSeekTime = await service.lastSeekTime
+
+        XCTAssertEqual(lastSeekTime, 15)
+        await service.verify()
+    }
+}

--- a/Domain/Sources/Policy.swift
+++ b/Domain/Sources/Policy.swift
@@ -31,6 +31,6 @@ public enum Policy {
     /// 재생 상태 스트림의 최대 대기 개수 (초과 시 최신값 유지)
     public static let playbackStateStreamBufferLimit: Int = 8
 
-    /// 재생 진행률 업데이트 주기 (나노초, 1초)
-    public static let playbackProgressUpdateInterval: UInt64 = 1_000_000_000
+    /// 재생 진행률 업데이트 주기 (나노초, 0.1초)
+    public static let playbackProgressUpdateInterval: UInt64 = 100_000_000
 }

--- a/Domain/Sources/Policy.swift
+++ b/Domain/Sources/Policy.swift
@@ -27,4 +27,10 @@ public enum Policy {
 
     /// 최근 기록 탭에서 표시할 최대 VoiceNote 개수
     public static let recentVoiceNoteLimit: Int = 5
+
+    /// 재생 상태 스트림의 최대 대기 개수 (초과 시 최신값 유지)
+    public static let playbackStateStreamBufferLimit: Int = 8
+
+    /// 재생 진행률 업데이트 주기 (나노초, 1초)
+    public static let playbackProgressUpdateInterval: UInt64 = 1_000_000_000
 }


### PR DESCRIPTION
## ✨ 작업 요약
> 음성 녹음 파일 재생을 위한 Data 레이어(Service, Repository) 구현 및 단위 테스트 추가

## 📋 구체적인 내용
- **추가/변경된 동작**:
    - `AVAudioPlayer`를 활용한 오디오 재생 서비스(`AudioPlaybackPlayerService`) 구현
    - `AsyncStream`을 통한 실시간 재생 상태(상태, 현재 시간, 총 시간) 스트리밍 지원
    - `VoiceRecordPlaybackRepository` 실체화(`DefaultVoiceRecordPlaybackRepository`)
    - 오디오 중단(Interruption) 및 세션 제어 로직 추가
- **영향 받는 화면/모듈**:
    - `Data` 모듈 (Infrastructure, Interfaces, Repositories)
    - `Domain` 모듈 (Policy 상수 추가)

---

## 🔗 연관 이슈

- closed #176

---

## 🧩 설계·구현 노트

- **선택한 방식**
    - **AsyncStream 기반 상태 관리**: Delegate나 Notification 대신 `AsyncStream`을 사용하여 재생 상태 변화를 단일 파이프라인으로 관찰할 수 있게 했습니다. 이는 UI 레이어에서 별도의 상태 관리 로직을 줄이고 리액티브하게 대응하기 위함입니다.
    - **@MainActor 격리**: `AVAudioPlayer`와 재생 상태 데이터들이 메인 스레드에서만 접근되도록 보장하여, 별도의 Lock 없이도 안전하게 상태를 업데이트하도록 설계했습니다.
    - **Policy 상수화**: 스트림 버퍼 크기나 업데이트 간격(0.1초)을 `Policy.swift`에서 관리하여 유지보수성을 높였습니다.

- **고려했다가 제외한 방식**
    - **AVPlayer 사용**: 스트리밍 재생이 아닌 로컬 파일 재생 위주이므로, 오버헤드가 적고 세밀한 제어가 용이한 `AVAudioPlayer`를 선택했습니다.

---

## ✅ 확인 사항

- [x] 정상 플로우 동작 확인 (Play, Pause, Seek, Stop)
- [x] 엣지 케이스 / 빈 값·에러 처리 확인 (파일 로드 실패, 세션 활성 실패 등)
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [x] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [ ] `AudioPlaybackPlayerService`에서 `AsyncStream`을 생성하고 `Continuation`을 관리하는 방식이 적절한지
- [ ] `AVAudioSession`의 활성화/비활성화 시점이 오디오 중단 시나리오(전화 등)를 잘 커버하고 있는지
- [ ] `DefaultVoiceRecordPlaybackRepositoryTests`에서 Mock을 통한 검증 로직이 충분한지

**특히 봐줬으면 하는 부분**

- `AudioPlaybackPlayerService`의 `streamProgress()` 내 `Task.sleep` 간격(0.1초)이 UI 애니메이션을 구현하기에 적절한지 의견 부탁드립니다.

---

## 📚 참고

- [AVAudioPlayerDelegate Documentation](https://developer.apple.com/documentation/avfaudio/avaudioplayerdelegate)
