### PR TITLE
차곡 배경 적용 및 컴포넌트 리펙토링 합니다.

### DIFF
--- a/Presentation/Sources/Component/Common/AlertView.swift
+++ b/Presentation/Sources/Component/Common/AlertView.swift
@@ -57,6 +57,7 @@ final class AlertView: UIView {
         self.primaryButton = primaryButton
         super.init(frame: frame)
         setup()
+        setupButton()
         childSetup()
     }
 
@@ -103,6 +104,16 @@ extension AlertView {
         backgroundColor = .point200.withAlphaComponent(Constant.backgroundOpacity)
         layer.borderWidth = Constant.borderWidth
         layer.borderColor = UIColor.gray600.cgColor
+    }
+
+    /// AlertView에 맞게 외부 설정 값 상관 없이 내부에서 일관된 디자인을  처리합니다.
+    private func setupButton() {
+        // close
+        closeButton.setShadow(false)
+        closeButton.setCapsuleCornerRadius()
+        // primary
+        primaryButton.setShadow(false)
+        primaryButton.setCapsuleCornerRadius()
     }
 
     /// AlertView 내부의 컴포넌트들(제목, 부제목, 버튼 등)을 StackView에 배치하고

--- a/Presentation/Sources/Component/Common/GlassButton.swift
+++ b/Presentation/Sources/Component/Common/GlassButton.swift
@@ -7,11 +7,6 @@ final class GlassButton: UIButton {
     var isShadow: Bool = true
     var cornerRadius: CGFloat = Constant.cornerRadius
 
-    struct Border {
-        let color: UIColor
-        let width: CGFloat
-    }
-
     // MARK: - Initializer
 
     override init(frame: CGRect) {
@@ -21,7 +16,7 @@ final class GlassButton: UIButton {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        nil
     }
 
     // MARK: - Lifecycle
@@ -60,6 +55,10 @@ final class GlassButton: UIButton {
     override func updateConfiguration() {
         super.updateConfiguration()
         configuration?.background.cornerRadius = cornerRadius
+
+        if let unifiedView = configuration?.background.customView as? UnifiedGradientView {
+            unifiedView.updateCornerRadius(cornerRadius)
+        }
     }
 }
 
@@ -72,26 +71,29 @@ extension GlassButton {
         clipsToBounds = false
     }
 
-    /// GlassButton의 전반적인 디자인(텍스트, 폰트, 테두리, 배경색 등)을 세부적으로 구성합니다.
+    /// GlassButton의 전반적인 디자인(텍스트, 폰트, 테두리, 배경색, 이미지 등)을 세부적으로 구성합니다.
+    /// 단일 색상(Solid Color)뿐만 아니라 배열 형태의 그라데이션(Gradient) 색상 적용도 투명 효과와 함께 지원합니다.
     ///
     /// - Parameters:
-    ///   - title: 버튼 내부에 표시될 텍스트 문자열입니다.
+    ///   - title: 버튼 내부에 표시될 텍스트 문자열입니다. 타이틀이 필요 없을 경우 nil을 전달합니다.
     ///   - typography: 애플리케이션 공통 폰트 지정 열거형(`Typography`)으로 폰트 스타일을 적용합니다.
-    ///   - border: 필요에 따라 테두리(색상, 두께)를 지정하는 `Border` 구조체를 전달합니다. 옵셔널 값입니다.
-    ///   - backgroundColor: 버튼의 기본 배경색 (기본값: `.point600`).
-    ///   - foregroundColor: 버튼 텍스트의 기본 색상 (기본값: `.white`).
+    ///   - border: 필요에 따라 테두리를 지정하는 `Border` 구조체를 전달합니다. 단색 또는 그라데이션(`GradientSet`), 두께를 설정할 수 있습니다.
+    ///   - image: 버튼 내에 들어갈 아이콘 이미지(`ImageAsset`)를 지정합니다. 리소스 형식과 SFSymbol 형식을 모두 지정 가능합니다.
+    ///   - backgroundColor: 버튼의 배경색을 결정하는 `GradientSet` 열거형입니다. 단색 또는 여러 색상 배열의 그라데이션을 사용할 수 있습니다. (기본값:
+    /// `.color(.point600)`)
+    ///   - foregroundColor: 버튼 텍스트 및 이미지의 기본 색상입니다. (기본값: `.white`)
     func configure(
-        _ title: String,
+        _ title: String?,
         typography: Typography,
         border: Border? = nil,
-        backgroundColor: UIColor = .point600,
+        image: ImageAsset? = nil,
+        backgroundColor: GradientSet = .color(.point600),
         foregroundColor: UIColor = .white
     ) {
         var config: UIButton.Configuration = .prominentGlass()
 
         config.title = title
         config.baseForegroundColor = foregroundColor
-        config.baseBackgroundColor = backgroundColor
         config.background.cornerRadius = cornerRadius
         config.cornerStyle = .fixed
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
@@ -100,9 +102,55 @@ extension GlassButton {
             return outgoing
         }
 
+        if let image {
+            switch image.type {
+            case .resource:
+                config.image = UIImage(named: image.imageName)
+            case .system:
+                config.image = UIImage(systemName: image.imageName)
+            }
+        }
+
+        var needsCustomView = false
+        var bgColors: [UIColor]? = nil
+        var bgColor: UIColor? = nil
+        var borderColors: [UIColor]? = nil
+
+        switch backgroundColor {
+        case .color(let color):
+            bgColor = color
+            config.baseBackgroundColor = color
+        case .gradient(let colors):
+            bgColors = colors
+            config.baseBackgroundColor = .clear
+            needsCustomView = true
+        }
+
         if let border {
-            config.background.strokeColor = border.color
-            config.background.strokeWidth = border.width
+            switch border.color {
+            case .color(let color):
+                config.background.strokeColor = color
+                config.background.strokeWidth = border.width
+            case .gradient(let colors):
+                borderColors = colors
+                config.background.strokeWidth = 0
+                needsCustomView = true
+            }
+        }
+
+        if needsCustomView {
+            let unifiedView = UnifiedGradientView(
+                bgColor: bgColors == nil ? bgColor : nil,
+                bgColors: bgColors,
+                borderColors: borderColors,
+                borderWidth: border?.width ?? 0,
+                cornerRadius: cornerRadius
+            )
+            config.background.customView = unifiedView
+
+            if bgColors == nil {
+                config.baseBackgroundColor = .clear
+            }
         }
 
         configuration = config
@@ -121,6 +169,8 @@ extension GlassButton {
     }
 }
 
+// MARK: GlassButton Factory
+
 extension GlassButton {
     /// 기본 스타일의 GlassButton 인스턴스를 생성하여 반환합니다.
     /// - Parameter title: 버튼에 표시될 텍스트
@@ -130,8 +180,8 @@ extension GlassButton {
         btn.configure(
             title,
             typography: .subtitle1,
-            border: Border(color: UIColor.gray600, width: Constant.borderWidth),
-            backgroundColor: UIColor.point200.withAlphaComponent(Constant.backgroundOpacity),
+            border: Border(color: .color(UIColor.gray600), width: Constant.borderWidth),
+            backgroundColor: .color(UIColor.point200.withAlphaComponent(Constant.backgroundOpacity)),
             foregroundColor: UIColor.gray900
         )
 
@@ -146,7 +196,7 @@ extension GlassButton {
         btn.configure(
             title,
             typography: .subtitle1,
-            backgroundColor: UIColor.point600,
+            backgroundColor: .color(UIColor.point600),
             foregroundColor: .white
         )
 
@@ -161,7 +211,7 @@ extension GlassButton {
         btn.configure(
             title,
             typography: .subtitle1,
-            backgroundColor: UIColor.danger,
+            backgroundColor: .color(UIColor.danger),
             foregroundColor: .white
         )
         return btn
@@ -175,9 +225,129 @@ extension GlassButton {
         btn.configure(
             title,
             typography: .body1,
-            backgroundColor: UIColor.gray300,
+            backgroundColor: .color(UIColor.gray300),
             foregroundColor: UIColor.gray750
         )
         return btn
+    }
+
+    /// 64x64 크기의 둥근 플로팅 액션 버튼(FAB) 형태인 GlassButton 인스턴스를 생성하여 반환합니다.
+    /// 배경과 테두리에 기본적으로 음성 녹음 관련 그라데이션 컬러 매핑이 적용되어 있습니다.
+    ///
+    /// - Parameter image: 버튼 중앙에 표시할 아이콘 이미지 (`ImageAsset`)
+    /// - Returns: 기본 제약조건(Width, Height) 및 그라데이션 스타일이 적용된 GlassButton 인스턴스
+    static func floating(image: ImageAsset) -> GlassButton {
+        let btn = GlassButton()
+        btn.configure(
+            nil,
+            typography: .body1,
+            border: .init(color: .gradient([.point900, .point1000]), width: 1),
+            image: image,
+            backgroundColor: .gradient([.point800, .point600]),
+            foregroundColor: UIColor.gray950
+        )
+        btn.widthAnchor.constraint(equalToConstant: Constant.floatingButtonSize).isActive = true
+        btn.heightAnchor.constraint(equalToConstant: Constant.floatingButtonSize).isActive = true
+
+        return btn
+    }
+}
+
+// MARK: Data 구조
+
+extension GlassButton {
+    struct Border {
+        let color: GradientSet
+        let width: CGFloat
+    }
+
+    struct ImageAsset {
+        let imageName: String
+        let type: GlassImageType
+    }
+
+    enum GlassImageType {
+        case resource
+        case system
+    }
+
+    enum GradientSet {
+        case color(UIColor)
+        case gradient([UIColor])
+    }
+}
+
+// MARK: - Gradient 커스텀 뷰
+
+private final class UnifiedGradientView: UIView {
+    private let backgroundGradientLayer = CAGradientLayer()
+    private let borderGradientLayer = CAGradientLayer()
+    private let borderMaskLayer = CAShapeLayer()
+
+    private var currentCornerRadius: CGFloat
+
+    init(
+        bgColor: UIColor?,
+        bgColors: [UIColor]?,
+        borderColors: [UIColor]?,
+        borderWidth: CGFloat,
+        cornerRadius: CGFloat
+    ) {
+        currentCornerRadius = cornerRadius
+        super.init(frame: .zero)
+        isUserInteractionEnabled = false
+
+        if let bgColor {
+            backgroundColor = bgColor
+        }
+
+        if let bgColors {
+            backgroundGradientLayer.colors = bgColors.map(\.cgColor)
+            backgroundGradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
+            backgroundGradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+            layer.addSublayer(backgroundGradientLayer)
+        }
+
+        if let borderColors {
+            borderGradientLayer.colors = borderColors.map(\.cgColor)
+            borderGradientLayer.startPoint = CGPoint(x: 0.5, y: 1)
+            borderGradientLayer.endPoint = CGPoint(x: 0.5, y: 0)
+
+            borderMaskLayer.fillColor = UIColor.clear.cgColor
+            borderMaskLayer.strokeColor = UIColor.black.cgColor
+            borderMaskLayer.lineWidth = borderWidth
+            borderGradientLayer.mask = borderMaskLayer
+
+            layer.addSublayer(borderGradientLayer)
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    func updateCornerRadius(_ radius: CGFloat) {
+        currentCornerRadius = radius
+        setNeedsLayout()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        if backgroundGradientLayer.superlayer != nil {
+            backgroundGradientLayer.frame = bounds
+            backgroundGradientLayer.cornerRadius = currentCornerRadius
+        }
+
+        if borderGradientLayer.superlayer != nil {
+            borderGradientLayer.frame = bounds
+            let inset = borderMaskLayer.lineWidth / 2
+            let path = UIBezierPath(
+                roundedRect: bounds.insetBy(dx: inset, dy: inset),
+                cornerRadius: max(currentCornerRadius - inset, 0)
+            )
+            borderMaskLayer.path = path.cgPath
+        }
     }
 }

--- a/Presentation/Sources/DesignSystem/Constant.swift
+++ b/Presentation/Sources/DesignSystem/Constant.swift
@@ -31,6 +31,9 @@ public extension Constant {
     /// GlassButton Shadow Offset ( width, height )
     static let shadowOffsetWidth: CGFloat = 2
     static let shadowOffsetHeight: CGFloat = 2
+
+    /// GlassButton Floating Size
+    static let floatingButtonSize: CGFloat = 64
 }
 
 // MARK: - AlertView Constants

--- a/Presentation/Sources/DesignSystem/Constant.swift
+++ b/Presentation/Sources/DesignSystem/Constant.swift
@@ -164,6 +164,7 @@ public extension Constant {
     /// LanguagePicker 라디오 버튼과 텍스트 사이 간격 (6)
     static let languagePickerTitleSpacing: CGFloat = 6
 }
+
 // MARK: - BackgroundView Constants
 
 public extension Constant {

--- a/Presentation/Sources/DesignSystem/Constant.swift
+++ b/Presentation/Sources/DesignSystem/Constant.swift
@@ -164,3 +164,33 @@ public extension Constant {
     /// LanguagePicker 라디오 버튼과 텍스트 사이 간격 (6)
     static let languagePickerTitleSpacing: CGFloat = 6
 }
+// MARK: - BackgroundView Constants
+
+public extension Constant {
+    /// 첫 번째 타원 초기 높이 (195)
+    static let ellipseFirstHeight: CGFloat = 195
+    /// 두 번째 타원 초기 높이 (116)
+    static let ellipseSecondHeight: CGFloat = 116
+    /// 첫 번째 타원 초기 Blur (100)
+    static let ellipseFirstBlur: CGFloat = 100
+    /// 두 번째 타원 초기 Blur (40)
+    static let ellipseSecondBlur: CGFloat = 40
+
+    /// 첫 번째 타원 Blur 진폭 배율 (250)
+    static let ellipseFirstBlurAmplitudeMultiplier: CGFloat = 250
+    /// 두 번째 타원 Blur 진폭 배율 (100)
+    static let ellipseSecondBlurAmplitudeMultiplier: CGFloat = 100
+    /// 첫 번째 타원 높이 진폭 배율 (643)
+    static let ellipseFirstHeightAmplitudeMultiplier: CGFloat = 643
+    /// 두 번째 타원 높이 진폭 배율 (204)
+    static let ellipseSecondHeightAmplitudeMultiplier: CGFloat = 204
+
+    /// 첫 번째 타원 Leading Offset (-16)
+    static let ellipseFirstLeadingOffset: CGFloat = -16
+    /// 첫 번째 타원 Trailing Offset (16)
+    static let ellipseFirstTrailingOffset: CGFloat = 16
+    /// 첫 번째 타원 Bottom Offset (69)
+    static let ellipseFirstBottomOffset: CGFloat = 69
+    /// 두 번째 타원 Bottom Offset (100)
+    static let ellipseSecondBottomOffset: CGFloat = 100
+}

--- a/Presentation/Sources/DesignSystem/UIViewController+Extension.swift
+++ b/Presentation/Sources/DesignSystem/UIViewController+Extension.swift
@@ -1,0 +1,220 @@
+import UIKit
+
+// MARK: UIViewController
+
+public class ViewController: UIViewController {
+    lazy var chagokBackgroundView: ChaGokBackgroundView = .init()
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    override public func loadView() {
+        view = chagokBackgroundView
+    }
+}
+
+// MARK: UICollectionViewController
+
+public class CollectionViewController: UICollectionViewController {
+    lazy var chagokBackgroundView: ChaGokBackgroundView = .init()
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    override public func loadView() {
+        view = chagokBackgroundView
+    }
+}
+
+// MARK: UICollectionView
+
+public class CollectionView: UICollectionView {
+    lazy var chagokBackgroundView: ChaGokBackgroundView = .init()
+
+    override public init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
+        super.init(frame: frame, collectionViewLayout: layout)
+        backgroundView = chagokBackgroundView
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        backgroundView = chagokBackgroundView
+    }
+}
+
+// MARK: UITableViewController
+
+public class TableViewController: UITableViewController {
+    lazy var chagokBackgroundView: ChaGokBackgroundView = .init()
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    override public func loadView() {
+        view = chagokBackgroundView
+    }
+}
+
+// MARK: UITableView
+
+public class TableView: UITableView {
+    lazy var chagokBackgroundView: ChaGokBackgroundView = .init()
+
+    override public init(frame: CGRect, style: UITableView.Style) {
+        super.init(frame: frame, style: style)
+        backgroundView = chagokBackgroundView
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        backgroundView = chagokBackgroundView
+    }
+}
+
+// MARK: - Background 커스텀 뷰
+
+final class ChaGokBackgroundView: UIView {
+    let ellipseFirst: UIView = {
+        let e = UIView()
+        e.translatesAutoresizingMaskIntoConstraints = false
+        return e
+    }()
+
+    let ellipseSecond: UIView = {
+        let e = UIView()
+        e.translatesAutoresizingMaskIntoConstraints = false
+        e.backgroundColor = .yellow
+        return e
+    }()
+
+    // 제약조건(Constraint)을 애니메이션 시점에 변경하기 위해 참조를 유지합니다.
+    private var ellipseFirstHeightConstraint: NSLayoutConstraint?
+    private var ellipseSecondHeightConstraint: NSLayoutConstraint?
+
+    var animationValue: AnimationValue = .init()
+    var amplitude: Amplitude = .init()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+        setupEllipseFirst()
+        setupEllipseSecond()
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        ellipseFirstStyle()
+        ellipseSecondStyle()
+    }
+
+    override func updateProperties() {
+        super.updateProperties()
+        let amp = CGFloat(amplitude.value)
+
+        // 속성(Properties) 업데이트: Blur 반경
+        let firstBlur = animationValue.ellipseFirstBlur + (amp * 250)
+        let secondBlur = animationValue.ellipseSecondBlur + (amp * 100)
+        ellipseFirst.layer.shadowRadius = firstBlur
+        ellipseSecond.layer.shadowRadius = secondBlur
+        // background Color
+        ellipseFirst.layer.shadowColor = amp == 0.0 ? UIColor.point300.cgColor : UIColor.point300.cgColor
+        ellipseSecond.layer.shadowColor = amp == 0.0 ? UIColor.point500.cgColor : UIColor.point600.cgColor
+    }
+
+    override func updateConstraints() {
+        super.updateConstraints()
+        let amp = CGFloat(amplitude.value)
+        // 제약조건(Constraints) 업데이트: 높이
+        ellipseFirstHeightConstraint?.constant = animationValue.ellipseFirstHeight + (amp * 643)
+        ellipseSecondHeightConstraint?.constant = animationValue.ellipseSecondHeight + (amp * 204)
+    }
+
+    private func setup() {
+        backgroundColor = UIColor.gray50
+        addSubview(ellipseFirst)
+        addSubview(ellipseSecond)
+    }
+
+    private func setupEllipseFirst() {
+        let heightConstraint = ellipseFirst.heightAnchor.constraint(equalToConstant: animationValue.ellipseFirstHeight)
+        ellipseFirstHeightConstraint = heightConstraint
+
+        NSLayoutConstraint.activate([
+            ellipseFirst.centerXAnchor.constraint(equalTo: centerXAnchor),
+            ellipseFirst.leadingAnchor.constraint(equalTo: leadingAnchor, constant: -16),
+            ellipseFirst.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 16),
+            heightConstraint,
+            ellipseFirst.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 69)
+        ])
+    }
+
+    private func setupEllipseSecond() {
+        let heightConstraint = ellipseSecond.heightAnchor
+            .constraint(equalToConstant: animationValue.ellipseSecondHeight)
+        ellipseSecondHeightConstraint = heightConstraint
+
+        NSLayoutConstraint.activate([
+            ellipseSecond.centerXAnchor.constraint(equalTo: centerXAnchor),
+            ellipseSecond.leadingAnchor.constraint(equalTo: leadingAnchor),
+            ellipseSecond.trailingAnchor.constraint(equalTo: trailingAnchor),
+            heightConstraint,
+            ellipseSecond.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 100)
+        ])
+    }
+}
+
+// MARK: Ellipse Data 구조
+
+extension ChaGokBackgroundView {
+    @Observable
+    final class Amplitude {
+        var value: Float
+
+        init(value: Float = 0.0) {
+            self.value = value
+        }
+    }
+
+    struct AnimationValue {
+        // 제약조건의 높이 최소/최대 (원하시는 수치로 언제든 수정 가능합니다)
+        var ellipseFirstHeight: CGFloat = 195
+        var ellipseSecondHeight: CGFloat = 116
+        // Blur(그림자 흐림 반경)
+        var ellipseFirstBlur: CGFloat = 100
+        var ellipseSecondBlur: CGFloat = 40
+    }
+}
+
+// MARK: Ellipse Style
+
+extension ChaGokBackgroundView {
+    private func ellipseFirstStyle() {
+        let path = UIBezierPath(ovalIn: ellipseFirst.bounds)
+        ellipseFirst.backgroundColor = .clear
+        ellipseFirst.layer.shadowOpacity = 1.0
+        ellipseFirst.layer.shadowOffset = .zero
+        ellipseFirst.layer.shadowPath = path.cgPath
+    }
+
+    private func ellipseSecondStyle() {
+        let rectForHalfEllipse = CGRect(
+            x: 0,
+            y: 0,
+            width: ellipseSecond.bounds.width,
+            height: ellipseSecond.bounds.height * 2
+        )
+        // 반타원 패스
+        let path = UIBezierPath(ovalIn: rectForHalfEllipse)
+        ellipseSecond.backgroundColor = .clear
+        ellipseSecond.layer.shadowOpacity = 1.0
+        ellipseSecond.layer.shadowOffset = .zero
+        ellipseSecond.layer.shadowPath = path.cgPath
+    }
+}

--- a/Presentation/Sources/DesignSystem/UIViewController+Extension.swift
+++ b/Presentation/Sources/DesignSystem/UIViewController+Extension.swift
@@ -5,10 +5,6 @@ import UIKit
 public class ViewController: UIViewController {
     lazy var chagokBackgroundView: ChaGokBackgroundView = .init()
 
-    override public func viewDidLoad() {
-        super.viewDidLoad()
-    }
-
     override public func loadView() {
         view = chagokBackgroundView
     }
@@ -21,10 +17,8 @@ public class CollectionViewController: UICollectionViewController {
 
     override public func viewDidLoad() {
         super.viewDidLoad()
-    }
-
-    override public func loadView() {
-        view = chagokBackgroundView
+        collectionView.backgroundView = chagokBackgroundView
+        collectionView.backgroundColor = .clear
     }
 }
 
@@ -51,10 +45,8 @@ public class TableViewController: UITableViewController {
 
     override public func viewDidLoad() {
         super.viewDidLoad()
-    }
-
-    override public func loadView() {
-        view = chagokBackgroundView
+        tableView.backgroundView = chagokBackgroundView
+        tableView.backgroundColor = .clear
     }
 }
 
@@ -86,7 +78,6 @@ final class ChaGokBackgroundView: UIView {
     let ellipseSecond: UIView = {
         let e = UIView()
         e.translatesAutoresizingMaskIntoConstraints = false
-        e.backgroundColor = .yellow
         return e
     }()
 

--- a/Presentation/Sources/DesignSystem/UIViewController+Extension.swift
+++ b/Presentation/Sources/DesignSystem/UIViewController+Extension.swift
@@ -119,21 +119,22 @@ final class ChaGokBackgroundView: UIView {
         let amp = CGFloat(amplitude.value)
 
         // 속성(Properties) 업데이트: Blur 반경
-        let firstBlur = animationValue.ellipseFirstBlur + (amp * 250)
-        let secondBlur = animationValue.ellipseSecondBlur + (amp * 100)
+        let firstBlur = animationValue.ellipseFirstBlur + (amp * Constant.ellipseFirstBlurAmplitudeMultiplier)
+        let secondBlur = animationValue.ellipseSecondBlur + (amp * Constant.ellipseSecondBlurAmplitudeMultiplier)
         ellipseFirst.layer.shadowRadius = firstBlur
         ellipseSecond.layer.shadowRadius = secondBlur
         // background Color
-        ellipseFirst.layer.shadowColor = amp == 0.0 ? UIColor.point300.cgColor : UIColor.point300.cgColor
+        ellipseFirst.layer.shadowColor = amp == 0.0 ? UIColor.point300.cgColor : UIColor.point500.cgColor
         ellipseSecond.layer.shadowColor = amp == 0.0 ? UIColor.point500.cgColor : UIColor.point600.cgColor
+        setNeedsUpdateConstraints()
     }
 
     override func updateConstraints() {
         super.updateConstraints()
         let amp = CGFloat(amplitude.value)
         // 제약조건(Constraints) 업데이트: 높이
-        ellipseFirstHeightConstraint?.constant = animationValue.ellipseFirstHeight + (amp * 643)
-        ellipseSecondHeightConstraint?.constant = animationValue.ellipseSecondHeight + (amp * 204)
+        ellipseFirstHeightConstraint?.constant = animationValue.ellipseFirstHeight + (amp * Constant.ellipseFirstHeightAmplitudeMultiplier)
+        ellipseSecondHeightConstraint?.constant = animationValue.ellipseSecondHeight + (amp * Constant.ellipseSecondHeightAmplitudeMultiplier)
     }
 
     private func setup() {
@@ -148,10 +149,10 @@ final class ChaGokBackgroundView: UIView {
 
         NSLayoutConstraint.activate([
             ellipseFirst.centerXAnchor.constraint(equalTo: centerXAnchor),
-            ellipseFirst.leadingAnchor.constraint(equalTo: leadingAnchor, constant: -16),
-            ellipseFirst.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 16),
+            ellipseFirst.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constant.ellipseFirstLeadingOffset),
+            ellipseFirst.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constant.ellipseFirstTrailingOffset),
             heightConstraint,
-            ellipseFirst.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 69)
+            ellipseFirst.bottomAnchor.constraint(equalTo: bottomAnchor, constant: Constant.ellipseFirstBottomOffset)
         ])
     }
 
@@ -165,7 +166,7 @@ final class ChaGokBackgroundView: UIView {
             ellipseSecond.leadingAnchor.constraint(equalTo: leadingAnchor),
             ellipseSecond.trailingAnchor.constraint(equalTo: trailingAnchor),
             heightConstraint,
-            ellipseSecond.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 100)
+            ellipseSecond.bottomAnchor.constraint(equalTo: bottomAnchor, constant: Constant.ellipseSecondBottomOffset)
         ])
     }
 }
@@ -184,11 +185,11 @@ extension ChaGokBackgroundView {
 
     struct AnimationValue {
         // 제약조건의 높이 최소/최대 (원하시는 수치로 언제든 수정 가능합니다)
-        var ellipseFirstHeight: CGFloat = 195
-        var ellipseSecondHeight: CGFloat = 116
+        var ellipseFirstHeight: CGFloat = Constant.ellipseFirstHeight
+        var ellipseSecondHeight: CGFloat = Constant.ellipseSecondHeight
         // Blur(그림자 흐림 반경)
-        var ellipseFirstBlur: CGFloat = 100
-        var ellipseSecondBlur: CGFloat = 40
+        var ellipseFirstBlur: CGFloat = Constant.ellipseFirstBlur
+        var ellipseSecondBlur: CGFloat = Constant.ellipseSecondBlur
     }
 }
 

--- a/Presentation/Sources/DesignSystem/UIViewController+Extension.swift
+++ b/Presentation/Sources/DesignSystem/UIViewController+Extension.swift
@@ -133,8 +133,10 @@ final class ChaGokBackgroundView: UIView {
         super.updateConstraints()
         let amp = CGFloat(amplitude.value)
         // 제약조건(Constraints) 업데이트: 높이
-        ellipseFirstHeightConstraint?.constant = animationValue.ellipseFirstHeight + (amp * Constant.ellipseFirstHeightAmplitudeMultiplier)
-        ellipseSecondHeightConstraint?.constant = animationValue.ellipseSecondHeight + (amp * Constant.ellipseSecondHeightAmplitudeMultiplier)
+        ellipseFirstHeightConstraint?.constant = animationValue
+            .ellipseFirstHeight + (amp * Constant.ellipseFirstHeightAmplitudeMultiplier)
+        ellipseSecondHeightConstraint?.constant = animationValue
+            .ellipseSecondHeight + (amp * Constant.ellipseSecondHeightAmplitudeMultiplier)
     }
 
     private func setup() {
@@ -150,7 +152,10 @@ final class ChaGokBackgroundView: UIView {
         NSLayoutConstraint.activate([
             ellipseFirst.centerXAnchor.constraint(equalTo: centerXAnchor),
             ellipseFirst.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constant.ellipseFirstLeadingOffset),
-            ellipseFirst.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constant.ellipseFirstTrailingOffset),
+            ellipseFirst.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: Constant.ellipseFirstTrailingOffset
+            ),
             heightConstraint,
             ellipseFirst.bottomAnchor.constraint(equalTo: bottomAnchor, constant: Constant.ellipseFirstBottomOffset)
         ])

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -31,11 +31,13 @@ public final class MainViewController: ViewController {
         let layout = UICollectionViewFlowLayout()
         let c = UICollectionView(frame: .zero, collectionViewLayout: layout)
         c.translatesAutoresizingMaskIntoConstraints = false
-        c.backgroundColor = UIColor.gray50
+        c.backgroundColor = .clear
         return c
     }()
 
-    private let floatingButton: GlassButton = .primary("녹음 시작")
+    private let floatingButton: GlassButton = .floating(
+        image: .init(imageName: "microphone", type: .system)
+    )
 
     var dataSource: UICollectionViewDiffableDataSource<MainSection, MainCellItem>!
 
@@ -64,7 +66,6 @@ public final class MainViewController: ViewController {
     // MARK: Setup
 
     private func setup() {
-        view.backgroundColor = UIColor.gray50
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
         appearance.backgroundColor = UIColor.gray50

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public final class MainViewController: UIViewController {
+public final class MainViewController: ViewController {
     // MARK: - View Model
 
     private let vm: MainViewModel

--- a/Presentation/Sources/View/OnBoarding/OnBoardingViewController.swift
+++ b/Presentation/Sources/View/OnBoarding/OnBoardingViewController.swift
@@ -3,7 +3,7 @@ import Domain
 import Foundation
 import UIKit
 
-public final class OnBoardingViewController: UIViewController {
+public final class OnBoardingViewController: ViewController {
     // MARK: - State
 
     private let vm: OnBoardingViewModel

--- a/Presentation/Sources/View/Recoding/RecordingViewController.swift
+++ b/Presentation/Sources/View/Recoding/RecordingViewController.swift
@@ -1,12 +1,10 @@
 import Domain
 import UIKit
 
-public final class RecordingViewController: UIViewController {
+public final class RecordingViewController: ViewController {
     private let viewModel: RecordingViewModel
 
     // MARK: - UI Components
-
-    private let backgroundView: RecordingBackgroundView = .init()
 
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -73,7 +71,7 @@ public final class RecordingViewController: UIViewController {
 
     override public func updateProperties() {
         super.updateProperties()
-        backgroundView.updateValue(viewModel.state.amplitude)
+        chagokBackgroundView.amplitude = .init(value: viewModel.state.amplitude)
         titleLabel.setTypography(text: viewModel.state.title, style: .header2)
         timestampLabel.setTypography(text: viewModel.state.displayStartDate, style: .subtitle2)
         durationLabel.setTypography(text: viewModel.state.displayDuration, style: .header1)
@@ -99,16 +97,12 @@ public final class RecordingViewController: UIViewController {
     }
 
     private func setupUI() {
-        for item in [backgroundView, titleLabel, durationLabel, recordButton, timestampLabel] {
+        for item in [titleLabel, durationLabel, recordButton, timestampLabel] {
             item.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview(item)
         }
 
         NSLayoutConstraint.activate([
-            backgroundView.topAnchor.constraint(equalTo: view.topAnchor),
-            backgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            backgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            backgroundView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 180),
             titleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 24),

--- a/Presentation/Sources/View/Recoding/RecordingViewController.swift
+++ b/Presentation/Sources/View/Recoding/RecordingViewController.swift
@@ -71,7 +71,7 @@ public final class RecordingViewController: ViewController {
 
     override public func updateProperties() {
         super.updateProperties()
-        chagokBackgroundView.amplitude = .init(value: viewModel.state.amplitude)
+        chagokBackgroundView.amplitude.value = viewModel.state.amplitude
         titleLabel.setTypography(text: viewModel.state.title, style: .header2)
         timestampLabel.setTypography(text: viewModel.state.displayStartDate, style: .subtitle2)
         durationLabel.setTypography(text: viewModel.state.displayDuration, style: .header1)


### PR DESCRIPTION
---

## ✨ 작업 요약
> 한 줄로 무엇을 추가/변경했는지

앱 전반에 쓰이는 동적 그라데이션 배경(`ChaGokBackgroundView`) 상속 구조 구현 및 `GlassButton` 그라데이션 테두리/배경 렌더링 로직 추가

## 📋 구체적인 내용
- **추가/변경된 동작:**
  - `Amplitude` 값 변화에 반응하여 실시간으로 타원 크기 및 Blur가 변동되는 `ChaGokBackgroundView` 구현
  - `GlassButton`에 색상 배열(`[UIColor]`)만으로도 그라데이션 배경과 테두리를 완벽하게 구성할 수 있는 통합 API 지원 및 플로팅 버튼 팩토리 추가
  - `MainViewController`에 신규 Floating 버튼 부착 및 CollectionView 배경색 투명화(`.clear`)로 동적 배경 노출되도록 수정
- **영향 받는 화면/모듈:**
  - 앱 공통 Base UI (상속용 Controller 및 View 모듈화)
  - `GlassButton` (재사용 컴포넌트)
  - `MainViewController` 및 상수 풀(`Constant`)

---

## 🔗 연관 이슈

- closed #184 

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
  - **Base 컨테이너 상속 구조 설계:** `ChaGokBackgroundView`를 화면마다 일일이 선언하여 띄우는 수고를 덜기 위해 `ViewController`, `TableViewController` 등 래핑(Wrapping)된 Base 객체 상속으로 구조화했습니다.
  - **`GlassButton` 커스텀 그라데이션 단일화:** 순정 `UIButton.Configuration`에는 그라데이션 테두리를 지원하는 속성이 없어 불가피하게 `customView`를 사용해야 했습니다. 이때 배경과 테두리가 서로 뷰를 덮어씌우는 현상을 막고자, 두 가지 레이어 상태를 통합 계산하는 단위 뷰(`UnifiedGradientView`)를 구축한 뒤 주입했습니다.
- **고려했다가 제외한 방식**
  - **단순 sublayer 추가 방식:** `GlassButton.layer`에 직접 추가해보았으나 버튼의 눌림이나 모서리 둥글기가 변경되는 런타임 환경에서 크기를 올바르게 추적하지 못해 기각했습니다.

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [x] 정상 플로우 동작 확인
- [ ] 엣지 케이스 / 빈 값·에러 처리 확인
- [x] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [ ] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [x] 예외/에러 핸들링
- [x] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- `GlassButton`에 추가된 `.gradient(["컬러 배열"])` Enum API가 향후 디자인 시스템 구성에 있어 직관적인지 확인 부탁드립니다.
- **(팀원 필수 안내 사항)** 앞으로 UI를 구성하실 때 기본 `UIViewController`, `UITableView` 대신 확장을 통해 만들어둔 `ViewController`, `TableView` 객체를 상속해서 사용해주세요. Background View가 자동으로 편하게 적용됩니다!

---

## 📚 참고

- (기타 공유할 레퍼런스나 스크린샷을 이 곳에 첨부해 주세요.)