### PR TITLE
녹음 파일 경로를 절대 경로에서 상대 경로(String)로 변경합니다.

### DIFF
--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -23,7 +23,8 @@ public final class AppDIContainer {
         storageService: storageService
     )
     private lazy var voiceRecordPlaybackRepository = DefaultVoiceRecordPlaybackRepository(
-        audioPlaybackService: audioPlaybackService
+        audioPlaybackService: audioPlaybackService,
+        storageService: storageService
     )
     private lazy var checkFirstLaunchRepository = DefaultCheckFirstLaunchRepository(store: store)
     private lazy var folderRepository = DefaultFolderRepository(store: localDataBase)
@@ -31,7 +32,7 @@ public final class AppDIContainer {
     private lazy var voiceNoteFetchRepository = DefaultVoiceNoteFetchRepository(store: localDataBase)
     private lazy var voiceNoteUpdateRepository = DefaultVoiceNoteUpdateRepository(store: localDataBase)
     private lazy var wasteBasketRepository = DefaultWasteBasketRepository(store: localDataBase)
-    private lazy var sttRepository = DefaultSTTRepository(service: SpeechService())
+    private lazy var sttRepository = DefaultSTTRepository(service: SpeechService(), storageService: storageService)
     private lazy var summaryRepository = DefaultSummaryRepository(service: AppleFoundationSummaryService())
 
     /// UseCase

--- a/Data/Resources/ChaGok.xcdatamodeld/ChaGok.xcdatamodel/contents
+++ b/Data/Resources/ChaGok.xcdatamodeld/ChaGok.xcdatamodel/contents
@@ -39,7 +39,7 @@
         <relationship name="voiceRecord" maxCount="1" deletionRule="Cascade" destinationEntity="VoiceRecord" inverseName="voiceNote" inverseEntity="VoiceRecord"/>
     </entity>
     <entity name="VoiceRecord" representedClassName="VoiceRecordEntity" syncable="YES">
-        <attribute name="audioFilePath" attributeType="URI"/>
+        <attribute name="audioFilePath" attributeType="String"/>
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="duration" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>

--- a/Data/Sources/Infrastructure/CoreData/Entities/VoiceRecordEntity+CoreDataClass.swift
+++ b/Data/Sources/Infrastructure/CoreData/Entities/VoiceRecordEntity+CoreDataClass.swift
@@ -7,7 +7,7 @@ public final class VoiceRecordEntity: NSManagedObject {
     public var id: UUID
 
     @NSManaged
-    public var audioFilePath: URL
+    public var audioFilePath: String
 
     @NSManaged
     public var createdAt: Date

--- a/Data/Sources/Infrastructure/FileManager/FileManagerStorageService.swift
+++ b/Data/Sources/Infrastructure/FileManager/FileManagerStorageService.swift
@@ -35,7 +35,7 @@ public actor FileManagerStorageService: StorageService {
         from sourceURL: URL,
         toDirectory directory: String,
         fileName: String
-    ) async throws(StorageServiceError) -> URL {
+    ) async throws(StorageServiceError) -> String {
         AppLogger.debug("파일 이동 시작: \(sourceURL.lastPathComponent) -> \(directory)/\(fileName)")
 
         if Task.isCancelled {
@@ -74,7 +74,7 @@ public actor FileManagerStorageService: StorageService {
 
             try fileManager.moveItem(at: sourceURL, to: destinationURL)
             AppLogger.info("파일 이동 성공: \(destinationURL.path)")
-            return destinationURL
+            return "\(directory)/\(fileName)"
         } catch {
             AppLogger.error("파일 이동 실패: \(error)")
             throw StorageServiceError.moveFailed
@@ -85,7 +85,7 @@ public actor FileManagerStorageService: StorageService {
         data: Data,
         toDirectory directory: String,
         fileName: String
-    ) async throws(StorageServiceError) -> URL {
+    ) async throws(StorageServiceError) -> String {
         AppLogger.debug("파일 저장 시작: \(directory)/\(fileName) (size: \(data.count) bytes)")
 
         if Task.isCancelled {
@@ -114,29 +114,30 @@ public actor FileManagerStorageService: StorageService {
 
             try data.write(to: fileURL, options: .atomic)
             AppLogger.info("파일 저장 성공: \(fileURL.path)")
-            return fileURL
+            return "\(directory)/\(fileName)"
         } catch {
             AppLogger.error("파일 저장 실패: \(error)")
             throw StorageServiceError.writeFailed
         }
     }
 
-    public func load(fileURL: URL) async throws(StorageServiceError) -> Data {
-        AppLogger.debug("파일 로드 시작: \(fileURL.path)")
+    public func load(relativePath: String) async throws(StorageServiceError) -> Data {
+        let absoluteURL = absoluteURL(for: relativePath)
+        AppLogger.debug("파일 로드 시작: \(absoluteURL.path)")
 
         if Task.isCancelled {
             AppLogger.debug("작업 취소됨: load")
             throw StorageServiceError.cancelled
         }
 
-        guard fileManager.fileExists(atPath: fileURL.path) else {
-            AppLogger.error("파일을 찾을 수 없음: \(fileURL.path)")
+        guard fileManager.fileExists(atPath: absoluteURL.path) else {
+            AppLogger.error("파일을 찾을 수 없음: \(absoluteURL.path)")
             throw StorageServiceError.fileNotFound
         }
 
         do {
-            let data = try Data(contentsOf: fileURL)
-            AppLogger.debug("파일 로드 성공: \(fileURL.path) (\(data.count) bytes)")
+            let data = try Data(contentsOf: absoluteURL)
+            AppLogger.debug("파일 로드 성공: \(absoluteURL.path) (\(data.count) bytes)")
             return data
         } catch {
             AppLogger.error("파일 로드 실패: \(error)")
@@ -145,7 +146,7 @@ public actor FileManagerStorageService: StorageService {
     }
 
     public func delete(fileURL: URL) async throws(StorageServiceError) {
-        AppLogger.debug("파일 삭제 시작: \(fileURL.path)")
+        AppLogger.debug("임시 파일 삭제 시작: \(fileURL.path)")
 
         if Task.isCancelled {
             AppLogger.debug("작업 취소됨: delete")
@@ -159,16 +160,22 @@ public actor FileManagerStorageService: StorageService {
 
         do {
             try fileManager.removeItem(at: fileURL)
-            AppLogger.info("파일 삭제 성공: \(fileURL.path)")
+            AppLogger.info("임시 파일 삭제 성공: \(fileURL.path)")
         } catch {
-            AppLogger.error("파일 삭제 실패: \(error)")
+            AppLogger.error("임시 파일 삭제 실패: \(error)")
             throw StorageServiceError.deleteFailed
         }
     }
 
-    public func exists(fileURL: URL) async -> Bool {
-        let isExists = fileManager.fileExists(atPath: fileURL.path)
-        AppLogger.debug("파일 존재 확인 (\(isExists)): \(fileURL.path)")
+    public func exists(relativePath: String) async -> Bool {
+        let absoluteURL = absoluteURL(for: relativePath)
+        let isExists = fileManager.fileExists(atPath: absoluteURL.path)
+        AppLogger.debug("파일 존재 확인 (\(isExists)): \(absoluteURL.path)")
         return isExists
+    }
+
+    public nonisolated func absoluteURL(for relativePath: String) -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(relativePath)
     }
 }

--- a/Data/Sources/Interfaces/Storage/StorageService.swift
+++ b/Data/Sources/Interfaces/Storage/StorageService.swift
@@ -1,48 +1,56 @@
 import Foundation
 
 /// 스토리지 서비스 프로토콜
+///
+/// - 임시 파일 (녹음 중): `URL` 기반 — 절대 경로로 즉시 접근 필요
+/// - 영구 파일 (Documents 저장): `String` 경로 기반 — 앱 컨테이너 변경에 안전한 상대 경로
 public protocol StorageService: Sendable {
-    /// 작업을 위한 안전한 임시 파일 경로를 생성하여 반환합니다.
+    /// 녹음 작업을 위한 임시 파일 URL을 생성합니다.
     /// - Parameter fileName: 생성할 임시 파일의 이름
-    /// - Returns: 생성된 임시 파일의 URL
+    /// - Returns: 생성된 임시 파일의 절대 URL
     /// - Throws: `StorageServiceError.uncreatableTemporaryPath`
     func generateTemporaryURL(fileName: String) async throws(StorageServiceError) -> URL
 
-    /// 지정된 원본 파일을 새로운 디렉토리와 이름으로 이동시킵니다.
+    /// 임시 파일을 Documents 하위 디렉토리로 이동합니다.
     /// - Parameters:
-    ///   - sourceURL: 원본 파일이 위치한 URL
-    ///   - directory: 최종 저장할 논리적 디렉토리 이름
-    ///   - fileName: 저장할 최종 파일 이름
-    /// - Returns: 이동이 완료된 최종 파일의 URL
+    ///   - sourceURL: 이동할 임시 파일의 절대 URL
+    ///   - directory: 저장할 디렉토리 이름
+    ///   - fileName: 저장할 파일 이름
+    /// - Returns: Documents 기준 상대 경로 (예: `"VoiceRecords/file.m4a"`)
     /// - Throws: `StorageServiceError.moveFailed`
     func moveFile(
         from sourceURL: URL,
         toDirectory directory: String,
         fileName: String
-    ) async throws(StorageServiceError) -> URL
+    ) async throws(StorageServiceError) -> String
 
-    /// 메모리 상의 Data를 특정 디렉토리에 파일로 저장합니다.
+    /// 데이터를 Documents 하위 디렉토리에 파일로 저장합니다.
     /// - Parameters:
     ///   - data: 저장할 데이터
     ///   - directory: 저장할 디렉토리 이름
     ///   - fileName: 저장할 파일 이름
-    /// - Returns: 저장된 파일의 URL
+    /// - Returns: Documents 기준 상대 경로 (예: `"Images/file.png"`)
     /// - Throws: `StorageServiceError.writeFailed`
-    func save(data: Data, toDirectory directory: String, fileName: String) async throws(StorageServiceError) -> URL
+    func save(data: Data, toDirectory directory: String, fileName: String) async throws(StorageServiceError) -> String
 
-    /// 지정된 URL의 파일을 읽어 Data로 반환합니다.
-    /// - Parameter fileURL: 읽어올 파일의 URL
+    /// 영구 저장 파일을 읽어 Data로 반환합니다.
+    /// - Parameter relativePath: Documents 기준 상대 경로 (예: `"VoiceRecords/file.m4a"`)
     /// - Returns: 파일의 Data
     /// - Throws: `StorageServiceError.readFailed`
-    func load(fileURL: URL) async throws(StorageServiceError) -> Data
+    func load(relativePath: String) async throws(StorageServiceError) -> Data
 
-    /// 지정된 URL의 파일을 시스템에서 영구 삭제합니다.
-    /// - Parameter fileURL: 삭제할 파일의 URL
+    /// 임시 파일을 삭제합니다.
+    /// - Parameter fileURL: 삭제할 임시 파일의 절대 URL
     /// - Throws: `StorageServiceError.deleteFailed`
     func delete(fileURL: URL) async throws(StorageServiceError)
 
-    /// 지정된 URL에 파일이 존재하는지 확인합니다.
-    /// - Parameter fileURL: 확인할 파일의 URL
-    /// - Returns: 존재 여부
-    func exists(fileURL: URL) async -> Bool
+    /// 영구 저장 파일의 존재 여부를 확인합니다.
+    /// - Parameter relativePath: Documents 기준 상대 경로 (예: `"VoiceRecords/file.m4a"`)
+    /// - Returns: 파일 존재 여부
+    func exists(relativePath: String) async -> Bool
+
+    /// 상대 경로를 현재 Documents 디렉토리 기준 절대 URL로 변환합니다.
+    /// - Parameter relativePath: Documents 기준 상대 경로 (예: `"VoiceRecords/file.m4a"`)
+    /// - Returns: 파일 시스템에서 실제로 접근 가능한 절대 URL
+    func absoluteURL(for relativePath: String) -> URL
 }

--- a/Data/Sources/Repositories/VoiceNotes/DefaultSTTRepository.swift
+++ b/Data/Sources/Repositories/VoiceNotes/DefaultSTTRepository.swift
@@ -5,15 +5,18 @@ import Foundation
 /// 음성 인식(STT) 리포지토리 기본 구현체.
 public struct DefaultSTTRepository: STTRepository {
     private let service: any STTService
+    private let storageService: any StorageService
 
-    public init(service: any STTService) {
+    public init(service: any STTService, storageService: any StorageService) {
         self.service = service
+        self.storageService = storageService
     }
 
-    public func transcribe(audioFileURL: URL) async throws(STTRepositoryError) -> Transcript {
+    public func transcribe(audioFilePath: String) async throws(STTRepositoryError) -> Transcript {
         if Task.isCancelled { throw .cancelled }
+        let absoluteURL = storageService.absoluteURL(for: audioFilePath)
         do {
-            let result = try await service.transcribe(audioFileURL: audioFileURL)
+            let result = try await service.transcribe(audioFileURL: absoluteURL)
             let segments = result.segments.map {
                 TranscriptSegment(substring: $0.substring, timestamp: $0.timestamp, duration: $0.duration)
             }

--- a/Data/Sources/Repositories/VoiceRecords/DefaultVoiceRecordPlaybackRepository.swift
+++ b/Data/Sources/Repositories/VoiceRecords/DefaultVoiceRecordPlaybackRepository.swift
@@ -5,16 +5,19 @@ import Foundation
 @MainActor
 public struct DefaultVoiceRecordPlaybackRepository: VoiceRecordPlaybackRepository {
     private let audioPlaybackService: any AudioPlaybackService
+    private let storageService: any StorageService
 
-    public init(audioPlaybackService: any AudioPlaybackService) {
+    public init(audioPlaybackService: any AudioPlaybackService, storageService: any StorageService) {
         self.audioPlaybackService = audioPlaybackService
+        self.storageService = storageService
     }
 
-    public func prepare(audioFileURL: URL) throws(VoiceRecordPlaybackRepositoryError)
+    public func prepare(audioFilePath: String) throws(VoiceRecordPlaybackRepositoryError)
         -> AsyncStream<AudioPlaybackState>
     {
+        let absoluteURL = storageService.absoluteURL(for: audioFilePath)
         do {
-            return try audioPlaybackService.preparePlayback(at: audioFileURL)
+            return try audioPlaybackService.preparePlayback(at: absoluteURL)
         } catch {
             AppLogger.error(error)
             throw VoiceRecordPlaybackRepositoryError(error)

--- a/Data/Sources/Repositories/VoiceRecords/DefaultVoiceRecordRepository.swift
+++ b/Data/Sources/Repositories/VoiceRecords/DefaultVoiceRecordRepository.swift
@@ -94,7 +94,7 @@ public struct DefaultVoiceRecordRepository: VoiceRecordRepository {
                 in: CharacterSet(charactersIn: ".")
             )
             let fileName = "\(recorded.createdAt.yyyyMMddHHmmssString).\(normalizedExtension)"
-            let permanentURL = try await storageService.moveFile(
+            let relativePath = try await storageService.moveFile(
                 from: recorded.audioFilePath,
                 toDirectory: "VoiceRecords",
                 fileName: fileName
@@ -102,7 +102,7 @@ public struct DefaultVoiceRecordRepository: VoiceRecordRepository {
 
             return VoiceRecord(
                 createdAt: recorded.createdAt,
-                audioFilePath: permanentURL,
+                audioFilePath: relativePath,
                 duration: recorded.duration
             )
         } catch {

--- a/Data/Tests/Interfaces/Storage/MockStorageService.swift
+++ b/Data/Tests/Interfaces/Storage/MockStorageService.swift
@@ -4,8 +4,8 @@ import XCTest
 
 actor MockStorageService: StorageService {
     private var generateTempResult: Result<URL, StorageServiceError>?
-    private var moveFileResult: Result<URL, StorageServiceError>?
-    private var saveResult: Result<URL, StorageServiceError>?
+    private var moveFileResult: Result<String, StorageServiceError>?
+    private var saveResult: Result<String, StorageServiceError>?
     private var loadResult: Result<Data, StorageServiceError>?
     private var deleteResult: Result<Void, StorageServiceError>?
     private var existsResult: Bool = false
@@ -33,11 +33,11 @@ actor MockStorageService: StorageService {
         generateTempResult = result
     }
 
-    func setMoveFileResult(_ result: Result<URL, StorageServiceError>) {
+    func setMoveFileResult(_ result: Result<String, StorageServiceError>) {
         moveFileResult = result
     }
 
-    func setSaveResult(_ result: Result<URL, StorageServiceError>) {
+    func setSaveResult(_ result: Result<String, StorageServiceError>) {
         saveResult = result
     }
 
@@ -112,7 +112,7 @@ actor MockStorageService: StorageService {
         from sourceURL: URL,
         toDirectory directory: String,
         fileName: String
-    ) async throws(StorageServiceError) -> URL {
+    ) async throws(StorageServiceError) -> String {
         moveFileCallCount += 1
         movedSourceURL = sourceURL
         movedDirectory = directory
@@ -124,7 +124,7 @@ actor MockStorageService: StorageService {
         return try result.get()
     }
 
-    func save(data: Data, toDirectory directory: String, fileName: String) async throws(StorageServiceError) -> URL {
+    func save(data: Data, toDirectory directory: String, fileName: String) async throws(StorageServiceError) -> String {
         saveCallCount += 1
         guard let result = saveResult else {
             XCTFail("saveResult가 설정되지 않았습니다.")
@@ -133,7 +133,7 @@ actor MockStorageService: StorageService {
         return try result.get()
     }
 
-    func load(fileURL: URL) async throws(StorageServiceError) -> Data {
+    func load(relativePath: String) async throws(StorageServiceError) -> Data {
         loadCallCount += 1
         guard let result = loadResult else {
             XCTFail("loadResult가 설정되지 않았습니다.")
@@ -151,8 +151,13 @@ actor MockStorageService: StorageService {
         _ = try result.get()
     }
 
-    func exists(fileURL: URL) async -> Bool {
+    func exists(relativePath: String) async -> Bool {
         existsCallCount += 1
         return existsResult
+    }
+
+    nonisolated func absoluteURL(for relativePath: String) -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(relativePath)
     }
 }

--- a/Data/Tests/Repositories/CoreData/FolderEntityTests.swift
+++ b/Data/Tests/Repositories/CoreData/FolderEntityTests.swift
@@ -21,7 +21,7 @@ final class FolderEntityTests: XCTestCase {
     }
 
     private func makeVoiceRecord() -> VoiceRecord {
-        VoiceRecord(audioFilePath: URL(fileURLWithPath: "/tmp/test.m4a"), duration: 60.0)
+        VoiceRecord(audioFilePath: "VoiceRecords/test.m4a", duration: 60.0)
     }
 
     // MARK: - Create → Fetch(byId) 속성 유지

--- a/Data/Tests/Repositories/CoreData/VoiceNoteEntityTests.swift
+++ b/Data/Tests/Repositories/CoreData/VoiceNoteEntityTests.swift
@@ -14,7 +14,7 @@ final class VoiceNoteEntityTests: XCTestCase {
     }
 
     private func makeVoiceRecord(
-        audioFilePath: URL = URL(fileURLWithPath: "/tmp/test.m4a"),
+        audioFilePath: String = "VoiceRecords/test.m4a",
         duration: Double = 60.0
     ) -> VoiceRecord {
         VoiceRecord(audioFilePath: audioFilePath, duration: duration)

--- a/Data/Tests/Repositories/VoiceNotes/DefaultSTTRepositoryTest.swift
+++ b/Data/Tests/Repositories/VoiceNotes/DefaultSTTRepositoryTest.swift
@@ -10,13 +10,13 @@ extension DefaultSTTRepositoryTest {
     func test_정상상태_전사시_Transcript를반환한다() async throws {
         // Given
         let mockService = MockSTTService()
-        let sut = DefaultSTTRepository(service: mockService)
-        let audioURL = URL(fileURLWithPath: "/test/audio.m4a")
+        let sut = DefaultSTTRepository(service: mockService, storageService: MockStorageService())
+        let audioFilePath = "VoiceRecords/audio.m4a"
         await mockService.setResult(.success(STTResult(text: "테스트 전사 텍스트", segments: [])))
-        await mockService.expectTranscribe(callCount: 1, audioFileURL: audioURL)
+        await mockService.expectTranscribe(callCount: 1)
 
         // When
-        let result = try await sut.transcribe(audioFileURL: audioURL)
+        let result = try await sut.transcribe(audioFilePath: audioFilePath)
 
         // Then
         XCTAssertEqual(result.text, "테스트 전사 텍스트")
@@ -30,8 +30,7 @@ extension DefaultSTTRepositoryTest {
     func test_서비스에러상태_전사시_transcribeFailed에러를던진다() async throws {
         // Given
         let mockService = MockSTTService()
-        let sut = DefaultSTTRepository(service: mockService)
-        let audioURL = URL(fileURLWithPath: "/test/audio.m4a")
+        let sut = DefaultSTTRepository(service: mockService, storageService: MockStorageService())
         let serviceErrors: [STTServiceError] = [
             .transcribeFailed,
             .recognizerUnavailable,
@@ -44,7 +43,7 @@ extension DefaultSTTRepositoryTest {
 
             // When & Then
             do {
-                _ = try await sut.transcribe(audioFileURL: audioURL)
+                _ = try await sut.transcribe(audioFilePath: "VoiceRecords/audio.m4a")
                 XCTFail("STTRepositoryError.transcribeFailed 에러를 throw 해야 합니다. (serviceError: \(serviceError))")
             } catch {
                 guard case .transcribeFailed = error else {
@@ -60,13 +59,13 @@ extension DefaultSTTRepositoryTest {
     func test_서비스취소에러상태_전사시_cancelled에러를던진다() async throws {
         // Given
         let mockService = MockSTTService()
-        let sut = DefaultSTTRepository(service: mockService)
+        let sut = DefaultSTTRepository(service: mockService, storageService: MockStorageService())
         // STTServiceError.cancelled (서비스 레벨 취소) → STTRepositoryError.cancelled 매핑 검증
         await mockService.setResult(.failure(.cancelled))
 
         // When & Then
         do {
-            _ = try await sut.transcribe(audioFileURL: URL(fileURLWithPath: "/test/audio.m4a"))
+            _ = try await sut.transcribe(audioFilePath: "VoiceRecords/audio.m4a")
             XCTFail("STTRepositoryError.cancelled 에러를 throw 해야 합니다.")
         } catch {
             guard case .cancelled = error else {
@@ -80,13 +79,13 @@ extension DefaultSTTRepositoryTest {
     func test_알수없는에러상태_전사시_unknown에러를던진다() async throws {
         // Given
         let mockService = MockSTTService()
-        let sut = DefaultSTTRepository(service: mockService)
+        let sut = DefaultSTTRepository(service: mockService, storageService: MockStorageService())
         let underlyingError = NSError(domain: "TestDomain", code: -1)
         await mockService.setResult(.failure(.unknown(underlyingError)))
 
         // When & Then
         do {
-            _ = try await sut.transcribe(audioFileURL: URL(fileURLWithPath: "/test/audio.m4a"))
+            _ = try await sut.transcribe(audioFilePath: "VoiceRecords/audio.m4a")
             XCTFail("STTRepositoryError.unknown 에러를 throw 해야 합니다.")
         } catch {
             guard case .unknown = error else {
@@ -104,12 +103,12 @@ extension DefaultSTTRepositoryTest {
     func test_태스크취소상태_전사시_cancelled에러를던진다() async throws {
         // Given
         let mockService = MockSTTService()
-        let sut = DefaultSTTRepository(service: mockService)
+        let sut = DefaultSTTRepository(service: mockService, storageService: MockStorageService())
         await mockService.expectTranscribe(callCount: 0)
 
         let task = Task {
             withUnsafeCurrentTask { $0?.cancel() }
-            return try await sut.transcribe(audioFileURL: URL(fileURLWithPath: "/test/audio.m4a"))
+            return try await sut.transcribe(audioFilePath: "VoiceRecords/audio.m4a")
         }
 
         // When & Then
@@ -133,7 +132,7 @@ extension DefaultSTTRepositoryTest {
 extension DefaultSTTRepositoryTest {
     func test_STT권한허용상태_권한확인시_authorized를반환한다() async throws {
         let mockService = MockSTTService()
-        let sut = DefaultSTTRepository(service: mockService)
+        let sut = DefaultSTTRepository(service: mockService, storageService: MockStorageService())
 
         // Given
         await mockService.setCheckResult(.authorized)
@@ -149,7 +148,7 @@ extension DefaultSTTRepositoryTest {
 
     func test_STT권한거부상태_권한확인시_denied를반환한다() async throws {
         let mockService = MockSTTService()
-        let sut = DefaultSTTRepository(service: mockService)
+        let sut = DefaultSTTRepository(service: mockService, storageService: MockStorageService())
 
         // Given
         await mockService.setCheckResult(.denied)
@@ -165,7 +164,7 @@ extension DefaultSTTRepositoryTest {
 
     func test_STT권한미결정상태_권한확인시_notDetermined를반환한다() async throws {
         let mockService = MockSTTService()
-        let sut = DefaultSTTRepository(service: mockService)
+        let sut = DefaultSTTRepository(service: mockService, storageService: MockStorageService())
 
         // Given
         await mockService.setCheckResult(.notDetermined)
@@ -185,7 +184,7 @@ extension DefaultSTTRepositoryTest {
 extension DefaultSTTRepositoryTest {
     func test_태스크취소상태_권한확인시_cancelled에러를던진다() async throws {
         let mockService = MockSTTService()
-        let sut = DefaultSTTRepository(service: mockService)
+        let sut = DefaultSTTRepository(service: mockService, storageService: MockStorageService())
 
         // Given
         await mockService.expectCheck(callCount: 0)
@@ -216,7 +215,7 @@ extension DefaultSTTRepositoryTest {
 extension DefaultSTTRepositoryTest {
     func test_STT권한허용상태_권한요청시_authorized를반환한다() async throws {
         let mockService = MockSTTService()
-        let sut = DefaultSTTRepository(service: mockService)
+        let sut = DefaultSTTRepository(service: mockService, storageService: MockStorageService())
 
         // Given
         await mockService.setRequestResult(.authorized)
@@ -232,7 +231,7 @@ extension DefaultSTTRepositoryTest {
 
     func test_STT권한거부상태_권한요청시_denied를반환한다() async throws {
         let mockService = MockSTTService()
-        let sut = DefaultSTTRepository(service: mockService)
+        let sut = DefaultSTTRepository(service: mockService, storageService: MockStorageService())
 
         // Given
         await mockService.setRequestResult(.denied)
@@ -252,7 +251,7 @@ extension DefaultSTTRepositoryTest {
 extension DefaultSTTRepositoryTest {
     func test_태스크취소상태_권한요청시_cancelled에러를던진다() async throws {
         let mockService = MockSTTService()
-        let sut = DefaultSTTRepository(service: mockService)
+        let sut = DefaultSTTRepository(service: mockService, storageService: MockStorageService())
 
         // Given
         await mockService.expectRequest(callCount: 0)

--- a/Data/Tests/Repositories/VoiceNotes/DefaultVoiceNoteCreateRepositoryTests.swift
+++ b/Data/Tests/Repositories/VoiceNotes/DefaultVoiceNoteCreateRepositoryTests.swift
@@ -11,7 +11,7 @@ final class DefaultVoiceNoteCreateRepositoryTests: XCTestCase {
         let createdAt = Date(timeIntervalSince1970: 1_710_000_000)
         let voiceRecord = VoiceRecord(
             createdAt: createdAt,
-            audioFilePath: URL(fileURLWithPath: "/tmp/1710000000000.m4a"),
+            audioFilePath: "VoiceRecords/1710000000000.m4a",
             duration: 60
         )
         let sut = DefaultVoiceNoteCreateRepository(store: store)

--- a/Data/Tests/Repositories/VoiceRecords/DefaultVoiceRecordPlaybackRepositoryTests.swift
+++ b/Data/Tests/Repositories/VoiceRecords/DefaultVoiceRecordPlaybackRepositoryTests.swift
@@ -9,28 +9,30 @@ final class DefaultVoiceRecordPlaybackRepositoryTests: XCTestCase {}
 extension DefaultVoiceRecordPlaybackRepositoryTests {
     func test_prepare호출시_servicePrepare를호출하고결과를반환한다() async throws {
         let service = MockAudioPlaybackService()
-        let sut = DefaultVoiceRecordPlaybackRepository(audioPlaybackService: service)
+        let storageService = MockStorageService()
+        let sut = DefaultVoiceRecordPlaybackRepository(audioPlaybackService: service, storageService: storageService)
         let stream = AsyncStream<AudioPlaybackState> { continuation in
             continuation.yield(.init(status: .idle, currentTime: 0, duration: 90))
             continuation.finish()
         }
-        let audioURL = URL(fileURLWithPath: "/tmp/playback.m4a")
+        let audioFilePath = "VoiceRecords/playback.m4a"
+        let expectedAbsoluteURL = storageService.absoluteURL(for: audioFilePath)
         service.setPrepareResult(.success(stream))
         service.expectPrepare(callCount: 1)
 
-        let result = try sut.prepare(audioFileURL: audioURL)
+        let result = try sut.prepare(audioFilePath: audioFilePath)
         let preparedURL = service.preparedURL
         var iterator = result.makeAsyncIterator()
         let initialState = await iterator.next()
 
         XCTAssertEqual(initialState, .init(status: .idle, currentTime: 0, duration: 90))
-        XCTAssertEqual(preparedURL, audioURL)
+        XCTAssertEqual(preparedURL, expectedAbsoluteURL)
         service.verify()
     }
 
     func test_play실패시_repositoryError로매핑한다() {
         let service = MockAudioPlaybackService()
-        let sut = DefaultVoiceRecordPlaybackRepository(audioPlaybackService: service)
+        let sut = DefaultVoiceRecordPlaybackRepository(audioPlaybackService: service, storageService: MockStorageService())
         service.setPlayResult(.failure(.playFailed))
         service.expectPlay(callCount: 1)
 
@@ -48,7 +50,7 @@ extension DefaultVoiceRecordPlaybackRepositoryTests {
 
     func test_seek호출시_serviceSeek를호출한다() throws {
         let service = MockAudioPlaybackService()
-        let sut = DefaultVoiceRecordPlaybackRepository(audioPlaybackService: service)
+        let sut = DefaultVoiceRecordPlaybackRepository(audioPlaybackService: service, storageService: MockStorageService())
         service.setSeekResult(.success(()))
         service.expectSeek(callCount: 1)
 

--- a/Data/Tests/Repositories/VoiceRecords/DefaultVoiceRecordPlaybackRepositoryTests.swift
+++ b/Data/Tests/Repositories/VoiceRecords/DefaultVoiceRecordPlaybackRepositoryTests.swift
@@ -32,7 +32,10 @@ extension DefaultVoiceRecordPlaybackRepositoryTests {
 
     func test_play실패시_repositoryError로매핑한다() {
         let service = MockAudioPlaybackService()
-        let sut = DefaultVoiceRecordPlaybackRepository(audioPlaybackService: service, storageService: MockStorageService())
+        let sut = DefaultVoiceRecordPlaybackRepository(
+            audioPlaybackService: service,
+            storageService: MockStorageService()
+        )
         service.setPlayResult(.failure(.playFailed))
         service.expectPlay(callCount: 1)
 
@@ -50,7 +53,10 @@ extension DefaultVoiceRecordPlaybackRepositoryTests {
 
     func test_seek호출시_serviceSeek를호출한다() throws {
         let service = MockAudioPlaybackService()
-        let sut = DefaultVoiceRecordPlaybackRepository(audioPlaybackService: service, storageService: MockStorageService())
+        let sut = DefaultVoiceRecordPlaybackRepository(
+            audioPlaybackService: service,
+            storageService: MockStorageService()
+        )
         service.setSeekResult(.success(()))
         service.expectSeek(callCount: 1)
 

--- a/Data/Tests/Repositories/VoiceRecords/DefaultVoiceRecordRepositoryTest.swift
+++ b/Data/Tests/Repositories/VoiceRecords/DefaultVoiceRecordRepositoryTest.swift
@@ -252,7 +252,7 @@ extension DefaultVoiceRecordRepositoryTest {
         // Given
         let createdAt = Date(timeIntervalSince1970: 1234)
         let tempURL = URL(fileURLWithPath: "/temp/path.m4a")
-        let permanentURL = URL(fileURLWithPath: "/permanent/path.m4a")
+        let permanentPath = "VoiceRecords/\(createdAt.yyyyMMddHHmmssString).m4a"
         let duration = 12.34
         let recordedAudio = RecordedAudio(
             createdAt: createdAt,
@@ -260,7 +260,7 @@ extension DefaultVoiceRecordRepositoryTest {
             duration: duration
         )
         await audioService.setFinishResult(Result<RecordedAudio, AudioRecorderServiceError>.success(recordedAudio))
-        await storageService.setMoveFileResult(Result<URL, StorageServiceError>.success(permanentURL))
+        await storageService.setMoveFileResult(Result<String, StorageServiceError>.success(permanentPath))
 
         await audioService.expectFinish(callCount: 1)
         await storageService.expectMoveFile(callCount: 1)
@@ -270,7 +270,7 @@ extension DefaultVoiceRecordRepositoryTest {
 
         // Then
         XCTAssertEqual(voiceRecord.createdAt, createdAt)
-        XCTAssertEqual(voiceRecord.audioFilePath, permanentURL)
+        XCTAssertEqual(voiceRecord.audioFilePath, permanentPath)
         XCTAssertEqual(voiceRecord.duration, duration, accuracy: 0.001)
 
         let movedSourceURL = await storageService.movedSourceURL

--- a/Data/Tests/Storage/FileManager/FileManagerStorageServiceTests.swift
+++ b/Data/Tests/Storage/FileManager/FileManagerStorageServiceTests.swift
@@ -3,12 +3,10 @@ import Foundation
 import XCTest
 
 final class FileManagerStorageServiceTests: XCTestCase {
-    /// 테스트용 디렉토리를 생성하고 클린업을 위한 URL을 반환합니다.
-    private func makeTestDirectory() throws -> (name: String, url: URL) {
+    /// 테스트용 디렉토리 이름을 생성하고 클린업을 위한 URL을 반환합니다.
+    private func makeTestDirectory() -> (name: String, url: URL) {
         let name = "Test_ChaGok_\(UUID().uuidString)"
-        guard let documentURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-            fatalError("Document directory not found")
-        }
+        let documentURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         let url = documentURL.appendingPathComponent(name)
         return (name, url)
     }
@@ -23,7 +21,7 @@ final class FileManagerStorageServiceTests: XCTestCase {
 extension FileManagerStorageServiceTests {
     func test_유효한데이터일때_저장및로드요청시_성공한다() async throws {
         let sut = FileManagerStorageService()
-        let (dirName, dirURL) = try makeTestDirectory()
+        let (dirName, dirURL) = makeTestDirectory()
         defer { cleanUp(dirURL) }
 
         // Given
@@ -31,9 +29,9 @@ extension FileManagerStorageServiceTests {
         let fileName = "test_roundtrip.txt"
 
         // When
-        let fileURL = try await sut.save(data: data, toDirectory: dirName, fileName: fileName)
-        let loadedData = try await sut.load(fileURL: fileURL)
-        let isExists = await sut.exists(fileURL: fileURL)
+        let relativePath = try await sut.save(data: data, toDirectory: dirName, fileName: fileName)
+        let loadedData = try await sut.load(relativePath: relativePath)
+        let isExists = await sut.exists(relativePath: relativePath)
 
         // Then
         XCTAssertTrue(isExists)
@@ -42,16 +40,17 @@ extension FileManagerStorageServiceTests {
 
     func test_파일이존재할때_삭제요청시_성공적으로삭제한다() async throws {
         let sut = FileManagerStorageService()
-        let (dirName, dirURL) = try makeTestDirectory()
+        let (dirName, dirURL) = makeTestDirectory()
         defer { cleanUp(dirURL) }
 
         // Given
         let data = Data([0x01])
-        let fileURL = try await sut.save(data: data, toDirectory: dirName, fileName: "delete.me")
+        let relativePath = try await sut.save(data: data, toDirectory: dirName, fileName: "delete.me")
+        let absoluteURL = sut.absoluteURL(for: relativePath)
 
         // When
-        try await sut.delete(fileURL: fileURL)
-        let isExists = await sut.exists(fileURL: fileURL)
+        try await sut.delete(fileURL: absoluteURL)
+        let isExists = await sut.exists(relativePath: relativePath)
 
         // Then
         XCTAssertFalse(isExists)
@@ -63,11 +62,11 @@ extension FileManagerStorageServiceTests {
 extension FileManagerStorageServiceTests {
     func test_존재하지않는파일일때_로드요청시_fileNotFound에러를던진다() async throws {
         let sut = FileManagerStorageService()
-        let nonExistentURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let nonExistentPath = "NonExistent/\(UUID().uuidString).txt"
 
         // When & Then
         do {
-            _ = try await sut.load(fileURL: nonExistentURL)
+            _ = try await sut.load(relativePath: nonExistentPath)
             XCTFail("StorageServiceError.fileNotFound 에러를 throw 해야 합니다.")
         } catch {
             guard case StorageServiceError.fileNotFound = error else {
@@ -141,7 +140,7 @@ extension FileManagerStorageServiceTests {
 extension FileManagerStorageServiceTests {
     func test_임시파일이있을때_이동요청시_목적지로성공적으로이동한다() async throws {
         let sut = FileManagerStorageService()
-        let (dirName, dirURL) = try makeTestDirectory()
+        let (dirName, dirURL) = makeTestDirectory()
         defer { cleanUp(dirURL) }
 
         // Given
@@ -151,9 +150,9 @@ extension FileManagerStorageServiceTests {
         try data.write(to: tempURL)
 
         // When
-        let finalURL = try await sut.moveFile(from: tempURL, toDirectory: dirName, fileName: fileName)
-        let isFinalExists = await sut.exists(fileURL: finalURL)
-        let isTempExists = await sut.exists(fileURL: tempURL)
+        let relativePath = try await sut.moveFile(from: tempURL, toDirectory: dirName, fileName: fileName)
+        let isFinalExists = await sut.exists(relativePath: relativePath)
+        let isTempExists = await sut.exists(relativePath: tempURL.path)
 
         // Then
         XCTAssertTrue(isFinalExists)
@@ -162,7 +161,7 @@ extension FileManagerStorageServiceTests {
 
     func test_목적지에파일이미있을때_이동요청시_덮어쓰기에성공한다() async throws {
         let sut = FileManagerStorageService()
-        let (dirName, dirURL) = try makeTestDirectory()
+        let (dirName, dirURL) = makeTestDirectory()
         defer { cleanUp(dirURL) }
 
         // Given
@@ -175,8 +174,8 @@ extension FileManagerStorageServiceTests {
         try newData.write(to: tempURL)
 
         // When
-        let finalURL = try await sut.moveFile(from: tempURL, toDirectory: dirName, fileName: fileName)
-        let loadedData = try await sut.load(fileURL: finalURL)
+        let relativePath = try await sut.moveFile(from: tempURL, toDirectory: dirName, fileName: fileName)
+        let loadedData = try await sut.load(relativePath: relativePath)
 
         // Then
         XCTAssertEqual(loadedData, newData)
@@ -184,7 +183,7 @@ extension FileManagerStorageServiceTests {
 
     func test_디렉토리가없을때_저장요청시_자동으로디렉토리를생성한다() async throws {
         let sut = FileManagerStorageService()
-        let (dirName, dirURL) = try makeTestDirectory()
+        let (dirName, dirURL) = makeTestDirectory()
         defer { cleanUp(dirURL) }
 
         // Given
@@ -192,8 +191,8 @@ extension FileManagerStorageServiceTests {
         let data = Data([0x01])
 
         // When
-        let fileURL = try await sut.save(data: data, toDirectory: nestedDir, fileName: "test.data")
-        let isExists = await sut.exists(fileURL: fileURL)
+        let relativePath = try await sut.save(data: data, toDirectory: nestedDir, fileName: "test.data")
+        let isExists = await sut.exists(relativePath: relativePath)
 
         // Then
         XCTAssertTrue(isExists)

--- a/Domain/Sources/Entities/VoiceRecord.swift
+++ b/Domain/Sources/Entities/VoiceRecord.swift
@@ -3,13 +3,13 @@ import Foundation
 public struct VoiceRecord: Sendable, Identifiable, Hashable {
     public let id: UUID
     public let createdAt: Date
-    public let audioFilePath: URL
+    public let audioFilePath: String
     public let duration: Double
 
     public init(
         id: UUID = UUID(),
         createdAt: Date = Date.now,
-        audioFilePath: URL,
+        audioFilePath: String,
         duration: Double
     ) {
         self.id = id

--- a/Domain/Sources/Interfaces/STTRepository.swift
+++ b/Domain/Sources/Interfaces/STTRepository.swift
@@ -3,10 +3,10 @@ import Foundation
 /// 음성 인식(Speech-to-Text) 및 STT 권한을 담당하는 리포지토리 프로토콜.
 public protocol STTRepository: Sendable {
     /// 오디오 파일을 전사(Transcription)합니다.
-    /// - Parameter audioFileURL: 전사할 오디오 파일의 URL
+    /// - Parameter audioFilePath: 전사할 오디오 파일의 상대 경로 (예: `"VoiceRecords/file.m4a"`)
     /// - Returns: 전사된 텍스트 엔티티
     /// - Throws: `STTRepositoryError` (전사 실패)
-    func transcribe(audioFileURL: URL) async throws(STTRepositoryError) -> Transcript
+    func transcribe(audioFilePath: String) async throws(STTRepositoryError) -> Transcript
 
     /// STT 권한이 허용되어 있는지 확인합니다.
     /// - Returns: 현재 권한 상태.

--- a/Domain/Sources/Interfaces/VoiceRecords/VoiceRecordPlaybackRepository.swift
+++ b/Domain/Sources/Interfaces/VoiceRecords/VoiceRecordPlaybackRepository.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @MainActor
 public protocol VoiceRecordPlaybackRepository: Sendable {
-    func prepare(audioFileURL: URL) throws(VoiceRecordPlaybackRepositoryError) -> AsyncStream<AudioPlaybackState>
+    func prepare(audioFilePath: String) throws(VoiceRecordPlaybackRepositoryError) -> AsyncStream<AudioPlaybackState>
     func play() throws(VoiceRecordPlaybackRepositoryError)
     func pause() throws(VoiceRecordPlaybackRepositoryError)
     func seek(to time: TimeInterval) throws(VoiceRecordPlaybackRepositoryError)

--- a/Domain/Sources/UseCases/VoiceNotes/AudioToSummaryUseCase.swift
+++ b/Domain/Sources/UseCases/VoiceNotes/AudioToSummaryUseCase.swift
@@ -9,7 +9,7 @@ public protocol AudioToSummaryUseCase: Sendable {
     ///   - language: 요약 및 키워드 생성에 사용할 출력 언어
     /// - Returns: 전사, 키워드, 요약이 포함된 `AudioToSummaryResult`
     /// - Throws: `AudioToSummaryUseCaseError` (전사·요약 실패)
-    func execute(audioFileURL: URL, language: Language) async throws(AudioToSummaryUseCaseError) -> AudioToSummaryResult
+    func execute(audioFilePath: String, language: Language) async throws(AudioToSummaryUseCaseError) -> AudioToSummaryResult
 }
 
 public struct DefaultAudioToSummaryUseCase: AudioToSummaryUseCase {
@@ -24,13 +24,13 @@ public struct DefaultAudioToSummaryUseCase: AudioToSummaryUseCase {
         self.summaryRepository = summaryRepository
     }
 
-    public func execute(audioFileURL: URL, language: Language) async throws(AudioToSummaryUseCaseError)
+    public func execute(audioFilePath: String, language: Language) async throws(AudioToSummaryUseCaseError)
         -> AudioToSummaryResult
     {
         do {
             try Task.checkCancellation()
 
-            let transcript = try await sttRepository.transcribe(audioFileURL: audioFileURL)
+            let transcript = try await sttRepository.transcribe(audioFilePath: audioFilePath)
 
             try Task.checkCancellation()
 

--- a/Domain/Sources/UseCases/VoiceNotes/AudioToSummaryUseCase.swift
+++ b/Domain/Sources/UseCases/VoiceNotes/AudioToSummaryUseCase.swift
@@ -9,7 +9,8 @@ public protocol AudioToSummaryUseCase: Sendable {
     ///   - language: 요약 및 키워드 생성에 사용할 출력 언어
     /// - Returns: 전사, 키워드, 요약이 포함된 `AudioToSummaryResult`
     /// - Throws: `AudioToSummaryUseCaseError` (전사·요약 실패)
-    func execute(audioFilePath: String, language: Language) async throws(AudioToSummaryUseCaseError) -> AudioToSummaryResult
+    func execute(audioFilePath: String, language: Language) async throws(AudioToSummaryUseCaseError)
+        -> AudioToSummaryResult
 }
 
 public struct DefaultAudioToSummaryUseCase: AudioToSummaryUseCase {

--- a/Domain/Sources/UseCases/VoiceNotes/CreateVoiceNoteUseCase.swift
+++ b/Domain/Sources/UseCases/VoiceNotes/CreateVoiceNoteUseCase.swift
@@ -28,20 +28,14 @@ public struct DefaultCreateVoiceNoteUseCase: CreateVoiceNoteUseCase {
             throw error
         }
 
-        if !voiceRecord.audioFilePath.isFileURL {
-            let error = CreateVoiceNoteUseCaseError.invalidAudioFilePath(voiceRecord.audioFilePath)
-            AppLogger.error(error)
-            throw error
-        }
-
-        let fileName = voiceRecord.audioFilePath.lastPathComponent
+        let fileName = (voiceRecord.audioFilePath as NSString).lastPathComponent
         if fileName.isEmpty {
             let error = CreateVoiceNoteUseCaseError.emptyFileName
             AppLogger.error(error)
             throw error
         }
 
-        let pathExtension = voiceRecord.audioFilePath.pathExtension
+        let pathExtension = (voiceRecord.audioFilePath as NSString).pathExtension
         guard let _ = AudioFileFormat(extension: pathExtension) else {
             let error = CreateVoiceNoteUseCaseError.unsupportedExtension(pathExtension)
             AppLogger.error(error)

--- a/Domain/Sources/UseCases/VoiceRecords/PrepareVoiceRecordPlaybackUseCase.swift
+++ b/Domain/Sources/UseCases/VoiceRecords/PrepareVoiceRecordPlaybackUseCase.swift
@@ -3,7 +3,7 @@ import Foundation
 
 @MainActor
 public protocol PrepareVoiceRecordPlaybackUseCase: Sendable {
-    func execute(audioFileURL: URL) throws(PrepareVoiceRecordPlaybackUseCaseError)
+    func execute(audioFilePath: String) throws(PrepareVoiceRecordPlaybackUseCaseError)
         -> AsyncStream<AudioPlaybackState>
 }
 
@@ -15,11 +15,11 @@ public struct DefaultPrepareVoiceRecordPlaybackUseCase: PrepareVoiceRecordPlayba
         self.repository = repository
     }
 
-    public func execute(audioFileURL: URL) throws(PrepareVoiceRecordPlaybackUseCaseError)
+    public func execute(audioFilePath: String) throws(PrepareVoiceRecordPlaybackUseCaseError)
         -> AsyncStream<AudioPlaybackState>
     {
         do {
-            return try repository.prepare(audioFileURL: audioFileURL)
+            return try repository.prepare(audioFilePath: audioFilePath)
         } catch {
             AppLogger.error(error)
             throw PrepareVoiceRecordPlaybackUseCaseError(error)

--- a/Domain/Testing/Entities/Stubs/VoiceRecord+Stub.swift
+++ b/Domain/Testing/Entities/Stubs/VoiceRecord+Stub.swift
@@ -5,7 +5,7 @@ public extension VoiceRecord {
     static func stub(
         id: UUID = UUID(),
         createdAt: Date = Date(),
-        audioFilePath: URL = URL(fileURLWithPath: "/test/path.m4a"),
+        audioFilePath: String = "VoiceRecords/test.m4a",
         duration: Double = 60.0
     ) -> VoiceRecord {
         VoiceRecord(

--- a/Domain/Testing/Interfaces/Mocks/VoiceNote/MockSTTRepository.swift
+++ b/Domain/Testing/Interfaces/Mocks/VoiceNote/MockSTTRepository.swift
@@ -10,12 +10,12 @@ public actor MockSTTRepository: STTRepository {
     private var requestResult: Result<PermissionStatus, STTPermissionRepositoryError>?
 
     private var actualCallCount = 0
-    private var actualAudioFileURL: URL?
+    private var actualAudioFilePath: String?
     private var actualCheckSTTPermissionCallCount = 0
     private var actualRequestSTTPermissionCallCount = 0
 
     private var expectedCallCount: Int?
-    private var expectedAudioFileURL: URL?
+    private var expectedAudioFilePath: String?
     private var expectedCheckSTTPermissionCallCount: Int?
     private var expectedRequestSTTPermissionCallCount: Int?
 
@@ -31,9 +31,9 @@ public actor MockSTTRepository: STTRepository {
         requestResult = result
     }
 
-    public func expectTranscribe(callCount: Int, audioFileURL: URL? = nil) {
+    public func expectTranscribe(callCount: Int, audioFilePath: String? = nil) {
         expectedCallCount = callCount
-        expectedAudioFileURL = audioFileURL
+        expectedAudioFilePath = audioFilePath
     }
 
     public func expectCheckSTTPermission(callCount: Int) {
@@ -50,9 +50,9 @@ public actor MockSTTRepository: STTRepository {
                 actualCallCount, expected, "변환 호출 횟수가 일치하지 않습니다.", file: file, line: line
             )
         }
-        if let expectedURL = expectedAudioFileURL {
+        if let expectedPath = expectedAudioFilePath {
             XCTAssertEqual(
-                actualAudioFileURL, expectedURL, "변환 오디오 파일 URL이 일치하지 않습니다.", file: file, line: line
+                actualAudioFilePath, expectedPath, "변환 오디오 파일 경로가 일치하지 않습니다.", file: file, line: line
             )
         }
         if let expected = expectedCheckSTTPermissionCallCount {
@@ -75,9 +75,9 @@ public actor MockSTTRepository: STTRepository {
         }
     }
 
-    public func transcribe(audioFileURL: URL) async throws(STTRepositoryError) -> Transcript {
+    public func transcribe(audioFilePath: String) async throws(STTRepositoryError) -> Transcript {
         actualCallCount += 1
-        actualAudioFileURL = audioFileURL
+        actualAudioFilePath = audioFilePath
 
         switch result {
         case .success(let value):

--- a/Domain/Testing/Interfaces/Mocks/VoiceRecords/MockVoiceRecordPlaybackRepository.swift
+++ b/Domain/Testing/Interfaces/Mocks/VoiceRecords/MockVoiceRecordPlaybackRepository.swift
@@ -23,7 +23,7 @@ public final class MockVoiceRecordPlaybackRepository: VoiceRecordPlaybackReposit
     private var expectedSeekCallCount: Int?
     private var expectedStopCallCount: Int?
 
-    public private(set) var preparedAudioFileURL: URL?
+    public private(set) var preparedAudioFilePath: String?
     public private(set) var lastSeekTime: TimeInterval?
 
     public func setPrepareResult(_ result: Result<
@@ -88,11 +88,11 @@ public final class MockVoiceRecordPlaybackRepository: VoiceRecordPlaybackReposit
         XCTAssertEqual(actual, expected, "\(label) 호출 횟수 불일치", file: file, line: line)
     }
 
-    public func prepare(audioFileURL: URL) throws(VoiceRecordPlaybackRepositoryError)
+    public func prepare(audioFilePath: String) throws(VoiceRecordPlaybackRepositoryError)
         -> AsyncStream<AudioPlaybackState>
     {
         actualPrepareCallCount += 1
-        preparedAudioFileURL = audioFileURL
+        preparedAudioFilePath = audioFilePath
         switch prepareResult {
         case .success(let stream): return stream
         case .failure(let error): throw error

--- a/Domain/Tests/UseCases/VoiceNotes/AudioToSummaryUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceNotes/AudioToSummaryUseCaseTest.swift
@@ -17,13 +17,13 @@ extension AudioToSummaryUseCaseTest {
         )
 
         // Given
-        let audioURL = URL(fileURLWithPath: "/test.m4a")
+        let audioFilePath = "VoiceRecords/test.m4a"
         let expectedTranscript = Transcript.stub()
         let expectedSummary = Summary.stub()
         let expectedKeywords = [Keyword.stub()]
 
         await sttRepository.setResult(.success(expectedTranscript))
-        await sttRepository.expectTranscribe(callCount: 1, audioFileURL: audioURL)
+        await sttRepository.expectTranscribe(callCount: 1, audioFilePath: audioFilePath)
 
         await summaryRepository.setResult(.success((expectedKeywords, expectedSummary)))
         await summaryRepository.expectSummarize(
@@ -31,7 +31,7 @@ extension AudioToSummaryUseCaseTest {
         )
 
         // When
-        let result = try await sut.execute(audioFileURL: audioURL, language: .ko)
+        let result = try await sut.execute(audioFilePath: audioFilePath, language: .ko)
 
         // Then
         XCTAssertEqual(result.transcript.text, expectedTranscript.text)
@@ -57,15 +57,15 @@ extension AudioToSummaryUseCaseTest {
         )
 
         // Given
-        let audioURL = URL(fileURLWithPath: "/test.m4a")
+        let audioFilePath = "VoiceRecords/test.m4a"
 
         await sttRepository.setResult(.failure(.transcribeFailed))
-        await sttRepository.expectTranscribe(callCount: 1, audioFileURL: audioURL)
+        await sttRepository.expectTranscribe(callCount: 1, audioFilePath: audioFilePath)
         await summaryRepository.expectSummarize(callCount: 0)
 
         // When & Then
         do {
-            _ = try await sut.execute(audioFileURL: audioURL, language: .ko)
+            _ = try await sut.execute(audioFilePath: audioFilePath, language: .ko)
             XCTFail("AudioToSummaryUseCaseError.transcribeFailed 에러를 throw 해야 합니다.")
         } catch {
             guard case .transcribeFailed = error else {
@@ -87,11 +87,11 @@ extension AudioToSummaryUseCaseTest {
         )
 
         // Given
-        let audioURL = URL(fileURLWithPath: "/test.m4a")
+        let audioFilePath = "VoiceRecords/test.m4a"
         let expectedTranscript = Transcript.stub()
 
         await sttRepository.setResult(.success(expectedTranscript))
-        await sttRepository.expectTranscribe(callCount: 1, audioFileURL: audioURL)
+        await sttRepository.expectTranscribe(callCount: 1, audioFilePath: audioFilePath)
 
         await summaryRepository.setResult(.failure(.summarizeFailed))
         await summaryRepository.expectSummarize(
@@ -100,7 +100,7 @@ extension AudioToSummaryUseCaseTest {
 
         // When & Then
         do {
-            _ = try await sut.execute(audioFileURL: audioURL, language: .ko)
+            _ = try await sut.execute(audioFilePath: audioFilePath, language: .ko)
             XCTFail("AudioToSummaryUseCaseError.summarizeFailed 에러를 throw 해야 합니다.")
         } catch {
             guard case .summarizeFailed = error else {
@@ -122,16 +122,16 @@ extension AudioToSummaryUseCaseTest {
         )
 
         // Given
-        let audioURL = URL(fileURLWithPath: "/test.m4a")
+        let audioFilePath = "VoiceRecords/test.m4a"
         struct DummyError: Error {}
         let expectedError = DummyError()
 
         await sttRepository.setResult(.failure(.unknown(expectedError)))
-        await sttRepository.expectTranscribe(callCount: 1, audioFileURL: audioURL)
+        await sttRepository.expectTranscribe(callCount: 1, audioFilePath: audioFilePath)
 
         // When & Then
         do {
-            _ = try await sut.execute(audioFileURL: audioURL, language: .ko)
+            _ = try await sut.execute(audioFilePath: audioFilePath, language: .ko)
             XCTFail("AudioToSummaryUseCaseError.unknown 에러를 throw 해야 합니다.")
         } catch {
             guard case .unknown(let underlyingError) = error else {
@@ -158,14 +158,14 @@ extension AudioToSummaryUseCaseTest {
         )
 
         // Given
-        let audioURL = URL(fileURLWithPath: "/test.m4a")
+        let audioFilePath = "VoiceRecords/test.m4a"
 
         await sttRepository.setResult(.failure(.cancelled))
-        await sttRepository.expectTranscribe(callCount: 1, audioFileURL: audioURL)
+        await sttRepository.expectTranscribe(callCount: 1, audioFilePath: audioFilePath)
 
         // When & Then
         do {
-            _ = try await sut.execute(audioFileURL: audioURL, language: .ko)
+            _ = try await sut.execute(audioFilePath: audioFilePath, language: .ko)
             XCTFail("AudioToSummaryUseCaseError.cancelled 에러를 throw 해야 합니다.")
         } catch {
             guard case .cancelled = error else {
@@ -187,14 +187,14 @@ extension AudioToSummaryUseCaseTest {
         )
 
         // Given
-        let audioURL = URL(fileURLWithPath: "/test.m4a")
+        let audioFilePath = "VoiceRecords/test.m4a"
 
         await sttRepository.expectTranscribe(callCount: 0)
 
         // When & Then
         let task = Task {
             withUnsafeCurrentTask { $0?.cancel() }
-            _ = try await sut.execute(audioFileURL: audioURL, language: .ko)
+            _ = try await sut.execute(audioFilePath: audioFilePath, language: .ko)
         }
 
         do {

--- a/Domain/Tests/UseCases/VoiceNotes/UpdateVoiceNoteUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceNotes/UpdateVoiceNoteUseCaseTest.swift
@@ -31,7 +31,7 @@ extension UpdateVoiceNoteUseCaseTest {
         let repository = MockVoiceNoteUpdateRepository()
         let sut = DefaultUpdateVoiceNoteUseCase(repository: repository)
 
-        let voiceRecord = VoiceRecord.stub(audioFilePath: URL(fileURLWithPath: "/tmp/20260409_120000_000.m4a"))
+        let voiceRecord = VoiceRecord.stub(audioFilePath: "VoiceRecords/20260409_120000_000.m4a")
         let editedVoiceNote = VoiceNote.stub(title: "회의 정리", voiceRecord: voiceRecord)
 
         await repository.setResult(.success(editedVoiceNote))

--- a/Domain/Tests/UseCases/VoiceRecords/PrepareVoiceRecordPlaybackUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceRecords/PrepareVoiceRecordPlaybackUseCaseTest.swift
@@ -10,7 +10,7 @@ extension PrepareVoiceRecordPlaybackUseCaseTest {
     func test_정상상태_prepare호출시_preparedPlayback을반환한다() async throws {
         let repository = MockVoiceRecordPlaybackRepository()
         let sut = DefaultPrepareVoiceRecordPlaybackUseCase(repository: repository)
-        let audioURL = URL(fileURLWithPath: "/tmp/test.m4a")
+        let audioFilePath = "VoiceRecords/test.m4a"
         let stream = AsyncStream<AudioPlaybackState> { continuation in
             continuation.yield(.stub(duration: 42))
             continuation.finish()
@@ -18,13 +18,13 @@ extension PrepareVoiceRecordPlaybackUseCaseTest {
         repository.setPrepareResult(.success(stream))
         repository.expectPrepare(callCount: 1)
 
-        let result = try sut.execute(audioFileURL: audioURL)
-        let preparedAudioFileURL = repository.preparedAudioFileURL
+        let result = try sut.execute(audioFilePath: audioFilePath)
+        let preparedAudioFilePath = repository.preparedAudioFilePath
         var iterator = result.makeAsyncIterator()
         let initialState = await iterator.next()
 
         XCTAssertEqual(initialState, .stub(duration: 42))
-        XCTAssertEqual(preparedAudioFileURL, audioURL)
+        XCTAssertEqual(preparedAudioFilePath, audioFilePath)
         repository.verify()
     }
 
@@ -35,7 +35,7 @@ extension PrepareVoiceRecordPlaybackUseCaseTest {
         repository.expectPrepare(callCount: 1)
 
         do {
-            _ = try sut.execute(audioFileURL: URL(fileURLWithPath: "/tmp/test.m4a"))
+            _ = try sut.execute(audioFilePath: "VoiceRecords/test.m4a")
             XCTFail("PrepareVoiceRecordPlaybackUseCaseError.prepareFailed 에러를 throw 해야 합니다.")
         } catch {
             guard case .prepareFailed = error else {

--- a/Domain/Tests/UseCases/WasteBaskets/DeleteWasteBasketUseCaseTest.swift
+++ b/Domain/Tests/UseCases/WasteBaskets/DeleteWasteBasketUseCaseTest.swift
@@ -32,7 +32,7 @@ extension DeleteWasteBasketUseCaseTest {
         let voiceNote = VoiceNote(
             title: "테스트 음성 메모",
             folderID: UUID(),
-            voiceRecord: VoiceRecord(audioFilePath: URL(fileURLWithPath: "test.m4a"), duration: 10)
+            voiceRecord: VoiceRecord(audioFilePath: "VoiceRecords/test.m4a", duration: 10)
         )
         let items: [WasteBasketItem] = [
             .folder(obj: folder),

--- a/Domain/Tests/UseCases/WasteBaskets/FetchWasteBasketFolderUseCaseTest.swift
+++ b/Domain/Tests/UseCases/WasteBaskets/FetchWasteBasketFolderUseCaseTest.swift
@@ -17,7 +17,7 @@ extension FetchWasteBasketFolderUseCaseTest {
         let voiceNote = VoiceNote(
             title: "테스트 음성 메모",
             folderID: UUID(),
-            voiceRecord: VoiceRecord(audioFilePath: URL(fileURLWithPath: "test.m4a"), duration: 10)
+            voiceRecord: VoiceRecord(audioFilePath: "VoiceRecords/test.m4a", duration: 10)
         )
         let expectedItems: [WasteBasketItem] = [
             .folder(obj: folder),

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -294,7 +294,7 @@ extension MainViewModel {
             ) -> VoiceNote {
                 let record = VoiceRecord(
                     createdAt: createdAt,
-                    audioFilePath: URL(fileURLWithPath: "/tmp/\(UUID().uuidString).m4a"),
+                    audioFilePath: "VoiceRecords/\(UUID().uuidString).m4a",
                     duration: duration
                 )
 

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -148,7 +148,7 @@ public final class VoiceNoteViewModel {
         do {
             let language = try await fetchLanguageUseCase.execute()
             let result = try await audioToSummaryUseCase.execute(
-                audioFileURL: state.voiceNote.voiceRecord.audioFilePath,
+                audioFilePath: state.voiceNote.voiceRecord.audioFilePath,
                 language: language
             )
             let updated = VoiceNote(
@@ -176,7 +176,7 @@ public final class VoiceNoteViewModel {
         playbackObservationTask = nil
         do {
             let stream = try prepareVoiceRecordPlaybackUseCase.execute(
-                audioFileURL: state.voiceNote.voiceRecord.audioFilePath
+                audioFilePath: state.voiceNote.voiceRecord.audioFilePath
             )
             playbackObservationTask = Task {
                 for await playbackState in stream {

--- a/Presentation/Tests/Trash/TrashViewModelTests.swift
+++ b/Presentation/Tests/Trash/TrashViewModelTests.swift
@@ -126,7 +126,7 @@ final class TrashViewModelTests: XCTestCase {
             .voiceNote(obj: VoiceNote(
                 title: "테스트 노트",
                 folderID: UUID(),
-                voiceRecord: VoiceRecord(audioFilePath: XCTUnwrap(URL(string: "file://null")), duration: 10)
+                voiceRecord: VoiceRecord(audioFilePath: "VoiceRecords/null.m4a", duration: 10)
             ))
         ]
 


### PR DESCRIPTION
## ✨ 작업 요약
> iOS 앱 재설치·업데이트 시 앱 컨테이너 UUID가 변경되어 기존 녹음 파일을 찾지 못하는 버그를 수정합니다.

- `VoiceRecord.audioFilePath` 타입을 `URL`(절대 경로)에서 `String`(상대 경로)으로 변경
- CoreData 저장 포맷을 `URI` → `String`(상대 경로)으로 변경
- `StorageService` 계약을 상대 경로(String) 기반으로 통일하고, `absoluteURL(for:)` 메서드 추가
- 재생·전사 직전에만 Data 레이어에서 절대 경로로 변환하도록 책임 이동

## 📋 구체적인 내용
- 추가/변경된 동작:
  - 녹음 완료 시 `"VoiceRecords/{uuid}.m4a"` 형태의 상대 경로를 CoreData에 저장
  - 오디오 재생(`DefaultVoiceRecordPlaybackRepository`) 및 STT 전사(`DefaultSTTRepository`) 직전에 `storageService.absoluteURL(for:)`로 절대 경로 해석
  - `StorageService.save()`, `moveFile()` 반환 타입 `URL` → `String`, `load()/exists()` 파라미터 `fileURL:` → `relativePath:`

- 영향 받는 화면/모듈:
  - Domain: `VoiceRecord`, `STTRepository`, `VoiceRecordPlaybackRepository`, `AudioToSummaryUseCase`, `CreateVoiceNoteUseCase`, `PrepareVoiceRecordPlaybackUseCase`
  - Data: CoreData 스키마(`audioFilePath`), `StorageService`, `FileManagerStorageService`, `DefaultVoiceRecordRepository`, `DefaultVoiceRecordPlaybackRepository`, `DefaultSTTRepository`
  - App: `AppDIContainer`
  - Presentation: `VoiceNoteViewModel`, `MainViewModel`

---

## 🔗 연관 이슈

- closed #192

---

## 🧩 설계·구현 노트

- **선택한 방식**: `VoiceRecord.audioFilePath`를 `String` 상대 경로로 관리, 절대 경로 해석은 Data 레이어(`StorageService.absoluteURL(for:)`)에서만 수행
  - Domain은 상대 경로 문자열만 알면 되고, 절대 경로 해석 책임이 `StorageService`라는 명확한 경계가 생김
  - CoreData에서도 변환 없이 문자열 그대로 저장·복원 가능

- **고려했다가 제외한 방식**:
  - `URL`의 `relativePath` 컴포넌트 활용 — URL 타입을 유지하면서 상대 경로만 꺼낼 수 있으나, 생성 시점에도 절대 경로 기반 URL이 필요해 번거로움
  - Entity(CoreData)에서 변환 — Storage 추상화가 이미 있는데 Entity에서 FileManager를 직접 다루는 것은 책임 위반

---

## ✅ 확인 사항

- [x] 정상 플로우 동작 확인
- [x] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [x] (로직 추가 시) 테스트 추가 여부 — 기존 테스트 전체 통과 (`tuist test` 성공)

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [x] 로직·엣지 케이스
- [x] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- `StorageService` 계약에서 `delete(fileURL: URL)`만 URL을 유지한 것 — 임시 파일 삭제는 항상 절대 URL로 호출되므로 의도적인 예외입니다.
- `absoluteURL(for:)`이 `nonisolated`인 것 — actor isolation 없이 동기 호출이 가능해야 Repository에서 `throws` 없이 쓸 수 있습니다.

---

## 📚 참고

- [Cha-Gok/iOS#192](https://github.com/Cha-Gok/iOS/issues/192)

---

## 🗺 아키텍처 다이어그램

```mermaid
flowchart LR
    subgraph Domain
        VR["VoiceRecord\naudioFilePath: String"]
    end

    subgraph Data
        Repo["Repository\n(DefaultVoiceRecordPlaybackRepository\nDefaultSTTRepository)"]
        SS["StorageService\nabsoluteURL(for: String) → URL"]
        Infra["Infrastructure\n(AVPlayer / SpeechService)"]
    end

    subgraph CoreData
        CD["audioFilePath: String\n(상대 경로 저장)"]
    end

    VR -->|"상대 경로 전달"| Repo
    Repo -->|"absoluteURL(for:)"| SS
    SS -->|"절대 URL"| Infra
    VR <-->|"String 그대로 저장·복원"| CD
```
