### PR TITLE
새 폴더 생성 시트를 구현합니다.

### DIFF
--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -205,4 +205,8 @@ public final class AppDIContainer {
             updateVoiceNoteUseCase: updateVoiceNoteUseCase
         )
     }
+
+    public func makeNewFolderViewModel() -> NewFolderViewModel {
+        return NewFolderViewModel(createFolderUseCase: createFolderUseCase)
+    }
 }

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -141,13 +141,30 @@ extension MainCoordinator: VoiceNoteCoordinatorDelegate {
         let viewModel = dependencyContainer.makeMoveFolderListViewModel(voiceNote: voiceNote)
         viewModel.coordinator = self
         let viewController = MoveFolderListViewController(viewModel: viewModel)
+        let nav = UINavigationController(rootViewController: viewController)
+        nav.isNavigationBarHidden = true
 
-        if let sheet = viewController.sheetPresentationController {
+        if let sheet = nav.sheetPresentationController {
             sheet.detents = [.medium()]
             sheet.prefersGrabberVisible = true
         }
 
-        presenter.present(viewController, animated: true)
+        presenter.present(nav, animated: true)
+    }
+}
+
+// MARK: - NewFolderCoordinatorDelegate
+
+extension MainCoordinator: NewFolderCoordinatorDelegate {
+    func cancel() {
+        guard let nav = presenter.presentedViewController as? UINavigationController,
+              let sheet = nav.sheetPresentationController else { return }
+
+        nav.popViewController(animated: true)
+
+        sheet.animateChanges {
+            sheet.detents = [.medium()]
+        }
     }
 }
 
@@ -156,6 +173,23 @@ extension MainCoordinator: VoiceNoteCoordinatorDelegate {
 extension MainCoordinator: MoveFolderListCoordinatorDelegate {
     func dismiss() {
         presenter.dismiss(animated: true)
+    }
+
+    func pushNewFolder() {
+        guard let nav = presenter.presentedViewController as? UINavigationController,
+              let sheet = nav.sheetPresentationController else { return }
+
+        let newFolderVC = NewFolderViewController()
+        newFolderVC.coordinator = self
+        newFolderVC.view.layoutIfNeeded()
+
+        nav.pushViewController(newFolderVC, animated: true)
+
+        sheet.animateChanges {
+            sheet.detents = [.custom { [weak newFolderVC] _ in
+                newFolderVC?.preferredContentSize.height
+            }]
+        }
     }
 }
 

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -166,6 +166,17 @@ extension MainCoordinator: NewFolderCoordinatorDelegate {
             sheet.detents = [.medium()]
         }
     }
+
+    func folderCreated() {
+        guard let nav = presenter.presentedViewController as? UINavigationController,
+              let sheet = nav.sheetPresentationController else { return }
+
+        nav.popViewController(animated: true)
+
+        sheet.animateChanges {
+            sheet.detents = [.medium()]
+        }
+    }
 }
 
 // MARK: - MoveFolderListCoordinatorDelegate
@@ -179,8 +190,9 @@ extension MainCoordinator: MoveFolderListCoordinatorDelegate {
         guard let nav = presenter.presentedViewController as? UINavigationController,
               let sheet = nav.sheetPresentationController else { return }
 
-        let newFolderVC = NewFolderViewController()
-        newFolderVC.coordinator = self
+        let viewModel = dependencyContainer.makeNewFolderViewModel()
+        viewModel.coordinator = self
+        let newFolderVC = NewFolderViewController(viewModel: viewModel)
         newFolderVC.view.layoutIfNeeded()
 
         nav.pushViewController(newFolderVC, animated: true)

--- a/Presentation/Sources/DesignSystem/Alertable.swift
+++ b/Presentation/Sources/DesignSystem/Alertable.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+@MainActor
+public protocol Alertable: UIViewController {
+    func showAlert(message: String)
+}
+
+public extension Alertable {
+    func showAlert(message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        present(alert, animated: true)
+    }
+}

--- a/Presentation/Sources/DesignSystem/Alertable.swift
+++ b/Presentation/Sources/DesignSystem/Alertable.swift
@@ -7,8 +7,16 @@ public protocol Alertable: UIViewController {
 
 public extension Alertable {
     func showAlert(message: String) {
+        guard presentedViewController == nil else { return }
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "확인", style: .default))
+        present(alert, animated: true)
+    }
+
+    func showAlert(title: String, message: String, onDismiss: @escaping () -> Void) {
+        guard presentedViewController == nil else { return }
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default) { _ in onDismiss() })
         present(alert, animated: true)
     }
 }

--- a/Presentation/Sources/View/VoiceNote/MoveVoiceNote/MoveFolderListViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/MoveVoiceNote/MoveFolderListViewController.swift
@@ -37,7 +37,11 @@ public final class MoveFolderListViewController: UIViewController {
         configuration.baseForegroundColor = .gray800
         configuration.contentInsets = .zero
 
-        return UIButton(configuration: configuration)
+        let button = UIButton(configuration: configuration)
+        button.addAction(UIAction { [weak self] _ in
+            self?.viewModel.send(.view(.addFolderButtonTapped))
+        }, for: .touchUpInside)
+        return button
     }()
 
     private lazy var titleStack: UIStackView = {

--- a/Presentation/Sources/View/VoiceNote/MoveVoiceNote/MoveFolderListViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/MoveVoiceNote/MoveFolderListViewController.swift
@@ -83,6 +83,10 @@ public final class MoveFolderListViewController: UIViewController {
     override public func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
+    }
+
+    override public func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         viewModel.send(.view(.onAppear))
     }
 

--- a/Presentation/Sources/View/VoiceNote/MoveVoiceNote/NewFolderViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/MoveVoiceNote/NewFolderViewController.swift
@@ -1,12 +1,18 @@
 import UIKit
 
-@MainActor
-public protocol NewFolderCoordinatorDelegate: AnyObject {
-    func cancel()
-}
+public final class NewFolderViewController: UIViewController, Alertable {
+    private let viewModel: NewFolderViewModel
 
-public final class NewFolderViewController: UIViewController {
-    public weak var coordinator: NewFolderCoordinatorDelegate?
+    public init(viewModel: NewFolderViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.setTypography(text: "새 폴더 만들기", style: .title3)
@@ -39,11 +45,7 @@ public final class NewFolderViewController: UIViewController {
         configuration.baseBackgroundColor = .gray300
         configuration.baseForegroundColor = .gray950
         configuration.contentInsets = .zero
-        let button = UIButton(configuration: configuration)
-        button.addAction(UIAction { [weak self] _ in
-            self?.coordinator?.cancel()
-        }, for: .touchUpInside)
-        return button
+        return UIButton(configuration: configuration)
     }()
 
     private lazy var createButton: UIButton = {
@@ -66,15 +68,6 @@ public final class NewFolderViewController: UIViewController {
         return stack
     }()
 
-    public init() {
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        nil
-    }
-
     override public var preferredContentSize: CGSize {
         get {
             view.layoutIfNeeded()
@@ -91,6 +84,14 @@ public final class NewFolderViewController: UIViewController {
     override public func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
+        addActions()
+    }
+
+    override public func updateProperties() {
+        super.updateProperties()
+        guard let message = viewModel.state.errorMessage else { return }
+        viewModel.clearErrorMessage()
+        showAlert(message: message)
     }
 
     private func setupUI() {
@@ -129,5 +130,17 @@ public final class NewFolderViewController: UIViewController {
             spacerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             spacerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+    }
+
+    private func addActions() {
+        cancelButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            viewModel.send(.view(.cancelButtonTapped))
+        }, for: .touchUpInside)
+
+        createButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            viewModel.send(.view(.createButtonTapped(name: folderNameTextField.text ?? "")))
+        }, for: .touchUpInside)
     }
 }

--- a/Presentation/Sources/View/VoiceNote/MoveVoiceNote/NewFolderViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/MoveVoiceNote/NewFolderViewController.swift
@@ -1,0 +1,133 @@
+import UIKit
+
+@MainActor
+public protocol NewFolderCoordinatorDelegate: AnyObject {
+    func cancel()
+}
+
+public final class NewFolderViewController: UIViewController {
+    public weak var coordinator: NewFolderCoordinatorDelegate?
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.setTypography(text: "새 폴더 만들기", style: .title3)
+        label.textColor = .gray950
+        return label
+    }()
+
+    private lazy var folderNameTextField: UITextField = {
+        let textField = UITextField()
+        textField.borderStyle = .none
+        textField.textColor = .gray950
+        textField.attributedPlaceholder = NSAttributedString(
+            string: "사용자가 설정하는 폴더이름",
+            attributes: [.foregroundColor: UIColor.gray600]
+        )
+        return textField
+    }()
+
+    private lazy var textFieldContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray200
+        view.layer.cornerRadius = 8
+        return view
+    }()
+
+    private lazy var cancelButton: UIButton = {
+        var configuration = UIButton.Configuration.filled()
+        configuration.title = "취소"
+        configuration.background.cornerRadius = 20
+        configuration.baseBackgroundColor = .gray300
+        configuration.baseForegroundColor = .gray950
+        configuration.contentInsets = .zero
+        let button = UIButton(configuration: configuration)
+        button.addAction(UIAction { [weak self] _ in
+            self?.coordinator?.cancel()
+        }, for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var createButton: UIButton = {
+        var configuration = UIButton.Configuration.filled()
+        configuration.title = "만들기"
+        configuration.background.cornerRadius = 20
+        configuration.baseBackgroundColor = .point600
+        configuration.baseForegroundColor = .gray950
+        configuration.contentInsets = .zero
+        return UIButton(configuration: configuration)
+    }()
+
+    private let spacerView = UIView()
+
+    private lazy var buttonStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [cancelButton, createButton])
+        stack.axis = .horizontal
+        stack.spacing = 8
+        stack.distribution = .fillEqually
+        return stack
+    }()
+
+    public init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override public var preferredContentSize: CGSize {
+        get {
+            view.layoutIfNeeded()
+            let height = view.systemLayoutSizeFitting(
+                CGSize(width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height),
+                withHorizontalFittingPriority: .required,
+                verticalFittingPriority: .fittingSizeLevel
+            ).height
+            return CGSize(width: view.bounds.width, height: height)
+        }
+        set { super.preferredContentSize = newValue }
+    }
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+
+    private func setupUI() {
+        view.backgroundColor = .gray100
+
+        textFieldContainer.addSubview(folderNameTextField)
+        folderNameTextField.translatesAutoresizingMaskIntoConstraints = false
+
+        for subview in [titleLabel, textFieldContainer, buttonStack, spacerView] {
+            subview.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(subview)
+        }
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 44),
+            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            titleLabel.heightAnchor.constraint(equalToConstant: 24),
+
+            textFieldContainer.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 26),
+            textFieldContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            textFieldContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            textFieldContainer.heightAnchor.constraint(equalToConstant: 40),
+
+            folderNameTextField.leadingAnchor.constraint(equalTo: textFieldContainer.leadingAnchor, constant: 12),
+            folderNameTextField.trailingAnchor.constraint(equalTo: textFieldContainer.trailingAnchor, constant: -12),
+            folderNameTextField.centerYAnchor.constraint(equalTo: textFieldContainer.centerYAnchor),
+
+            buttonStack.topAnchor.constraint(equalTo: textFieldContainer.bottomAnchor, constant: 20),
+            buttonStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            buttonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            buttonStack.heightAnchor.constraint(equalToConstant: 46),
+
+            spacerView.topAnchor.constraint(equalTo: buttonStack.bottomAnchor),
+            spacerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            spacerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            spacerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+}

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -1,7 +1,7 @@
 import Domain
 import UIKit
 
-public final class VoiceNoteViewController: UIViewController {
+public final class VoiceNoteViewController: UIViewController, Alertable {
     typealias Section = VoiceNoteViewModel.Section
     typealias Item = VoiceNoteViewModel.Item
 
@@ -78,7 +78,9 @@ public final class VoiceNoteViewController: UIViewController {
             break
         }
         if let message = errorObservable.message {
-            showErrorAlert(message: message)
+            showAlert(title: "오류", message: message) { [weak self] in
+                self?.viewModel.send(.internal(.errorDismissed))
+            }
         }
     }
 }
@@ -177,19 +179,6 @@ private extension VoiceNoteViewController {
         playerView.onForward = { [weak self] in self?.viewModel.send(.view(.forwardButtonTapped)) }
         playerView.onSeekBegan = { [weak self] in self?.viewModel.send(.view(.seekBegan)) }
         playerView.onSeekEnded = { [weak self] time in self?.viewModel.send(.view(.seekEnded(time))) }
-    }
-}
-
-// MARK: - Alert
-
-private extension VoiceNoteViewController {
-    func showErrorAlert(message: String) {
-        guard presentedViewController == nil else { return }
-        let alert = UIAlertController(title: "오류", message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "확인", style: .default) { [weak self] _ in
-            self?.viewModel.send(.internal(.errorDismissed))
-        })
-        present(alert, animated: true)
     }
 }
 

--- a/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
@@ -4,6 +4,7 @@ import Foundation
 
 public protocol MoveFolderListCoordinatorDelegate: BaseCoordinatorDelegate {
     func dismiss()
+    func pushNewFolder()
 }
 
 @MainActor
@@ -38,6 +39,8 @@ public final class MoveFolderListViewModel {
                 Task { await moveVoiceNote() }
             case .closeButtonTapped:
                 coordinator?.dismiss()
+            case .addFolderButtonTapped:
+                coordinator?.pushNewFolder()
             }
         case .internal(let internalAction):
             switch internalAction {
@@ -98,6 +101,7 @@ extension MoveFolderListViewModel {
             case folderSelected(Folder)
             case moveButtonTapped
             case closeButtonTapped
+            case addFolderButtonTapped
         }
 
         public enum Internal {

--- a/Presentation/Sources/ViewModel/VoiceNote/NewFolderViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/NewFolderViewModel.swift
@@ -1,0 +1,62 @@
+import Core
+import Domain
+import Foundation
+
+public protocol NewFolderCoordinatorDelegate: BaseCoordinatorDelegate {
+    func cancel()
+    func folderCreated()
+}
+
+@MainActor
+@Observable
+public final class NewFolderViewModel {
+    public weak var coordinator: NewFolderCoordinatorDelegate?
+    private(set) var state: State = .init()
+
+    private let createFolderUseCase: any CreateFolderUseCase
+
+    public init(createFolderUseCase: any CreateFolderUseCase) {
+        self.createFolderUseCase = createFolderUseCase
+    }
+
+    func send(_ action: Action) {
+        switch action {
+        case .view(let viewAction):
+            switch viewAction {
+            case .cancelButtonTapped:
+                coordinator?.cancel()
+            case .createButtonTapped(let name):
+                Task { await createFolder(name: name) }
+            }
+        }
+    }
+
+    func clearErrorMessage() {
+        state.errorMessage = nil
+    }
+
+    private func createFolder(name: String) async {
+        do {
+            _ = try await createFolderUseCase.execute(name: name)
+            coordinator?.folderCreated()
+        } catch {
+            AppLogger.error(error)
+            state.errorMessage = error.localizedDescription
+        }
+    }
+}
+
+extension NewFolderViewModel {
+    struct State {
+        var errorMessage: String?
+    }
+
+    public enum Action {
+        public enum View {
+            case cancelButtonTapped
+            case createButtonTapped(name: String)
+        }
+
+        case view(View)
+    }
+}

--- a/Presentation/Tests/Trash/TrashViewModelTests.swift
+++ b/Presentation/Tests/Trash/TrashViewModelTests.swift
@@ -118,10 +118,10 @@ final class TrashViewModelTests: XCTestCase {
 
     // MARK: - Update & Fetch Tests
 
-    func test_fetchItems_정상적으로_가져오기() async throws {
+    func test_fetchItems_정상적으로_가져오기() async {
         // Given
         let sut = makeSUT()
-        let fetchResult: [WasteBasketItem] = try [
+        let fetchResult: [WasteBasketItem] = [
             .folder(obj: Folder(name: "테스트 폴더")),
             .voiceNote(obj: VoiceNote(
                 title: "테스트 노트",


### PR DESCRIPTION
## ✨ 작업 요약
> 음성노트 이동 시트에서 새 폴더를 직접 생성할 수 있도록 구현

- 이동 폴더 선택 시트에서 "새 폴더" 버튼 탭 시 `NewFolderViewController`로 슬라이드 전환
- 폴더 이름 입력 후 만들기 → 폴더 생성 및 목록으로 복귀
- 취소 → 이전 화면 복귀, 시트 크기 복원
- 에러 발생 시 알럿 표시

## 📋 구체적인 내용
- 추가/변경된 동작:
  - `MoveFolderListViewController` "새 폴더" 버튼 탭 → `NewFolderViewController` push (왼쪽 슬라이드)
  - 시트 detent가 `NewFolderViewController` 컨텐츠 높이에 맞게 동적으로 조정
  - 폴더 생성 성공 → `MoveFolderListViewController`로 pop + 목록 자동 새로고침
  - 키보드 올라올 때 하단 spacerView가 여백을 흡수하여 버튼 레이아웃 유지
  - `Alertable` 프로토콜로 에러 알럿 공통화
- 영향 받는 화면/모듈: `Presentation`, `App`

---

## 🔗 연관 이슈

- closed #196

---

## 🧩 설계·구현 노트

- **선택한 방식**
  - `MoveFolderListViewController`를 `UINavigationController`에 embed하여 sheet로 present → `pushViewController`로 자연스러운 슬라이드 전환
  - `UISheetPresentationController.animateChanges`로 push/pop 시 detent 동적 변경
  - `NewFolderViewController.preferredContentSize`를 `systemLayoutSizeFitting`으로 동적 계산하여 custom detent resolver에 전달

- **고려했다가 제외한 방식**
  - SheetCoordinator 분리: 시트 내 화면이 두 개로 고정이므로 과한 추상화 판단
  - 폴더 생성 성공 후 시트 전체 dismiss: UX 상 생성한 폴더를 바로 선택할 수 있도록 목록 복귀 방식 채택

---

## ✅ 확인 사항

- [ ] 정상 플로우 동작 확인 (새 폴더 생성 → 목록 복귀 → 폴더 선택 → 이동)
- [ ] 취소 버튼 탭 시 이전 화면 복귀 및 시트 크기 복원 확인
- [ ] 중복/빈 이름 등 에러 케이스 알럿 표시 확인
- [ ] 키보드 올라올 때 버튼 레이아웃 유지 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부

---

## 👀 리뷰 포인트

- [ ] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] UI/UX (해당 시)

**특히 봐줬으면 하는 부분**

- `preferredContentSize` + custom detent 조합으로 시트 높이를 동적으로 맞추는 방식이 적절한지
- `viewWillAppear`에서 폴더 목록을 매번 새로고침하는 게 성능상 문제 없는지

---

## 🗺 아키텍처 다이어그램

```mermaid
sequenceDiagram
    actor User
    participant MoveFolderListVC
    participant MoveFolderListVM
    participant MainCoordinator
    participant NewFolderVC
    participant NewFolderVM
    participant CreateFolderUseCase

    User->>MoveFolderListVC: 새 폴더 버튼 탭
    MoveFolderListVC->>MoveFolderListVM: send(.view(.addFolderButtonTapped))
    MoveFolderListVM->>MainCoordinator: pushNewFolder()
    MainCoordinator->>NewFolderVC: pushViewController (슬라이드)
    MainCoordinator->>MainCoordinator: sheet detent → preferredContentSize

    User->>NewFolderVC: 이름 입력 후 만들기 탭
    NewFolderVC->>NewFolderVM: send(.view(.createButtonTapped(name:)))
    NewFolderVM->>CreateFolderUseCase: execute(name:)
    CreateFolderUseCase-->>NewFolderVM: Folder
    NewFolderVM->>MainCoordinator: folderCreated()
    MainCoordinator->>MoveFolderListVC: popViewController (슬라이드)
    MainCoordinator->>MainCoordinator: sheet detent → .medium()
    MoveFolderListVC->>MoveFolderListVM: viewWillAppear → onAppear (목록 새로고침)
```