### PR TITLE
메인 화면, 개인 폴더 화면 UI/UX 리펙토링

### DIFF
--- a/Presentation/Sources/Component/Common/TextFieldView.swift
+++ b/Presentation/Sources/Component/Common/TextFieldView.swift
@@ -20,8 +20,7 @@ final class TextFieldView: UIView {
     private lazy var titleLabel: UILabel = {
         let t = UILabel()
         t.translatesAutoresizingMaskIntoConstraints = false
-        t.setTypography(text: field.title, style: .title2)
-        t.textAlignment = .center
+        t.setTypography(text: field.title, style: .title2, textAlignment: .center)
         t.textColor = .gray950
         return t
     }()
@@ -29,8 +28,7 @@ final class TextFieldView: UIView {
     private lazy var subTitleLabel: UILabel = {
         let t = UILabel()
         t.translatesAutoresizingMaskIntoConstraints = false
-        t.setTypography(text: field.subTitle, style: .body2)
-        t.textAlignment = .center
+        t.setTypography(text: field.subTitle, style: .body2, textAlignment: .center)
         t.textColor = .gray950
         t.numberOfLines = 0
         return t
@@ -43,7 +41,14 @@ final class TextFieldView: UIView {
         tf.layer.cornerRadius = 8
         tf.textColor = .gray950
         tf.font = Typography.body1.font
-        tf.defaultTextAttributes = Typography.body1.textAttributes
+        // UITextField는 한 줄 입력 요소이므로 줄간격(paragraphStyle)이나
+        // baselineOffset이 들어가면 자체 수직 정렬(Center Y) 계산과 충돌해 텍스트가 살짝 아래로 처집니다.
+        // 따라서 폰트, 글자색상, 자간(kern)만 명시적으로 넣어줍니다.
+        tf.defaultTextAttributes = [
+            .font: Typography.body1.font,
+            .foregroundColor: UIColor.gray950,
+            .kern: Typography.body1.letterSpacing
+        ]
         tf.delegate = self
         tf.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         tf.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: 0))
@@ -107,8 +112,8 @@ final class TextFieldView: UIView {
     
     override func updateProperties() {
         super.updateProperties()
-        titleLabel.setTypography(text: field.title, style: .title2)
-        subTitleLabel.setTypography(text: field.subTitle, style: .body2)
+        titleLabel.setTypography(text: field.title, style: .title2, textAlignment: .center)
+        subTitleLabel.setTypography(text: field.subTitle, style: .body2, textAlignment: .center)
         placeholderLabel.setTypography(text: field.placeHolder, style: .body1)
 
         if textField.text != field.text {

--- a/Presentation/Sources/Component/Common/TextFieldView.swift
+++ b/Presentation/Sources/Component/Common/TextFieldView.swift
@@ -1,251 +1,233 @@
 import UIKit
 
-public final class TextFieldView: UIView {
+final class TextFieldView: UIView {
     // MARK: - Properties
+    var field: Field
+    
+    // 키보드 상태 변화를 알리기 위한 콜백
+    var onEditingDidBegin: (() -> Void)?
+    var onEditingDidEnd: (() -> Void)?
 
-    var isEdit: Bool
-    var title: String
-    var subTitle: String
-    private let placeholder: String
-
-    var onConfirm: ((String) -> Void)?
-    var onCancel: (() -> Void)?
-
-    // MARK: - UI Components
-
-    private let containerStack: UIStackView = {
-        let stack = UIStackView()
-        stack.axis = .vertical
-        stack.distribution = .fill
-        stack.spacing = Constant.alertTopAndBottomContentSpacing
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        return stack
+    // MARK: - Componenet
+    private let container: UIStackView = {
+        let c = UIStackView()
+        c.translatesAutoresizingMaskIntoConstraints = false
+        c.axis = .vertical
+        c.spacing = 12
+        return c
     }()
-
-    private let topContentStack: UIStackView = {
-        let stack = UIStackView()
-        stack.axis = .vertical
-        stack.spacing = 12
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        return stack
+    
+    private lazy var titleLabel: UILabel = {
+        let t = UILabel()
+        t.translatesAutoresizingMaskIntoConstraints = false
+        t.setTypography(text: field.title, style: .title2)
+        t.textAlignment = .center
+        t.textColor = .gray950
+        return t
     }()
-
-    private let headerLabel: UILabel = {
-        let label = UILabel()
-        label.textAlignment = .center
-        label.textColor = .gray950
-        return label
+    
+    private lazy var subTitleLabel: UILabel = {
+        let t = UILabel()
+        t.translatesAutoresizingMaskIntoConstraints = false
+        t.setTypography(text: field.subTitle, style: .body2)
+        t.textAlignment = .center
+        t.textColor = .gray950
+        t.numberOfLines = 0
+        return t
     }()
-
-    private let bodyLabel: UILabel = {
-        let label = UILabel()
-        label.textAlignment = .center
-        label.textColor = .gray800
-        label.numberOfLines = 0
-        return label
-    }()
-
+    
     private lazy var textField: UITextField = {
         let tf = UITextField()
         tf.translatesAutoresizingMaskIntoConstraints = false
-        tf.backgroundColor = .white.withAlphaComponent(0.5)
-        tf.layer.cornerRadius = 12
-        tf.layer.borderWidth = 1
-        tf.layer.borderColor = UIColor.gray300.cgColor
-        tf.placeholder = placeholder
-        tf.font = Typography.body1.font
+        tf.backgroundColor = .gray100
+        tf.layer.cornerRadius = 8
         tf.textColor = .gray950
-        tf.autocorrectionType = .no
-        tf.spellCheckingType = .no
-        tf.clearButtonMode = .whileEditing
-
-        // Left Padding
-        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: 0))
-        tf.leftView = paddingView
-        tf.leftViewMode = .always
-
+        tf.font = Typography.body1.font
+        tf.defaultTextAttributes = Typography.body1.textAttributes
         tf.delegate = self
         tf.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+        tf.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: 0))
+        tf.leftViewMode = .always
+        tf.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: 0))
+        tf.rightViewMode = .always
         return tf
     }()
 
-    private let bottomContentStack: UIStackView = {
-        let stack = UIStackView()
-        stack.axis = .horizontal
-        stack.distribution = .fillEqually
-        stack.spacing = Constant.alertSpacing
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        return stack
+    private lazy var placeholderLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setTypography(text: field.placeHolder, style: .body1)
+        label.textColor = .gray600
+        label.numberOfLines = 0
+        return label
     }()
+    
+    private let bottomContainer: UIStackView = {
+        let c = UIStackView()
+        c.translatesAutoresizingMaskIntoConstraints = false
+        c.axis = .horizontal
+        c.spacing = 8
 
-    private let cancelButton: GlassButton = .close("취소")
-    private lazy var confirmButton: GlassButton = .primary(isEdit ? "수정" : "추가")
-
-    // MARK: - Initializer
-
-    init(isEdit: Bool, title: String, subTitle: String, placeholder: String) {
-        self.isEdit = isEdit
-        self.title = title
-        self.subTitle = subTitle
-        self.placeholder = placeholder
+        return c
+    }()
+    
+    private let cancelButton: GlassButton
+    private let primaryButton: GlassButton
+    // MARK: - Initialize
+    
+    init(
+        field: Field,
+        cancelButton: GlassButton,
+        primaryButton: GlassButton
+    ) {
+        self.field = field
+        self.cancelButton = cancelButton
+        self.primaryButton = primaryButton
         super.init(frame: .zero)
         setup()
-        setupConstraints()
-        setupActions()
     }
-
-    @available(*, unavailable)
+    
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        nil
     }
-
-    // MARK: - Lifecycle
-
-    override public func didMoveToSuperview() {
-        super.didMoveToSuperview()
-        guard let superview else { return }
-
-        NSLayoutConstraint.activate([
-            centerXAnchor.constraint(equalTo: superview.centerXAnchor),
-            centerYAnchor.constraint(equalTo: superview.centerYAnchor, constant: -100), // Keyboard offset
-            widthAnchor.constraint(equalTo: superview.widthAnchor, multiplier: Constant.alertMultiplierWidth)
-        ])
-
-        // Auto focus
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.textField.becomeFirstResponder()
-        }
-    }
-
-    override public func layoutSubviews() {
+    
+    // MARK: - LifeCycle
+    override func layoutSubviews() {
         super.layoutSubviews()
-        layer.cornerRadius = Constant.cornerRadius
-
         layer.shadowColor = UIColor.black.cgColor
         layer.shadowOpacity = Constant.shadowOpacity
         layer.shadowOffset = CGSize(width: Constant.shadowOffsetWidth, height: Constant.shadowOffsetHeight)
         layer.shadowRadius = Constant.cornerRadius
+        layer.shadowPath =
+            UIBezierPath(
+                roundedRect: bounds,
+                cornerRadius: Constant.cornerRadius
+            ).cgPath
     }
-}
+    
+    override func updateProperties() {
+        super.updateProperties()
+        titleLabel.setTypography(text: field.title, style: .title2)
+        subTitleLabel.setTypography(text: field.subTitle, style: .body2)
+        placeholderLabel.setTypography(text: field.placeHolder, style: .body1)
 
-// MARK: - Setup
+        if textField.text != field.text {
+            textField.text = field.text
+        }
 
-private extension TextFieldView {
-    func setup() {
+        switch field.mode {
+        case .create:
+            primaryButton.configuration?.title = "만들기"
+        case .edit:
+            primaryButton.configuration?.title = "수정하기"
+        }
+        primaryButton.isEnabled = field.isSubmitEnabled
+        updatePlaceholderVisibility()
+    }
+    
+    // MARK: - Setup
+    private func setup() {
         translatesAutoresizingMaskIntoConstraints = false
-        backgroundColor = .point200.withAlphaComponent(0.9) // More opaque for readability
-        layer.borderWidth = Constant.borderWidth
+        backgroundColor = .point200.withAlphaComponent(0.2)
+        layer.cornerRadius = Constant.cornerRadius
         layer.borderColor = UIColor.gray600.cgColor
-
-        headerLabel.setTypography(text: title, style: .title2)
-        bodyLabel.setTypography(text: subTitle, style: .body1)
-
-        confirmButton.isEnabled = false
-
-        addSubview(containerStack)
-        containerStack.addArrangedSubview(topContentStack)
-        containerStack.addArrangedSubview(bottomContentStack)
-
-        topContentStack.addArrangedSubview(headerLabel)
-        topContentStack.addArrangedSubview(bodyLabel)
-        topContentStack.addArrangedSubview(textField)
-
-        bottomContentStack.addArrangedSubview(cancelButton)
-        bottomContentStack.addArrangedSubview(confirmButton)
+        layer.borderWidth = Constant.borderWidth
+        setupConstraint()
+        setupStyle()
     }
-
-    func setupConstraints() {
+    
+    private func setupConstraint() {
+        bottomContainer.addArrangedSubview(cancelButton)
+        bottomContainer.addArrangedSubview(primaryButton)
+        container.addArrangedSubview(titleLabel)
+        container.addArrangedSubview(subTitleLabel)
+        container.addArrangedSubview(textField)
+        container.setCustomSpacing(24, after: textField)
+        container.addArrangedSubview(bottomContainer)
+        addSubview(container)
+        textField.addSubview(placeholderLabel)
+        
         NSLayoutConstraint.activate([
-            containerStack.topAnchor.constraint(
-                equalTo: topAnchor,
-                constant: Constant.alertTopAndBottomValueForTopContent
-            ),
-            containerStack.leadingAnchor.constraint(
-                equalTo: leadingAnchor,
-                constant: Constant.alertLeftAndRightValueForTopContent
-            ),
-            containerStack.trailingAnchor.constraint(
-                equalTo: trailingAnchor,
-                constant: -Constant.alertLeftAndRightValueForTopContent
-            ),
-            containerStack.bottomAnchor.constraint(
-                equalTo: bottomAnchor,
-                constant: -Constant.alertTopAndBottomValueForBottomContent
-            ),
-
+            container.topAnchor.constraint(equalTo: topAnchor, constant: 32),
+            container.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            container.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
+            container.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -32),
             textField.heightAnchor.constraint(equalToConstant: 48),
-            bottomContentStack.heightAnchor.constraint(equalToConstant: Constant.alertBottomContentHeight)
+            placeholderLabel.centerYAnchor.constraint(equalTo: textField.centerYAnchor),
+            placeholderLabel.leadingAnchor.constraint(equalTo: textField.leadingAnchor, constant: 12),
+            placeholderLabel.trailingAnchor.constraint(lessThanOrEqualTo: textField.trailingAnchor, constant: -12),
+            cancelButton.heightAnchor.constraint(equalToConstant: 46),
+            primaryButton.heightAnchor.constraint(equalToConstant: 46),
         ])
     }
+    
+    private func setupStyle() {
+        cancelButton.setShadow(true)
+        cancelButton.setCapsuleCornerRadius()
+        primaryButton.setShadow(true)
+        primaryButton.setCapsuleCornerRadius()
+        updatePlaceholderVisibility()
+    }
 
-    func setupActions() {
-        cancelButton.addAction(UIAction { [weak self] _ in
-            self?.onCancel?()
-            self?.textField.text = ""
-        }, for: .touchUpInside)
-
-        confirmButton.addAction(UIAction { [weak self] _ in
-            guard let text = self?.textField.text, !text.trimmingCharacters(in: .whitespaces).isEmpty else { return }
-            self?.onConfirm?(text)
-            self?.textField.text = ""
-        }, for: .touchUpInside)
+    private func updatePlaceholderVisibility() {
+        placeholderLabel.isHidden = !field.text.isEmpty
     }
 
     @objc
-    func textFieldDidChange() {
-        let text = textField.text ?? ""
-        confirmButton.isEnabled = !text.trimmingCharacters(in: .whitespaces).isEmpty
+    private func textFieldDidChange() {
+        field.text = textField.text ?? ""
+        updatePlaceholderVisibility()
     }
 }
 
-// MARK: - Public API
 
-public extension TextFieldView {
-    func configure(
-        isEdit: Bool,
-        name: String? = nil,
-        title: String? = nil,
-        subTitle: String? = nil
-    ) {
-        self.isEdit = isEdit
-        if let title { self.title = title }
-        if let subTitle { self.subTitle = subTitle }
+//MARK: - Observable 구조
 
-        headerLabel.setTypography(text: self.title, style: .title2)
-        bodyLabel.setTypography(text: self.subTitle, style: .body1)
+extension TextFieldView {
+    @Observable
+    final class Field {
+        var mode: Mode
+        var title: String
+        var subTitle: String
+        var placeHolder: String
+        var text: String
 
-        if isEdit {
-            textField.text = name
-            confirmButton.setTitle("수정", for: .normal)
-            confirmButton.isEnabled = !(name?.isEmpty ?? true)
-        } else {
-            textField.text = ""
-            confirmButton.setTitle("추가", for: .normal)
-            confirmButton.isEnabled = false
+        var trimmedText: String {
+            text.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        var isSubmitEnabled: Bool {
+            !trimmedText.isEmpty
+        }
+        
+        init(mode: Mode, title: String, subTitle: String, placeHolder: String, text: String = "") {
+            self.mode = mode
+            self.title = title
+            self.subTitle = subTitle
+            self.placeHolder = placeHolder
+            self.text = text
         }
     }
+
+    enum Mode {
+        case create
+        case edit
+    }
 }
 
-// MARK: - UITextFieldDelegate
+// MARK: TextField Delegate
 
 extension TextFieldView: UITextFieldDelegate {
-    public func textField(
-        _ textField: UITextField,
-        shouldChangeCharactersIn range: NSRange,
-        replacementString string: String
-    ) -> Bool {
-        let currentText = textField.text ?? ""
-        guard let stringRange = Range(range, in: currentText) else { return false }
-        let updatedText = currentText.replacingCharacters(in: stringRange, with: string)
-
-        return updatedText.count <= 20
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
     }
 
-    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if confirmButton.isEnabled {
-            guard let text = textField.text else { return true }
-            onConfirm?(text)
-        }
-        return true
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        onEditingDidBegin?()
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        onEditingDidEnd?()
     }
 }

--- a/Presentation/Sources/Component/Common/TextFieldView.swift
+++ b/Presentation/Sources/Component/Common/TextFieldView.swift
@@ -2,13 +2,15 @@ import UIKit
 
 final class TextFieldView: UIView {
     // MARK: - Properties
+
     var field: Field
-    
+
     // 키보드 상태 변화를 알리기 위한 콜백
     var onEditingDidBegin: (() -> Void)?
     var onEditingDidEnd: (() -> Void)?
 
     // MARK: - Componenet
+
     private let container: UIStackView = {
         let c = UIStackView()
         c.translatesAutoresizingMaskIntoConstraints = false
@@ -16,7 +18,7 @@ final class TextFieldView: UIView {
         c.spacing = 12
         return c
     }()
-    
+
     private lazy var titleLabel: UILabel = {
         let t = UILabel()
         t.translatesAutoresizingMaskIntoConstraints = false
@@ -24,7 +26,7 @@ final class TextFieldView: UIView {
         t.textColor = .gray950
         return t
     }()
-    
+
     private lazy var subTitleLabel: UILabel = {
         let t = UILabel()
         t.translatesAutoresizingMaskIntoConstraints = false
@@ -33,7 +35,7 @@ final class TextFieldView: UIView {
         t.numberOfLines = 0
         return t
     }()
-    
+
     private lazy var textField: UITextField = {
         let tf = UITextField()
         tf.translatesAutoresizingMaskIntoConstraints = false
@@ -66,7 +68,7 @@ final class TextFieldView: UIView {
         label.numberOfLines = 0
         return label
     }()
-    
+
     private let bottomContainer: UIStackView = {
         let c = UIStackView()
         c.translatesAutoresizingMaskIntoConstraints = false
@@ -75,11 +77,12 @@ final class TextFieldView: UIView {
 
         return c
     }()
-    
+
     private let cancelButton: GlassButton
     private let primaryButton: GlassButton
+
     // MARK: - Initialize
-    
+
     init(
         field: Field,
         cancelButton: GlassButton,
@@ -91,12 +94,13 @@ final class TextFieldView: UIView {
         super.init(frame: .zero)
         setup()
     }
-    
+
     required init?(coder: NSCoder) {
         nil
     }
-    
+
     // MARK: - LifeCycle
+
     override func layoutSubviews() {
         super.layoutSubviews()
         layer.shadowColor = UIColor.black.cgColor
@@ -109,7 +113,7 @@ final class TextFieldView: UIView {
                 cornerRadius: Constant.cornerRadius
             ).cgPath
     }
-    
+
     override func updateProperties() {
         super.updateProperties()
         titleLabel.setTypography(text: field.title, style: .title2, textAlignment: .center)
@@ -129,8 +133,9 @@ final class TextFieldView: UIView {
         primaryButton.isEnabled = field.isSubmitEnabled
         updatePlaceholderVisibility()
     }
-    
+
     // MARK: - Setup
+
     private func setup() {
         translatesAutoresizingMaskIntoConstraints = false
         backgroundColor = .point200.withAlphaComponent(0.2)
@@ -140,7 +145,7 @@ final class TextFieldView: UIView {
         setupConstraint()
         setupStyle()
     }
-    
+
     private func setupConstraint() {
         bottomContainer.addArrangedSubview(cancelButton)
         bottomContainer.addArrangedSubview(primaryButton)
@@ -151,7 +156,7 @@ final class TextFieldView: UIView {
         container.addArrangedSubview(bottomContainer)
         addSubview(container)
         textField.addSubview(placeholderLabel)
-        
+
         NSLayoutConstraint.activate([
             container.topAnchor.constraint(equalTo: topAnchor, constant: 32),
             container.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
@@ -162,10 +167,10 @@ final class TextFieldView: UIView {
             placeholderLabel.leadingAnchor.constraint(equalTo: textField.leadingAnchor, constant: 12),
             placeholderLabel.trailingAnchor.constraint(lessThanOrEqualTo: textField.trailingAnchor, constant: -12),
             cancelButton.heightAnchor.constraint(equalToConstant: 46),
-            primaryButton.heightAnchor.constraint(equalToConstant: 46),
+            primaryButton.heightAnchor.constraint(equalToConstant: 46)
         ])
     }
-    
+
     private func setupStyle() {
         cancelButton.setShadow(true)
         cancelButton.setCapsuleCornerRadius()
@@ -185,8 +190,7 @@ final class TextFieldView: UIView {
     }
 }
 
-
-//MARK: - Observable 구조
+// MARK: - Observable 구조
 
 extension TextFieldView {
     @Observable
@@ -204,7 +208,7 @@ extension TextFieldView {
         var isSubmitEnabled: Bool {
             !trimmedText.isEmpty
         }
-        
+
         init(mode: Mode, title: String, subTitle: String, placeHolder: String, text: String = "") {
             self.mode = mode
             self.title = title

--- a/Presentation/Sources/Component/Folder/FolderCardView.swift
+++ b/Presentation/Sources/Component/Folder/FolderCardView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct FolderCardView: View {
     let name: String
     let totalCount: Int
-    
+
     var body: some View {
         HStack(spacing: 8) {
             Group {
@@ -12,8 +12,8 @@ struct FolderCardView: View {
                     .font(Font.custom("Pretendard", size: 16))
                 Spacer()
                 Text(String(totalCount))
-                  .font(Font.custom("Pretendard", size: 16))
-                  .multilineTextAlignment(.trailing)
+                    .font(Font.custom("Pretendard", size: 16))
+                    .multilineTextAlignment(.trailing)
             }
             .foregroundColor(.gray800)
         }

--- a/Presentation/Sources/Component/Folder/FolderCardView.swift
+++ b/Presentation/Sources/Component/Folder/FolderCardView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct FolderCardView: View {
+    let name: String
+    let totalCount: Int
+    
+    var body: some View {
+        HStack(spacing: 8) {
+            Group {
+                Image(systemName: "folder")
+                Text(name)
+                    .font(Font.custom("Pretendard", size: 16))
+                Spacer()
+                Text(String(totalCount))
+                  .font(Font.custom("Pretendard", size: 16))
+                  .multilineTextAlignment(.trailing)
+            }
+            .foregroundColor(.gray800)
+        }
+        .padding(16)
+        .background(.point200.opacity(0.2))
+        .glassEffect(.clear, in: .rect(cornerRadius: 20))
+    }
+}

--- a/Presentation/Sources/DesignSystem/Font/Typography.swift
+++ b/Presentation/Sources/DesignSystem/Font/Typography.swift
@@ -82,12 +82,14 @@ public extension UILabel {
     func setTypography(text: String? = nil, style typography: Typography, textAlignment: NSTextAlignment = .left) {
         let textToUse = text ?? self.text ?? ""
         var attributes = typography.textAttributes
-        
-        if let paragraphStyle = (attributes[.paragraphStyle] as? NSParagraphStyle)?.mutableCopy() as? NSMutableParagraphStyle {
+
+        if let paragraphStyle = (attributes[.paragraphStyle] as? NSParagraphStyle)?
+            .mutableCopy() as? NSMutableParagraphStyle
+        {
             paragraphStyle.alignment = textAlignment
             attributes[.paragraphStyle] = paragraphStyle
         }
-        
+
         attributedText = NSAttributedString(string: textToUse, attributes: attributes)
     }
 }

--- a/Presentation/Sources/DesignSystem/Font/Typography.swift
+++ b/Presentation/Sources/DesignSystem/Font/Typography.swift
@@ -78,8 +78,16 @@ public extension UILabel {
     /// - Parameters:
     ///   - text: UILabel의 텍스트 입니다.
     ///   - typography: 글씨체, 행간 , 자간 복합적인 열겨형 데이터
-    func setTypography(text: String? = nil, style typography: Typography) {
+    ///   - textAlignment: 텍스트 정렬 설정 (기본값: .left)
+    func setTypography(text: String? = nil, style typography: Typography, textAlignment: NSTextAlignment = .left) {
         let textToUse = text ?? self.text ?? ""
-        attributedText = NSAttributedString(string: textToUse, attributes: typography.textAttributes)
+        var attributes = typography.textAttributes
+        
+        if let paragraphStyle = (attributes[.paragraphStyle] as? NSParagraphStyle)?.mutableCopy() as? NSMutableParagraphStyle {
+            paragraphStyle.alignment = textAlignment
+            attributes[.paragraphStyle] = paragraphStyle
+        }
+        
+        attributedText = NSAttributedString(string: textToUse, attributes: attributes)
     }
 }

--- a/Presentation/Sources/DesignSystem/Font/Typography.swift
+++ b/Presentation/Sources/DesignSystem/Font/Typography.swift
@@ -53,6 +53,24 @@ public enum Typography {
             return size * -0.03
         }
     }
+
+    var textAttributes: [NSAttributedString.Key: Any] {
+        let paragraphStyle = NSMutableParagraphStyle()
+        let fontLineHeight = font.lineHeight
+        let targetLineHeight = fontLineHeight * lineHeightMultiple
+
+        paragraphStyle.minimumLineHeight = targetLineHeight
+        paragraphStyle.maximumLineHeight = targetLineHeight
+
+        let baselineOffset = (targetLineHeight - fontLineHeight) / 2
+
+        return [
+            .font: font,
+            .paragraphStyle: paragraphStyle,
+            .kern: letterSpacing,
+            .baselineOffset: baselineOffset
+        ]
+    }
 }
 
 public extension UILabel {
@@ -62,24 +80,6 @@ public extension UILabel {
     ///   - typography: 글씨체, 행간 , 자간 복합적인 열겨형 데이터
     func setTypography(text: String? = nil, style typography: Typography) {
         let textToUse = text ?? self.text ?? ""
-
-        let paragraphStyle = NSMutableParagraphStyle()
-        // lineHeightMultiple을 설정하면 남는 여백이 주로 위쪽에 추가되어 텍스트가 아래로 쏠려 보입니다.
-        let fontLineHeight = typography.font.lineHeight
-        let targetLineHeight = fontLineHeight * typography.lineHeightMultiple
-
-        paragraphStyle.minimumLineHeight = targetLineHeight
-        paragraphStyle.maximumLineHeight = targetLineHeight
-
-        // 여백(targetLineHeight - fontLineHeight)의 절반만큼 위로 끌어올리면 정확히 중앙에 배치됩니다.
-        let baselineOffset = (targetLineHeight - fontLineHeight) / 2
-
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: typography.font,
-            .paragraphStyle: paragraphStyle,
-            .kern: typography.letterSpacing,
-            .baselineOffset: baselineOffset // 계산된 값 적용
-        ]
-        attributedText = NSAttributedString(string: textToUse, attributes: attributes)
+        attributedText = NSAttributedString(string: textToUse, attributes: typography.textAttributes)
     }
 }

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -1,36 +1,18 @@
 import Domain
 import Observation
 import UIKit
+import SwiftUI
 
-public final class FolderViewController: UITableViewController {
-    private enum Section {
+public final class FolderViewController: CollectionViewController {
+    enum Section {
         case main
     }
-
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, LibraryItem>
+    typealias SnapShot = NSDiffableDataSourceSnapshot<Section, LibraryItem>
     private let vm: FolderViewModel
-    private var dataSource: UITableViewDiffableDataSource<Section, LibraryItem>!
-
+    private var dataSource: DataSource!
+    private var listConfiguration: UICollectionLayoutListConfiguration = .init(appearance: .plain)
     // MARK: - Component
-
-    private let overlayView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .black.withAlphaComponent(0.3)
-        view.alpha = 0
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
-
-    private let textField: TextFieldView = {
-        let tf = TextFieldView(
-            isEdit: false,
-            title: "새 폴더",
-            subTitle: "새로 만들 폴더의 이름을 입력해주세요.",
-            placeholder: "폴더 이름을 적어주세요"
-        )
-        tf.alpha = 0
-        tf.transform = CGAffineTransform(scaleX: 1.1, y: 1.1)
-        return tf
-    }()
 
     private lazy var backButton: UIButton = {
         let btn = UIButton(type: .system)
@@ -51,17 +33,35 @@ public final class FolderViewController: UITableViewController {
         btn.tintColor = UIColor.gray950
         return btn
     }()
+    
+    private var cancelButton: GlassButton = .close("취소")
+    private var primaryButton: GlassButton = .primary("만들기")
+    private var isKeyboardVisible = false
+    private var textFieldCenterYConstraint: NSLayoutConstraint?
+    
+    private lazy var textField = TextFieldView(
+        field: .init(
+            mode: .create,
+            title: "새 폴더",
+            subTitle: "새로 만들 폴더의 이름을\n입력해주세요.",
+            placeHolder: "폴더 이름을 적어주세요"),
+        cancelButton: cancelButton,
+        primaryButton: primaryButton
+    )
 
     // MARK: - Initialize
 
     public init(vm: FolderViewModel) {
         self.vm = vm
-        super.init(nibName: nil, bundle: nil)
+        listConfiguration.backgroundColor = .clear
+        listConfiguration.showsSeparators = false
+        let layout = UICollectionViewCompositionalLayout.list(using: listConfiguration)
+        super.init(collectionViewLayout: layout)
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        nil
     }
 
     // MARK: - LifeCycle
@@ -70,10 +70,15 @@ public final class FolderViewController: UITableViewController {
         super.viewDidLoad()
         setup()
         setupNavigationBar()
-        bindTextFieldCancel()
-        bindTextFieldConfirm()
+        setupSwipeAction()
+        setupButtons()
         setupDataSource()
         updateDataSource(animated: false)
+    }
+
+    override public func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        vm.fetchAll()
     }
 
     override public func viewWillLayoutSubviews() {
@@ -82,24 +87,59 @@ public final class FolderViewController: UITableViewController {
 
     override public func updateProperties() {
         super.updateProperties()
-        if vm.showAlert {
-            presentAlert()
-        } else {
-            dismissAlert()
+        syncTextFieldField()
+        textField.isHidden = !vm.showTextField
+        let centerYOffset: CGFloat = isKeyboardVisible ? -24 : 0
+        guard textFieldCenterYConstraint?.constant != centerYOffset else { return }
+
+        view.setNeedsUpdateConstraints()
+
+        guard view.window != nil else { return }
+
+        UIView.animate(
+            withDuration: Constant.animationDuration,
+            delay: 0,
+            options: [.curveEaseInOut, .beginFromCurrentState, .allowUserInteraction]
+        ) {
+            self.view.layoutIfNeeded()
         }
-        // tableview 업데이트
-        updateDataSource()
+    }
+
+    override public func updateViewConstraints() {
+        textFieldCenterYConstraint?.constant = isKeyboardVisible ? -24 : 0
+        super.updateViewConstraints()
     }
 
     // MARK: - Setup
 
     private func setup() {
-        view.backgroundColor = UIColor.gray50
-        tableView.separatorStyle = .none
-        tableView.register(FolderViewCell.self, forCellReuseIdentifier: FolderViewCell.reuseIdentifier)
-    }
+        collectionView.showsVerticalScrollIndicator = false
+        view.addSubview(textField)
+        textFieldCenterYConstraint = textField.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        
+        NSLayoutConstraint.activate([
+            textField.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8),
+            textField.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.35),
+            textField.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            textFieldCenterYConstraint
+        ].compactMap { $0 })
 
+        // TextField 콜백 연결
+        textField.onEditingDidBegin = { [weak self] in
+            self?.isKeyboardVisible = true
+            self?.updateProperties()
+        }
+        
+        textField.onEditingDidEnd = { [weak self] in
+            self?.isKeyboardVisible = false
+            self?.updateProperties()
+        }
+    }
+    
     private func setupNavigationBar() {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundColor = UIColor.gray50
         backButton.addAction(
             UIAction { [weak self] _ in
                 self?.vm.didTapBack()
@@ -110,19 +150,80 @@ public final class FolderViewController: UITableViewController {
 
         addButton.addAction(
             UIAction { [weak self] _ in
-                self?.textField.configure(
-                    isEdit: false,
-                    title: "새 폴더",
-                    subTitle: "새로 만들 폴더의 이름을 입력해주세요."
-                )
-                self?.vm.openTextFieldView()
+                self?.vm.openTextField()
             }, for: .touchUpInside
         )
         let rightItem = UIBarButtonItem(customView: addButton)
         navigationItem.rightBarButtonItem = rightItem
-
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
         navigationItem.rightBarButtonItem?.hidesSharedBackground = true
+    }
+    
+    /// 오른쪽 Swipe 액션을 제어하는 함수
+    private func setupSwipeAction() {
+        listConfiguration.trailingSwipeActionsConfigurationProvider = { [weak self] indexPath in
+            self?.trailingAction(indexPath: indexPath)
+        }
+        
+        // List 레이아웃을 사용하되, 섹션 설정을 통해 간격을 조정합니다.
+        let layout = UICollectionViewCompositionalLayout { [weak self] sectionIndex, layoutEnvironment in
+            guard let self else { return nil }
+            let config = self.listConfiguration
+            // 개별 셀의 높이가 카드에 딱 맞게 설정되도록 여백 제거
+            let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: layoutEnvironment)
+            section.interGroupSpacing = 8
+            section.contentInsets = .init(top: 14, leading: 20, bottom: 14, trailing: 20)
+            return section
+        }
+        collectionView.setCollectionViewLayout(layout, animated: false)
+    }
+    
+    private func setupButtons() {
+        cancelButton.addAction(
+            UIAction { [weak self] _ in
+                guard let self else { return }
+                textField.field.text = ""
+                vm.closeTextField()
+            },
+            for: .touchUpInside
+        )
+        
+        primaryButton.addAction(
+            UIAction { [weak self] _ in
+                guard let self else { return }
+                let name = textField.field.trimmedText
+                guard !name.isEmpty else { return }
+
+                switch vm.mode {
+                case .create:
+                    vm.create(name: name)
+                case .edit:
+                    vm.update(name: name)
+                }
+                textField.field.text = ""
+                vm.closeTextField()
+            },
+            for: .touchUpInside
+        )
+    }
+
+    private func syncTextFieldField() {
+        textField.field.mode = vm.mode
+
+        switch vm.mode {
+        case .create:
+            textField.field.title = "새 폴더"
+            textField.field.subTitle = "새로 만들 폴더의 이름을\n입력해주세요."
+            textField.field.placeHolder = "폴더 이름을 적어주세요"
+            if !vm.showTextField {
+                textField.field.text = ""
+            }
+        case .edit:
+            textField.field.title = "폴더 이름 수정"
+            textField.field.subTitle = "수정할 폴더의 이름을\n입력해주세요."
+            textField.field.placeHolder = "폴더 이름을 적어주세요"
+            textField.field.text = vm.editFolder?.name ?? ""
+        }
     }
 }
 
@@ -130,95 +231,51 @@ public final class FolderViewController: UITableViewController {
 
 extension FolderViewController {
     private func setupDataSource() {
-        dataSource = UITableViewDiffableDataSource<
-            Section,
-            LibraryItem
-        >(tableView: tableView) { tableView, indexPath, item in
-            guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: FolderViewCell.reuseIdentifier,
-                for: indexPath
-            ) as? FolderViewCell else {
-                return UITableViewCell()
+        let cellRegistraint = UICollectionView.CellRegistration<UICollectionViewCell, LibraryItem> { cell, indexPath, item in
+            cell.backgroundConfiguration = .clear()
+            cell.contentConfiguration = UIHostingConfiguration {
+                switch item {
+                case .folder(let data):
+                    FolderCardView(
+                        name: data.name,
+                        totalCount: data.content.count
+                    )
+                case .voiceNote(let data):
+                    VoiceNoteCardView(title: data.title, subTitle: Date.now.voiceNoteDay(createdAt: data.createdAt, updatedAt: data.updatedAt, duration: data.voiceRecord.duration))
+                }
             }
-            cell.configure(with: item)
-            return cell
+            .margins(.all, 0)
         }
+            
+
+        dataSource = DataSource(
+            collectionView: collectionView, 
+            cellProvider: { col, indexPath, item in
+                return col.dequeueConfiguredReusableCell(using: cellRegistraint, for: indexPath, item: item)
+            }
+        )
+        updateDataSource()
     }
 
     private func updateDataSource(animated: Bool = true) {
-        var snapshot = NSDiffableDataSourceSnapshot<Section, LibraryItem>()
+        var snapshot = SnapShot()
         snapshot.appendSections([.main])
         snapshot.appendItems(vm.category.items, toSection: .main)
         dataSource.apply(snapshot, animatingDifferences: animated)
     }
 }
 
-// MARK: - Bind TextField
-
-extension FolderViewController {
-    private func bindTextFieldCancel() {
-        textField.onCancel = { [weak self] in
-            self?.vm.closeTextFieldView()
-        }
-    }
-
-    private func bindTextFieldConfirm() {
-        textField.onConfirm = { [weak self] name in
-            guard let self else { return }
-            if textField.isEdit {
-                vm.update(name: name)
-            } else {
-                vm.create(name: name)
-            }
-        }
-    }
-}
-
 // MARK: - TextField Alert Animation
 
 extension FolderViewController {
-    private func presentAlert() {
-        guard overlayView.superview == nil else { return }
-
-        // Add to window or navigation view to avoid scrolling with table
-        let parentView = navigationController?.view ?? view!
-        parentView.addSubview(overlayView)
-        parentView.addSubview(textField)
-
-        NSLayoutConstraint.activate([
-            overlayView.topAnchor.constraint(equalTo: parentView.topAnchor),
-            overlayView.leadingAnchor.constraint(equalTo: parentView.leadingAnchor),
-            overlayView.trailingAnchor.constraint(equalTo: parentView.trailingAnchor),
-            overlayView.bottomAnchor.constraint(equalTo: parentView.bottomAnchor)
-        ])
-
-        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseOut) {
-            self.overlayView.alpha = 1
-            self.textField.alpha = 1
-            self.textField.transform = .identity
-        }
-    }
-
-    private func dismissAlert() {
-        UIView.animate(withDuration: 0.2, animations: {
-            self.overlayView.alpha = 0
-            self.textField.alpha = 0
-            self.textField.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
-        }) { _ in
-            self.overlayView.removeFromSuperview()
-            self.textField.removeFromSuperview()
-        }
-    }
+    
 }
 
 // MARK: - Swipe Action Delegate
 
 public extension FolderViewController {
-    override func tableView(
-        _ tableView: UITableView,
-        trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
-    ) -> UISwipeActionsConfiguration? {
-        guard let item = dataSource.itemIdentifier(for: indexPath) else { return nil }
+    private func trailingAction(indexPath: IndexPath) -> UISwipeActionsConfiguration {
+        guard let item = self.dataSource.itemIdentifier(for: indexPath) else { return .init() }
 
         let deleteAction = UIContextualAction(style: .destructive, title: "삭제") {
             [weak self] _, _, completion in
@@ -232,13 +289,7 @@ public extension FolderViewController {
         let editAction = UIContextualAction(style: .normal, title: "수정") {
             [weak self] _, _, completion in
             if case .folder(let folder) = item {
-                self?.textField.configure(
-                    isEdit: true,
-                    name: folder.name,
-                    title: "폴더 이름 수정",
-                    subTitle: "수정할 폴더의 이름을 입력해주세요."
-                )
-                self?.vm.openTextFieldView(for: folder)
+                self?.vm.openTextField(for: folder)
             }
             completion(true)
         }
@@ -252,9 +303,9 @@ public extension FolderViewController {
 // MARK: - Cell Touch Delegate
 
 public extension FolderViewController {
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         // 터치 시 배경색 진해진 상태를 부드럽게 원래대로 돌려줍니다.
-        tableView.deselectRow(at: indexPath, animated: true)
+        collectionView.deselectItem(at: indexPath, animated: true)
 
         // 클릭한 셀의 데이터를 가져옵니다.
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
@@ -266,37 +317,12 @@ public extension FolderViewController {
     }
 }
 
-// #Preview {
-//    let dummyItems: [LibraryItem] = [
-//        .folder(
-//            Folder(
-//                name: "개인 아카이브",
-//                content: [
-//                    VoiceNote(
-//                        title: "백업",
-//                        folderID: UUID(),
-//                        voiceRecord: VoiceRecord(audioFilePath: URL(string: "file://2")!, duration: 10)
-//                    )
-//                ]
-//            )
-//        ),
-//        .folder(
-//            Folder(
-//                name: "test 1",
-//                content: [
-//                    VoiceNote(
-//                        title: "백업",
-//                        folderID: UUID(),
-//                        voiceRecord: VoiceRecord(audioFilePath: URL(string: "file://2")!, duration: 10)
-//                    )
-//                ]
-//            )
-//        )
-//    ]
-//
-//    let testFolder = CategoryToggle(imageName: "folder", title: "개인 폴더", items: dummyItems)
-//    let vm = FolderViewModel(category: testFolder)
-//    let folderVC = FolderViewController(vm: vm)
-//
-//    return UINavigationController(rootViewController: folderVC)
-// }
+#if DEBUG
+    #Preview("개인 폴더") {
+        UINavigationController(
+            rootViewController: FolderViewController(
+                vm: .preview()
+            )
+        )
+    }
+#endif

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -36,8 +36,6 @@ public final class FolderViewController: CollectionViewController {
     
     private var cancelButton: GlassButton = .close("취소")
     private var primaryButton: GlassButton = .primary("만들기")
-    private var isKeyboardVisible = false
-    private var textFieldCenterYConstraint: NSLayoutConstraint?
     
     private lazy var textField = TextFieldView(
         field: .init(
@@ -89,51 +87,27 @@ public final class FolderViewController: CollectionViewController {
         super.updateProperties()
         syncTextFieldField()
         textField.isHidden = !vm.showTextField
-        let centerYOffset: CGFloat = isKeyboardVisible ? -24 : 0
-        guard textFieldCenterYConstraint?.constant != centerYOffset else { return }
-
-        view.setNeedsUpdateConstraints()
-
-        guard view.window != nil else { return }
-
-        UIView.animate(
-            withDuration: Constant.animationDuration,
-            delay: 0,
-            options: [.curveEaseInOut, .beginFromCurrentState, .allowUserInteraction]
-        ) {
-            self.view.layoutIfNeeded()
-        }
-    }
-
-    override public func updateViewConstraints() {
-        textFieldCenterYConstraint?.constant = isKeyboardVisible ? -24 : 0
-        super.updateViewConstraints()
+        updateDataSource()
     }
 
     // MARK: - Setup
 
     private func setup() {
         collectionView.showsVerticalScrollIndicator = false
+        let containerGuide = UILayoutGuide()
+        view.addLayoutGuide(containerGuide)
         view.addSubview(textField)
-        textFieldCenterYConstraint = textField.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         
         NSLayoutConstraint.activate([
+            containerGuide.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            containerGuide.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            containerGuide.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            containerGuide.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),            
             textField.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8),
             textField.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.35),
-            textField.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            textFieldCenterYConstraint
-        ].compactMap { $0 })
-
-        // TextField 콜백 연결
-        textField.onEditingDidBegin = { [weak self] in
-            self?.isKeyboardVisible = true
-            self?.updateProperties()
-        }
-        
-        textField.onEditingDidEnd = { [weak self] in
-            self?.isKeyboardVisible = false
-            self?.updateProperties()
-        }
+            textField.centerXAnchor.constraint(equalTo: containerGuide.centerXAnchor),
+            textField.centerYAnchor.constraint(equalTo: containerGuide.centerYAnchor)
+        ])
     }
     
     private func setupNavigationBar() {

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -1,17 +1,19 @@
 import Domain
 import Observation
-import UIKit
 import SwiftUI
+import UIKit
 
 public final class FolderViewController: CollectionViewController {
     enum Section {
         case main
     }
+
     typealias DataSource = UICollectionViewDiffableDataSource<Section, LibraryItem>
     typealias SnapShot = NSDiffableDataSourceSnapshot<Section, LibraryItem>
     private let vm: FolderViewModel
     private var dataSource: DataSource!
     private var listConfiguration: UICollectionLayoutListConfiguration = .init(appearance: .plain)
+
     // MARK: - Component
 
     private lazy var backButton: UIButton = {
@@ -33,16 +35,17 @@ public final class FolderViewController: CollectionViewController {
         btn.tintColor = UIColor.gray950
         return btn
     }()
-    
+
     private var cancelButton: GlassButton = .close("취소")
     private var primaryButton: GlassButton = .primary("만들기")
-    
+
     private lazy var textField = TextFieldView(
         field: .init(
             mode: .create,
             title: "새 폴더",
             subTitle: "새로 만들 폴더의 이름을\n입력해주세요.",
-            placeHolder: "폴더 이름을 적어주세요"),
+            placeHolder: "폴더 이름을 적어주세요"
+        ),
         cancelButton: cancelButton,
         primaryButton: primaryButton
     )
@@ -97,19 +100,19 @@ public final class FolderViewController: CollectionViewController {
         let containerGuide = UILayoutGuide()
         view.addLayoutGuide(containerGuide)
         view.addSubview(textField)
-        
+
         NSLayoutConstraint.activate([
             containerGuide.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             containerGuide.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             containerGuide.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            containerGuide.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),            
+            containerGuide.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
             textField.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8),
             textField.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.35),
             textField.centerXAnchor.constraint(equalTo: containerGuide.centerXAnchor),
             textField.centerYAnchor.constraint(equalTo: containerGuide.centerYAnchor)
         ])
     }
-    
+
     private func setupNavigationBar() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
@@ -132,17 +135,17 @@ public final class FolderViewController: CollectionViewController {
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
         navigationItem.rightBarButtonItem?.hidesSharedBackground = true
     }
-    
+
     /// 오른쪽 Swipe 액션을 제어하는 함수
     private func setupSwipeAction() {
         listConfiguration.trailingSwipeActionsConfigurationProvider = { [weak self] indexPath in
             self?.trailingAction(indexPath: indexPath)
         }
-        
+
         // List 레이아웃을 사용하되, 섹션 설정을 통해 간격을 조정합니다.
         let layout = UICollectionViewCompositionalLayout { [weak self] sectionIndex, layoutEnvironment in
             guard let self else { return nil }
-            let config = self.listConfiguration
+            let config = listConfiguration
             // 개별 셀의 높이가 카드에 딱 맞게 설정되도록 여백 제거
             let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: layoutEnvironment)
             section.interGroupSpacing = 8
@@ -151,7 +154,7 @@ public final class FolderViewController: CollectionViewController {
         }
         collectionView.setCollectionViewLayout(layout, animated: false)
     }
-    
+
     private func setupButtons() {
         cancelButton.addAction(
             UIAction { [weak self] _ in
@@ -161,7 +164,7 @@ public final class FolderViewController: CollectionViewController {
             },
             for: .touchUpInside
         )
-        
+
         primaryButton.addAction(
             UIAction { [weak self] _ in
                 guard let self else { return }
@@ -175,7 +178,6 @@ public final class FolderViewController: CollectionViewController {
                     vm.update(name: name)
                 }
                 textField.field.text = ""
-                vm.closeTextField()
             },
             for: .touchUpInside
         )
@@ -205,25 +207,32 @@ public final class FolderViewController: CollectionViewController {
 
 extension FolderViewController {
     private func setupDataSource() {
-        let cellRegistraint = UICollectionView.CellRegistration<UICollectionViewCell, LibraryItem> { cell, indexPath, item in
-            cell.backgroundConfiguration = .clear()
-            cell.contentConfiguration = UIHostingConfiguration {
-                switch item {
-                case .folder(let data):
-                    FolderCardView(
-                        name: data.name,
-                        totalCount: data.content.count
-                    )
-                case .voiceNote(let data):
-                    VoiceNoteCardView(title: data.title, subTitle: Date.now.voiceNoteDay(createdAt: data.createdAt, updatedAt: data.updatedAt, duration: data.voiceRecord.duration))
+        let cellRegistraint = UICollectionView
+            .CellRegistration<UICollectionViewCell, LibraryItem> { cell, indexPath, item in
+                cell.backgroundConfiguration = .clear()
+                cell.contentConfiguration = UIHostingConfiguration {
+                    switch item {
+                    case .folder(let data):
+                        FolderCardView(
+                            name: data.name,
+                            totalCount: data.content.count
+                        )
+                    case .voiceNote(let data):
+                        VoiceNoteCardView(
+                            title: data.title,
+                            subTitle: Date.now.voiceNoteDay(
+                                createdAt: data.createdAt,
+                                updatedAt: data.updatedAt,
+                                duration: data.voiceRecord.duration
+                            )
+                        )
+                    }
                 }
+                .margins(.all, 0)
             }
-            .margins(.all, 0)
-        }
-            
 
         dataSource = DataSource(
-            collectionView: collectionView, 
+            collectionView: collectionView,
             cellProvider: { col, indexPath, item in
                 return col.dequeueConfiguredReusableCell(using: cellRegistraint, for: indexPath, item: item)
             }
@@ -239,17 +248,11 @@ extension FolderViewController {
     }
 }
 
-// MARK: - TextField Alert Animation
-
-extension FolderViewController {
-    
-}
-
 // MARK: - Swipe Action Delegate
 
 public extension FolderViewController {
     private func trailingAction(indexPath: IndexPath) -> UISwipeActionsConfiguration {
-        guard let item = self.dataSource.itemIdentifier(for: indexPath) else { return .init() }
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return .init() }
 
         let deleteAction = UIContextualAction(style: .destructive, title: "삭제") {
             [weak self] _, _, completion in

--- a/Presentation/Sources/View/Main/Cell/MainCategoryContentConfiguration.swift
+++ b/Presentation/Sources/View/Main/Cell/MainCategoryContentConfiguration.swift
@@ -99,20 +99,29 @@ final class MainCategoryContentView: UIView, UIContentView {
         container.setCustomSpacing(6, after: imageRow)
         container.setCustomSpacing(16, after: titleLabel)
 
+        let bottomConstraint = container.bottomAnchor.constraint(equalTo: bottomAnchor)
+        bottomConstraint.priority = .defaultHigh
+
         NSLayoutConstraint.activate([
             container.topAnchor.constraint(equalTo: topAnchor),
             container.leadingAnchor.constraint(equalTo: leadingAnchor),
             container.trailingAnchor.constraint(equalTo: trailingAnchor),
-            container.bottomAnchor.constraint(equalTo: bottomAnchor)
+            bottomConstraint
         ])
+
+        let widthConstraint = imageView.widthAnchor.constraint(equalToConstant: 20)
+        let heightConstraint = imageView.heightAnchor.constraint(equalToConstant: 20)
+        widthConstraint.priority = .init(999)
+        heightConstraint.priority = .init(999)
 
         NSLayoutConstraint.activate([
-            imageView.widthAnchor.constraint(equalToConstant: 20),
-            imageView.heightAnchor.constraint(equalToConstant: 20)
+            widthConstraint,
+            heightConstraint
         ])
 
-        imageRow.setContentHuggingPriority(.required, for: .horizontal)
-        imageRow.setContentCompressionResistancePriority(.required, for: .horizontal)
+        imageRow.setContentHuggingPriority(.init(999), for: .horizontal)
+        imageRow.setContentCompressionResistancePriority(.init(999), for: .horizontal)
+        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
         titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     }
 
@@ -131,7 +140,7 @@ final class MainCategoryContentView: UIView, UIContentView {
         container.alignment = didScroll ? .center : .fill
         container.spacing = didScroll ? 6 : 0
         container.layoutMargins = didScroll
-            ? UIEdgeInsets(top: 10, left: 14, bottom: 10, right: 14)
+            ? UIEdgeInsets(top: 8, left: 14, bottom: 8, right: 14)
             : UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
         container.layer.cornerRadius = didScroll ? 18 : 20
         imageSpacer.isHidden = didScroll

--- a/Presentation/Sources/View/Main/Cell/MainCategoryHeaderView.swift
+++ b/Presentation/Sources/View/Main/Cell/MainCategoryHeaderView.swift
@@ -1,13 +1,16 @@
 import UIKit
 
 final class MainCategoryHeaderView: UICollectionReusableView {
+    // MARK: - Type
+
+    typealias DataSource = UICollectionViewDiffableDataSource<Int, CategoryToggle>
+    typealias SnapShot = NSDiffableDataSourceSnapshot<Int, CategoryToggle>
     static let elementKind = "MainCategoryHeaderView"
     private static let cellReuseIdentifier = "MainCategoryHeaderCell"
     private enum LayoutConstant {
         static let expandedItemSize = CGSize(width: 92, height: 120)
         static let collapsedItemHeight: CGFloat = 38
-        static let collapsedMinimumWidth: CGFloat = 92
-        static let collapsedHorizontalPadding: CGFloat = 54
+        static let collapsedMinimumWidth: CGFloat = 116
     }
 
     private lazy var collectionView: UICollectionView = {
@@ -24,31 +27,22 @@ final class MainCategoryHeaderView: UICollectionReusableView {
         return view
     }()
 
-    private lazy var dataSource = UICollectionViewDiffableDataSource<Int, CategoryToggle>(
-        collectionView: collectionView
-    ) { [weak self] collectionView, indexPath, item in
-        guard let self else { return nil }
-        let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: Self.cellReuseIdentifier,
-            for: indexPath
-        )
-        cell.backgroundConfiguration = .clear()
-        cell.contentConfiguration = makeContentConfiguration(
-            for: item,
-            isSelected: indexPath.item == selectedIndex,
-            didScroll: didScroll
-        )
-        return cell
-    }
+    private var dataSource: DataSource!
+
+    // MARK: - State
 
     private var categories: [CategoryToggle] = []
     private var selectedIndex: Int = 0
     private var didScroll: Bool = false
     private var onSelect: ((Int) -> Void)?
+    private var heightConstraint: NSLayoutConstraint!
+
+    // MARK: - Initialize
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
+        setupDataSource()
     }
 
     @available(*, unavailable)
@@ -66,42 +60,89 @@ final class MainCategoryHeaderView: UICollectionReusableView {
         self.selectedIndex = selectedIndex
         self.onSelect = onSelect
         updateScrollState(didScroll)
-        var snapshot = NSDiffableDataSourceSnapshot<Int, CategoryToggle>()
-        snapshot.appendSections([0])
-        snapshot.appendItems(categories, toSection: 0)
-        dataSource.apply(snapshot, animatingDifferences: false) { [weak self] in
-            self?.applySelection(animated: false)
-        }
+        updateDataSource()
     }
 
     func updateScrollState(_ val: Bool) {
         guard didScroll != val else { return }
         didScroll = val
+        heightConstraint.constant = didScroll
+            ? LayoutConstant.collapsedItemHeight
+            : LayoutConstant.expandedItemSize.height
         updateVisibleCells()
+        collectionView.collectionViewLayout.invalidateLayout()
     }
 
     private func setupUI() {
         backgroundColor = UIColor.gray50
         addSubview(collectionView)
         collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: Self.cellReuseIdentifier)
+        heightConstraint = collectionView.heightAnchor.constraint(
+            equalToConstant: LayoutConstant.expandedItemSize.height
+        )
 
         NSLayoutConstraint.activate([
             collectionView.topAnchor.constraint(equalTo: topAnchor),
             collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            collectionView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            heightConstraint
         ])
+    }
+
+    private func setupDataSource() {
+        createDataSource()
+        updateDataSource()
     }
 
     private func applySelection(animated: Bool) {
         let indexPath = IndexPath(item: selectedIndex, section: 0)
         guard categories.indices.contains(selectedIndex) else { return }
-
         collectionView.selectItem(at: indexPath, animated: animated, scrollPosition: [])
         updateVisibleCells()
     }
 
-    private func updateVisibleCells() {
+    override func prepareForReuse() {
+        super.prepareForReuse()
+    }
+}
+
+// MARK: - DataSource
+
+fileprivate extension MainCategoryHeaderView {
+    func createDataSource() {
+        dataSource = DataSource(
+            collectionView: collectionView
+        ) { [weak self] collectionView, indexPath, item in
+            guard let self else { return nil }
+            let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: Self.cellReuseIdentifier,
+                for: indexPath
+            )
+            cell.backgroundConfiguration = .clear()
+            cell.contentConfiguration = makeContentConfiguration(
+                for: item,
+                isSelected: indexPath.item == selectedIndex,
+                didScroll: didScroll
+            )
+            return cell
+        }
+    }
+
+    func updateDataSource() {
+        var snapshot = SnapShot()
+        snapshot.appendSections([0])
+        snapshot.appendItems(categories, toSection: 0)
+        dataSource.apply(snapshot, animatingDifferences: false) { [weak self] in
+            self?.applySelection(animated: false)
+        }
+    }
+}
+
+// MARK: - Helper
+
+fileprivate extension MainCategoryHeaderView {
+    func updateVisibleCells() {
         for visibleCell in collectionView.visibleCells {
             guard let itemIndexPath = collectionView.indexPath(for: visibleCell),
                   let item = dataSource.itemIdentifier(for: itemIndexPath)
@@ -115,7 +156,7 @@ final class MainCategoryHeaderView: UICollectionReusableView {
         }
     }
 
-    private func makeContentConfiguration(
+    func makeContentConfiguration(
         for category: CategoryToggle,
         isSelected: Bool,
         didScroll: Bool
@@ -128,11 +169,9 @@ final class MainCategoryHeaderView: UICollectionReusableView {
             didScroll: didScroll
         )
     }
-
-    override func prepareForReuse() {
-        super.prepareForReuse()
-    }
 }
+
+// MARK: - Delegate
 
 extension MainCategoryHeaderView: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -146,20 +185,10 @@ extension MainCategoryHeaderView: UICollectionViewDelegateFlowLayout {
         layout collectionViewLayout: UICollectionViewLayout,
         sizeForItemAt indexPath: IndexPath
     ) -> CGSize {
-        guard categories.indices.contains(indexPath.item) else {
-            return didScroll
-                ? CGSize(width: LayoutConstant.collapsedMinimumWidth, height: LayoutConstant.collapsedItemHeight)
-                : LayoutConstant.expandedItemSize
-        }
-
-        if didScroll {
-            return CGSize(
-                width: pillWidth(for: categories[indexPath.item]),
-                height: LayoutConstant.collapsedItemHeight
-            )
-        }
-
-        return LayoutConstant.expandedItemSize
+        return .init(
+            width: didScroll ? LayoutConstant.collapsedMinimumWidth : LayoutConstant.expandedItemSize.width,
+            height: didScroll ? LayoutConstant.collapsedItemHeight : LayoutConstant.expandedItemSize.height
+        )
     }
 
     func collectionView(
@@ -168,13 +197,5 @@ extension MainCategoryHeaderView: UICollectionViewDelegateFlowLayout {
         insetForSectionAt section: Int
     ) -> UIEdgeInsets {
         UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
-    }
-
-    private func pillWidth(for category: CategoryToggle) -> CGFloat {
-        let titleWidth = ceil((category.title as NSString).size(withAttributes: [
-            .font: Typography.subtitle2.font
-        ]).width)
-
-        return max(LayoutConstant.collapsedMinimumWidth, titleWidth + LayoutConstant.collapsedHorizontalPadding)
     }
 }

--- a/Presentation/Sources/View/Main/Cell/MainCategoryHeaderView.swift
+++ b/Presentation/Sources/View/Main/Cell/MainCategoryHeaderView.swift
@@ -80,6 +80,7 @@ final class MainCategoryHeaderView: UICollectionReusableView {
         heightConstraint = collectionView.heightAnchor.constraint(
             equalToConstant: LayoutConstant.expandedItemSize.height
         )
+        heightConstraint.priority = .defaultHigh
 
         NSLayoutConstraint.activate([
             collectionView.topAnchor.constraint(equalTo: topAnchor),

--- a/Presentation/Sources/View/Main/Cell/MainSectionHeaderView.swift
+++ b/Presentation/Sources/View/Main/Cell/MainSectionHeaderView.swift
@@ -6,6 +6,7 @@ final class MainSectionHeaderView: UICollectionReusableView {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = UIColor.gray950
         return label
     }()
 
@@ -26,7 +27,7 @@ final class MainSectionHeaderView: UICollectionReusableView {
     private func setupUI() {
         addSubview(titleLabel)
         NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: topAnchor),
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 32),
             titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
             titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
             titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor)

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -12,11 +12,6 @@ public final class MainViewController: ViewController {
     typealias DataSource = UICollectionViewDiffableDataSource<MainSection, MainCellItem>
     typealias SnapShot = NSDiffableDataSourceSnapshot<MainSection, MainCellItem>
 
-    private enum LayoutConstant {
-        static let expandedCategoryHeaderHeight: CGFloat = 120
-        static let collapsedCategoryHeaderHeight: CGFloat = 40
-    }
-
     // MARK: - View Model
 
     private let vm: MainViewModel
@@ -237,10 +232,7 @@ extension MainViewController {
         let categoryHeader = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(
-                    vm.didScroll ? LayoutConstant.collapsedCategoryHeaderHeight : LayoutConstant
-                        .expandedCategoryHeaderHeight
-                )
+                heightDimension: .estimated(120)
             ),
             elementKind: MainCategoryHeaderView.elementKind,
             alignment: .top
@@ -435,6 +427,7 @@ extension MainViewController: UICollectionViewDelegate {
         guard let header = collectionView.visibleSupplementaryViews(ofKind: MainCategoryHeaderView.elementKind)
             .first as? MainCategoryHeaderView else { return }
         header.updateScrollState(didScroll)
+        collectionView.collectionViewLayout.invalidateLayout()
     }
 }
 

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -182,7 +182,7 @@ public final class MainViewController: ViewController {
 
         NSLayoutConstraint.activate([
             floatingButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            floatingButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20)
+            floatingButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -42)
         ])
     }
 }
@@ -215,7 +215,7 @@ extension MainViewController {
                     groupWidth: .fractionalWidth(1.0),
                     groupHeight: .estimated(120),
                     interGroupSpacing: 8,
-                    contentInsets: .init(top: 0, leading: 20, bottom: 32, trailing: 20),
+                    contentInsets: .init(top: 0, leading: 20, bottom: 0, trailing: 20),
                     headerHeight: 72
                 )
             case .emptyList:

--- a/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
@@ -28,14 +28,12 @@ public final class FolderViewModel {
 
     public init(
         category: CategoryToggle,
-        createUseCase: CreateFolderUseCase,
-        updateUseCase: UpdateFolderUseCase,
-        moveToTrashUseCase: MoveWasteBasketUseCase
+        folderUseCase: any FolderUseCase,
+        wasteBasketRepository: WasteBasketRepository
     ) {
         self.category = category
-        self.createUseCase = createUseCase
-        self.updateUseCase = updateUseCase
-        self.moveToTrashUseCase = moveToTrashUseCase
+        self.folderUseCase = folderUseCase
+        self.wasteBasketRepository = wasteBasketRepository
     }
 }
 
@@ -90,7 +88,7 @@ extension FolderViewModel {
     func fetchAll() {
         Task {
             do {
-                let folders: [Folder] = try await fetchUseCase.fetchDeletableFolders()
+                let folders: [Folder] = try await folderUseCase.fetchDeletableFolders()
                 let items: [LibraryItem] = folders.map { .folder($0) }
                 category.items = items
             } catch {
@@ -156,10 +154,8 @@ extension FolderViewModel {
 
             return FolderViewModel(
                 category: category,
-                createUseCase: PreviewCreateFolderUseCase(),
-                fetchUseCase: PreviewFetchFolderUseCase(items: previewData.folders),
-                updateUseCase: PreviewUpdateFolderUseCase(),
-                moveToTrashUseCase: PreviewMoveWasteBasketUseCase()
+                folderUseCase: PreviewFolderUseCase(items: previewData.folders),
+                wasteBasketRepository: PreviewWasteBasketRepository()
             )
         }
     }
@@ -182,41 +178,47 @@ extension FolderViewModel {
             }
         }
 
-        struct PreviewCreateFolderUseCase: CreateFolderUseCase {
-            func execute(name: String) async throws(CreateFolderUseCaseError) -> Folder {
-                Folder(name: name, createdAt: .now, content: [], isDeletable: true)
-            }
-        }
-
-        struct PreviewFetchFolderUseCase: FetchFolderUseCase {
+        struct PreviewFolderUseCase: FolderUseCase {
             let items: [Folder]
 
-            func fetchAll() async throws(FetchFolderUseCaseError) -> [Folder] {
+            func create(name: String) async throws(FolderUseCaseError) -> Folder {
+                Folder(name: name, createdAt: .now, content: [], isDeletable: true)
+            }
+
+            func createDefault() async throws(FolderUseCaseError) -> Folder {
+                Folder(name: "기본 폴더", isDeletable: false)
+            }
+
+            func fetchAll() async throws(FolderUseCaseError) -> [Folder] {
                 items
             }
 
-            func fetchDeletableFolders() async throws(FetchFolderUseCaseError) -> [Folder] {
+            func fetchDeletableFolders() async throws(FolderUseCaseError) -> [Folder] {
                 items.filter(\.isDeletable)
             }
 
-            func fetch(by id: UUID) async throws(FetchFolderUseCaseError) -> Folder {
-                guard let item = items.first(where: { $0.id == id }) else {
-                    throw .notFound
-                }
+            func fetch(by id: UUID) async throws(FolderUseCaseError) -> Folder {
+                guard let item = items.first(where: { $0.id == id }) else { throw .notFound }
                 return item
             }
-        }
 
-        struct PreviewUpdateFolderUseCase: UpdateFolderUseCase {
-            func execute(_ folder: Folder) async throws(UpdateFolderUseCaseError) -> Folder {
+            func update(_ folder: Folder) async throws(FolderUseCaseError) -> Folder {
                 folder
             }
         }
 
-        struct PreviewMoveWasteBasketUseCase: MoveWasteBasketUseCase {
-            func execute(method: MoveWasteBasketMethod) async throws(MoveWasteBasketUseCaseError) {
-                // Preview 환경이므로 실제 삭제 로직은 수행하지 않습니다.
+        struct PreviewWasteBasketRepository: WasteBasketRepository {
+            func allClear() async throws(DeleteWasteBasketRepositoryError) {}
+            func delete(item: WasteBasketItem) async throws(DeleteWasteBasketRepositoryError) {}
+            func deleteAll(items: [WasteBasketItem]) async throws(DeleteWasteBasketRepositoryError) {}
+            func moveToWasteBasket(item: WasteBasketItem) async throws(MoveWasteBasketRepositoryError) {}
+            func moveAllToWasteBasket(items: [WasteBasketItem]) async throws(MoveWasteBasketRepositoryError) {}
+            func fetchAll() async throws(FetchWasteBasketRepositoryError) -> [WasteBasketItem] {
+                []
             }
+
+            func restore(item: WasteBasketItem) async throws(RestoreWasteBasketRepositoryError) {}
+            func restoreAll(items: [WasteBasketItem]) async throws(RestoreWasteBasketRepositoryError) {}
         }
     }
 #endif

--- a/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
@@ -14,9 +14,9 @@ public final class FolderViewModel {
     // MARK: - State
 
     var category: CategoryToggle
-    private(set) var showAlert: Bool = false
+    private(set) var showTextField: Bool = false
     private(set) var editFolder: Folder?
-
+    private(set) var mode: TextFieldView.Mode = .create
     public weak var coordinator: FolderCoordinatorDelegate?
 
     // MARK: - Dependencies
@@ -28,20 +28,34 @@ public final class FolderViewModel {
 
     public init(
         category: CategoryToggle,
-        folderUseCase: any FolderUseCase,
-        wasteBasketRepository: WasteBasketRepository
+        createUseCase: CreateFolderUseCase,
+        updateUseCase: UpdateFolderUseCase,
+        moveToTrashUseCase: MoveWasteBasketUseCase
     ) {
         self.category = category
-        self.folderUseCase = folderUseCase
-        self.wasteBasketRepository = wasteBasketRepository
+        self.createUseCase = createUseCase
+        self.updateUseCase = updateUseCase
+        self.moveToTrashUseCase = moveToTrashUseCase
     }
 }
 
 // MARK: - Setter / Getter
 
 extension FolderViewModel {
-    private func setEditFolder(_ folder: Folder?) {
+    private func setMode(_ mode: TextFieldView.Mode) {
+        self.mode = mode
+    }
+    
+    func openTextField(for folder: Folder? = nil) {
         editFolder = folder
+        setMode(folder == nil ? .create : .edit)
+        self.showTextField = true
+    }
+    
+    func closeTextField() {
+        editFolder = nil
+        setMode(.create)
+        self.showTextField = false
     }
 }
 
@@ -55,16 +69,6 @@ extension FolderViewModel {
     func pushDetail(_ folder: Folder) {
         coordinator?.pushMyFolderDetailView(folder)
     }
-
-    func openTextFieldView(for folder: Folder? = nil) {
-        setEditFolder(folder)
-        showAlert = true
-    }
-
-    func closeTextFieldView() {
-        editFolder = nil
-        showAlert = false
-    }
 }
 
 // MARK: - C R U D
@@ -72,7 +76,6 @@ extension FolderViewModel {
 extension FolderViewModel {
     /// Domain.Folder를 생성하는 함수
     func create(name: String) {
-        closeTextFieldView()
         Task {
             do {
                 let folder = try await folderUseCase.create(name: name)
@@ -83,6 +86,18 @@ extension FolderViewModel {
         }
     }
 
+    func fetchAll() {
+        Task {
+            do {
+                let folders: [Folder] = try await fetchUseCase.fetchDeletableFolders()
+                let items: [LibraryItem] = folders.map { .folder($0) }
+                category.items = items
+            } catch {
+                AppLogger.error(error)
+            }
+        }
+    }
+    
     func update(name: String) {
         guard let folder = editFolder else { return }
 
@@ -94,8 +109,6 @@ extension FolderViewModel {
             isDeletable: folder.isDeletable,
             deletedAt: folder.deletedAt
         )
-
-        closeTextFieldView()
 
         Task {
             do {
@@ -128,3 +141,80 @@ extension FolderViewModel {
         }
     }
 }
+
+#if DEBUG
+    extension FolderViewModel {
+        static func preview() -> FolderViewModel {
+            let previewData = PreviewData.make()
+            let category = CategoryToggle(
+                imageName: "folder",
+                title: "개인 폴더",
+                items: previewData.folders.map(LibraryItem.folder)
+            )
+
+            return FolderViewModel(
+                category: category,
+                createUseCase: PreviewCreateFolderUseCase(),
+                fetchUseCase: PreviewFetchFolderUseCase(items: previewData.folders),
+                updateUseCase: PreviewUpdateFolderUseCase(),
+                moveToTrashUseCase: PreviewMoveWasteBasketUseCase()
+            )
+        }
+    }
+
+    private extension FolderViewModel {
+        struct PreviewData {
+            let folders: [Folder]
+
+            static func make(now: Date = .now) -> Self {
+                let folders: [Folder] = (0 ..< 10).map { index in
+                    let createdOffset = TimeInterval((index + 1) * 86400) * -1
+                    return Folder(
+                        name: "개인 폴더 \(index + 1)",
+                        createdAt: now.addingTimeInterval(createdOffset),
+                        content: [],
+                        isDeletable: true
+                    )
+                }
+                return PreviewData(folders: folders)
+            }
+        }
+
+        struct PreviewCreateFolderUseCase: CreateFolderUseCase {
+            func execute(name: String) async throws(CreateFolderUseCaseError) -> Folder {
+                Folder(name: name, createdAt: .now, content: [], isDeletable: true)
+            }
+        }
+
+        struct PreviewFetchFolderUseCase: FetchFolderUseCase {
+            let items: [Folder]
+
+            func fetchAll() async throws(FetchFolderUseCaseError) -> [Folder] {
+                items
+            }
+
+            func fetchDeletableFolders() async throws(FetchFolderUseCaseError) -> [Folder] {
+                items.filter(\.isDeletable)
+            }
+
+            func fetch(by id: UUID) async throws(FetchFolderUseCaseError) -> Folder {
+                guard let item = items.first(where: { $0.id == id }) else {
+                    throw .notFound
+                }
+                return item
+            }
+        }
+
+        struct PreviewUpdateFolderUseCase: UpdateFolderUseCase {
+            func execute(_ folder: Folder) async throws(UpdateFolderUseCaseError) -> Folder {
+                folder
+            }
+        }
+
+        struct PreviewMoveWasteBasketUseCase: MoveWasteBasketUseCase {
+            func execute(method: MoveWasteBasketMethod) async throws(MoveWasteBasketUseCaseError) {
+                // Preview 환경이므로 실제 삭제 로직은 수행하지 않습니다.
+            }
+        }
+    }
+#endif

--- a/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
@@ -45,17 +45,17 @@ extension FolderViewModel {
     private func setMode(_ mode: TextFieldView.Mode) {
         self.mode = mode
     }
-    
+
     func openTextField(for folder: Folder? = nil) {
         editFolder = folder
         setMode(folder == nil ? .create : .edit)
-        self.showTextField = true
+        showTextField = true
     }
-    
+
     func closeTextField() {
         editFolder = nil
         setMode(.create)
-        self.showTextField = false
+        showTextField = false
     }
 }
 
@@ -80,6 +80,7 @@ extension FolderViewModel {
             do {
                 let folder = try await folderUseCase.create(name: name)
                 category.items.insert(.folder(folder), at: 0)
+                closeTextField()
             } catch {
                 AppLogger.error(error)
             }
@@ -97,7 +98,7 @@ extension FolderViewModel {
             }
         }
     }
-    
+
     func update(name: String) {
         guard let folder = editFolder else { return }
 
@@ -121,6 +122,7 @@ extension FolderViewModel {
                 }) {
                     category.items[index] = .folder(updated)
                 }
+                closeTextField()
             } catch {
                 AppLogger.error(error)
             }

--- a/Presentation/Tests/Folder/FolderViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderViewModelTests.swift
@@ -60,7 +60,7 @@ final class FolderViewModelTests: XCTestCase {
         let sut = makeSUT()
 
         XCTAssertEqual(sut.viewModel.category.title, "개인 폴더")
-        XCTAssertFalse(sut.viewModel.showAlert)
+        XCTAssertFalse(sut.viewModel.showTextField)
         XCTAssertNil(sut.viewModel.editFolder)
     }
 
@@ -78,19 +78,19 @@ final class FolderViewModelTests: XCTestCase {
         let sut = makeSUT()
         let folder = Folder(name: "수정 폴더")
 
-        sut.viewModel.openTextFieldView(for: folder)
+        sut.viewModel.openTextField(for: folder)
 
-        XCTAssertTrue(sut.viewModel.showAlert)
+        XCTAssertTrue(sut.viewModel.showTextField)
         XCTAssertEqual(sut.viewModel.editFolder?.name, "수정 폴더")
     }
 
     func test_closeTextFieldView_호출시_상태초기화() {
         let sut = makeSUT()
-        sut.viewModel.openTextFieldView()
+        sut.viewModel.openTextField()
 
-        sut.viewModel.closeTextFieldView()
+        sut.viewModel.closeTextField()
 
-        XCTAssertFalse(sut.viewModel.showAlert)
+        XCTAssertFalse(sut.viewModel.showTextField)
         XCTAssertNil(sut.viewModel.editFolder)
     }
 
@@ -111,7 +111,7 @@ final class FolderViewModelTests: XCTestCase {
 
         await sut.mockFolderRepo.verify()
         XCTAssertEqual(sut.viewModel.category.items.count, 1)
-        XCTAssertFalse(sut.viewModel.showAlert)
+        XCTAssertFalse(sut.viewModel.showTextField)
     }
 
     func test_move_성공시_리스트에서제거() async {
@@ -148,7 +148,7 @@ final class FolderViewModelTests: XCTestCase {
         await sut.mockFolderRepo.expectUpdate(folderID: initialFolder.id, callCount: 1)
 
         // 수정 모드 진입
-        sut.viewModel.openTextFieldView(for: initialFolder)
+        sut.viewModel.openTextField(for: initialFolder)
 
         sut.viewModel.update(name: newName)
 
@@ -165,6 +165,6 @@ final class FolderViewModelTests: XCTestCase {
         }
 
         XCTAssertNil(sut.viewModel.editFolder)
-        XCTAssertFalse(sut.viewModel.showAlert)
+        XCTAssertFalse(sut.viewModel.showTextField)
     }
 }


### PR DESCRIPTION
---

## ✨ 작업 요약
> 메인 화면 카테고리 스크롤 UX 최적화 및 개인 폴더 관리 로직/UI 전면 리팩토링

- 메인 카테고리 헤더의 스크롤 전환 애니메이션 안정화 및 개인 폴더 도메인 로직(UseCase) 통합 리팩토링

## 📋 구체적인 내용
- 추가/변경된 동작:
  - **카테고리 스크롤 UX**: `MainCategoryHeaderView` 접힘/펴짐 시 발생하는 오토레이아웃 제약 조건 충돌 해결 (우선순위 조정 및 스페이스 최적화)
  - **개인 폴더 리팩토링**: `FolderViewModel`의 의존성을 통합된 `FolderUseCase` 및 `WasteBasketRepository` 체제로 전환
  - **TextFieldView 개선**: 컴포넌트 내 텍스트 정렬 이슈 수정 및 키보드 대응 레이아웃 적용
  - **상태 관리 최적화**: 폴더 생성/수정 성공 시 입력 UI가 자동으로 닫히도록 로직 개선 및 테스트 코드 동기화
- 영향 받는 화면/모듈:
  - 메인 화면 (`MainViewController`, `MainCategoryHeaderView`)
  - 폴더 관리 화면 (`FolderViewController`, `FolderViewModel`)
  - 공통 UI 컴포넌트 (`TextFieldView`)

---

## 🔗 연관 이슈

- closed #198

---

## 🧩 설계·구현 노트

- **선택한 방식: 통합 UseCase 및 상태 기반 UI 제어**
  - 개별로 분산되어 있던 폴더 관련 UseCase들을 `FolderUseCase` 하나로 통합하여 ViewModel의 의존성을 단순화했습니다.
  - UI 닫힘 처리를 ViewController가 아닌 ViewModel의 비동기 작업 성공 시점으로 옮겨 데이터 반영과 UI 전환의 정합성을 보장했습니다.
- **고려했다가 제외한 방식**
  - ViewController에서 직접 `closeTextField`를 호출하는 방식: 네트워크 지연이나 에러 발생 시 데이터가 반영되지 않았음에도 UI가 먼저 닫히는 UX 저해 요소가 있어 제외했습니다.

---

## ✅ 확인 사항

- [x] 정상 플로우 동작 확인 (폴더 생성, 수정, 삭제)
- [x] 엣지 케이스 / 빈 값·에러 처리 확인
- [x] (UI 변경 시) 스크린샷 또는 GIF 첨부 (카테고리 스크롤 전환 테스트 완료)
- [x] (로직 추가 시) 테스트 추가 여부 (`FolderViewModelTests` 성공 확인)

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성: 통합된 `FolderUseCase` 적용 방식
- [x] 로직·엣지 케이스: 생성/수정 시 비동기 처리 성공 후의 상태 전이
- [x] 예외/에러 핸들링: UseCase 에러 발생 시 UI 상태 유지 및 로깅
- [x] UI/UX (해당 시): 메인 카테고리 헤더 스크롤 시의 레이아웃 경고 발생 여부

**특히 봐줬으면 하는 부분**

- `MainCategoryContentView`에서 헤더가 접힐 때(6pt)와 펴질 때(12pt)의 간격 조정을 통해 충돌을 해결했는데, 의도한 디자인 가이드와 부합하는지 확인 부탁드립니다.

---

## 📚 참고