### PR TITLE
녹음 화면, 메인 화면 Alert 추가 및 백그라운드 재생 추가

### DIFF
--- a/App/Project.swift
+++ b/App/Project.swift
@@ -46,7 +46,8 @@ private let appTarget = Target.target(
             "UIUserInterfaceStyle": Plist.Value(stringLiteral: style),
             "NSMicrophoneUsageDescription": "음성 메모를 녹음하기 위해 마이크 권한이 필요합니다.",
             "NSSpeechRecognitionUsageDescription": "음성을 텍스트로 변환하기 위해 음성 인식 권한이 필요합니다.",
-            "ITSAppUsesNonExemptEncryption": false
+            "ITSAppUsesNonExemptEncryption": false,
+            "UIBackgroundModes": ["audio"]
         ]
     ),
     sources: ["Sources/**/*.swift"],

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -78,6 +78,7 @@ public final class AppDIContainer {
 
     public func makeMainViewModel() -> MainViewModel {
         return MainViewModel(
+            microphoneRepository: voiceRecordRepository,
             voiceNoteUseCase: voiceNoteUseCase,
             folderUseCase: folderUseCase,
             wasteBasketRepository: wasteBasketRepository

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -71,29 +71,6 @@ extension MainCoordinator: MainCoordinatorDelegate {
     // TODO: Present
 
     func presentRecodingView() {
-        Task {
-            let status = dependencyContainer.makeVoiceRecordRepository().checkMicrophonePermission()
-
-            switch status {
-            case .authorized:
-                showRecordingView()
-            case .denied:
-                showPermissionDeniedAlert()
-            case .notDetermined:
-                do {
-                    let grantedStatus = try await dependencyContainer.makeVoiceRecordRepository()
-                        .requestMicrophonePermission()
-                    if grantedStatus == .authorized {
-                        showRecordingView()
-                    }
-                } catch {
-                    AppLogger.error(error)
-                }
-            }
-        }
-    }
-
-    private func showRecordingView() {
         let navController = UINavigationController()
         let viewModel = dependencyContainer.makeRecordingViewModel()
         viewModel.coordinator = self
@@ -101,23 +78,6 @@ extension MainCoordinator: MainCoordinatorDelegate {
         navController.modalPresentationStyle = .fullScreen
         navController.setViewControllers([recordingVC], animated: false)
         presenter.present(navController, animated: true)
-    }
-
-    private func showPermissionDeniedAlert() {
-        let alert = UIAlertController(
-            title: "마이크 권한 필요",
-            message: "녹음을 위해 마이크 권한이 필요합니다. 설정에서 권한을 허용해주세요.",
-            preferredStyle: .alert
-        )
-
-        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
-        alert.addAction(UIAlertAction(title: "설정으로 이동", style: .default) { _ in
-            if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
-                UIApplication.shared.open(settingsURL)
-            }
-        })
-
-        presenter.present(alert, animated: true)
     }
 }
 

--- a/Presentation/Sources/Component/Common/AlertView.swift
+++ b/Presentation/Sources/Component/Common/AlertView.swift
@@ -8,6 +8,7 @@ final class AlertView: UIView {
     private let title: String
 
     private let subTitle: String
+    private var widthConstraint: NSLayoutConstraint?
 
     private let topContent: UIStackView = {
         let view = UIStackView()
@@ -32,6 +33,7 @@ final class AlertView: UIView {
         t.setTypography(text: title, style: .title2)
         t.textAlignment = .center
         t.textColor = UIColor.gray950
+        t.numberOfLines = 0
         return t
     }()
 
@@ -41,6 +43,7 @@ final class AlertView: UIView {
         d.setTypography(text: subTitle, style: .body1)
         d.textAlignment = .center
         d.textColor = UIColor.gray950
+        d.numberOfLines = 0
         return d
     }()
 
@@ -72,11 +75,15 @@ final class AlertView: UIView {
 extension AlertView {
     override func didMoveToSuperview() {
         super.didMoveToSuperview()
-        guard let superview else { return }
-        NSLayoutConstraint.activate([
-            widthAnchor.constraint(equalTo: superview.widthAnchor, multiplier: Constant.alertMultiplierWidth),
-            heightAnchor.constraint(equalTo: superview.heightAnchor, multiplier: Constant.alertMultiplierHeight)
-        ])
+        guard let superview else {
+            widthConstraint?.isActive = false
+            widthConstraint = nil
+            return
+        }
+        guard widthConstraint == nil else { return }
+        let width = widthAnchor.constraint(equalTo: superview.widthAnchor, multiplier: Constant.alertMultiplierWidth)
+        width.isActive = true
+        widthConstraint = width
     }
 
     override func layoutSubviews() {
@@ -121,7 +128,6 @@ extension AlertView {
     private func childSetup() {
         topContent.addArrangedSubview(header)
         topContent.addArrangedSubview(body)
-        topContent.addArrangedSubview(UIView())
         bottomContent.addArrangedSubview(closeButton)
         bottomContent.addArrangedSubview(primaryButton)
         addSubview(topContent)

--- a/Presentation/Sources/Component/Common/GlassButton.swift
+++ b/Presentation/Sources/Component/Common/GlassButton.swift
@@ -83,6 +83,7 @@ extension GlassButton {
     /// `.color(.point600)`)
     ///   - foregroundColor: 버튼 텍스트 및 이미지의 기본 색상입니다. (기본값: `.white`)
     func configure(
+        type: UIButton.Configuration = .prominentGlass(),
         _ title: String?,
         typography: Typography,
         border: Border? = nil,
@@ -90,7 +91,7 @@ extension GlassButton {
         backgroundColor: GradientSet = .color(.point600),
         foregroundColor: UIColor = .white
     ) {
-        var config: UIButton.Configuration = .prominentGlass()
+        var config: UIButton.Configuration = type
 
         config.title = title
         config.baseForegroundColor = foregroundColor

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
@@ -35,7 +35,7 @@ struct VoiceNoteCardView: View {
         .frame(maxWidth: .infinity, maxHeight: 120, alignment: .leading)
         .padding(.horizontal)
         .background(.point200.opacity(0.2))
-        .glassEffect(.clear.interactive(), in: .rect(cornerRadius: 20))
+        .glassEffect(.clear, in: .rect(cornerRadius: 20))
     }
 }
 

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -484,7 +484,7 @@ extension MainViewController: UICollectionViewDelegate {
         let didScroll = offsetY > 0
 
         guard vm.didScroll != didScroll else { return }
-        vm.getDidScroll(didScroll)
+        vm.setDidScroll(didScroll)
         guard let header = collectionView.visibleSupplementaryViews(ofKind: MainCategoryHeaderView.elementKind)
             .first as? MainCategoryHeaderView else { return }
         header.updateScrollState(didScroll)

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -46,6 +46,23 @@ public final class MainViewController: ViewController {
         return c
     }()
 
+    private let cancelAlertButton: GlassButton = .close("나중에")
+    private let primaryAlertButton: GlassButton = .primary("설정으로 이동")
+    private let permissionAlertOverlayView: UIView = {
+        let overlay = UIView()
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.25)
+        overlay.isHidden = true
+        return overlay
+    }()
+
+    private lazy var permissionAlertView: AlertView = .init(
+        title: "마이크 권한이 필요해요",
+        subTitle: "설정에서 마이크 권한을 \n허용해주세요.",
+        closeButton: cancelAlertButton,
+        primaryButton: primaryAlertButton
+    )
+
     private let floatingButton: GlassButton = .floating(
         image: .init(imageName: "microphone", type: .system)
     )
@@ -58,7 +75,8 @@ public final class MainViewController: ViewController {
         super.viewDidLoad()
         setup()
         setupCollectionView()
-        floatingButtonConstraint()
+        setupfloatingButton()
+        setupPermissionAlert()
     }
 
     override public func viewWillAppear(_ animated: Bool) {
@@ -71,6 +89,12 @@ public final class MainViewController: ViewController {
 
     override public func updateProperties() {
         super.updateProperties()
+        let shouldShowAlert = vm.showAlert
+        permissionAlertOverlayView.isHidden = !shouldShowAlert
+        updateInteractionForAlert(isPresented: shouldShowAlert)
+        if shouldShowAlert {
+            view.bringSubviewToFront(permissionAlertOverlayView)
+        }
         updateDataSource()
     }
 
@@ -93,6 +117,29 @@ public final class MainViewController: ViewController {
         )
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
         navigationItem.rightBarButtonItem?.hidesSharedBackground = true
+    }
+
+    private func setupPermissionAlert() {
+        cancelAlertButton.addAction(UIAction { [weak self] _ in
+            self?.vm.closeAlertView()
+        }, for: .touchUpInside)
+
+        primaryAlertButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            vm.closeAlertView()
+            openAppSettings()
+        }, for: .touchUpInside)
+
+        view.addSubview(permissionAlertOverlayView)
+        permissionAlertOverlayView.addSubview(permissionAlertView)
+        NSLayoutConstraint.activate([
+            permissionAlertOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
+            permissionAlertOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            permissionAlertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            permissionAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            permissionAlertView.centerXAnchor.constraint(equalTo: permissionAlertOverlayView.centerXAnchor),
+            permissionAlertView.centerYAnchor.constraint(equalTo: permissionAlertOverlayView.centerYAnchor)
+        ])
     }
 
     private func setupCollectionView() {
@@ -165,6 +212,20 @@ public final class MainViewController: ViewController {
         )
     }
 
+    private func setupfloatingButton() {
+        floatingButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            Task {
+                await self.vm.handleRecordButtonTap()
+            }
+        }, for: .touchUpInside)
+
+        NSLayoutConstraint.activate([
+            floatingButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            floatingButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -42)
+        ])
+    }
+
     private func collectionViewConstraint() {
         NSLayoutConstraint.activate([
             collectionView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -174,16 +235,18 @@ public final class MainViewController: ViewController {
         ])
     }
 
-    private func floatingButtonConstraint() {
-        floatingButton.addAction(UIAction { [weak self] _ in
-            guard let self else { return }
-            vm.presentRecodingView()
-        }, for: .touchUpInside)
+    private func updateInteractionForAlert(isPresented: Bool) {
+        collectionView.isUserInteractionEnabled = !isPresented
+        floatingButton.isEnabled = !isPresented
+        navigationItem.leftBarButtonItem?.isEnabled = !isPresented
+        navigationItem.rightBarButtonItem?.isEnabled = !isPresented
+        navigationItem.rightBarButtonItems?.forEach { $0.isEnabled = !isPresented }
+    }
 
-        NSLayoutConstraint.activate([
-            floatingButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            floatingButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -42)
-        ])
+    private func openAppSettings() {
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString),
+              UIApplication.shared.canOpenURL(settingsURL) else { return }
+        UIApplication.shared.open(settingsURL)
     }
 }
 
@@ -423,7 +486,7 @@ extension MainViewController: UICollectionViewDelegate {
         let didScroll = offsetY > 0
 
         guard vm.didScroll != didScroll else { return }
-        vm.didScroll = didScroll
+        vm.getDidScroll(didScroll)
         guard let header = collectionView.visibleSupplementaryViews(ofKind: MainCategoryHeaderView.elementKind)
             .first as? MainCategoryHeaderView else { return }
         header.updateScrollState(didScroll)

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -51,7 +51,7 @@ public final class MainViewController: ViewController {
     private let permissionAlertOverlayView: UIView = {
         let overlay = UIView()
         overlay.translatesAutoresizingMaskIntoConstraints = false
-        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.25)
+        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.6)
         overlay.isHidden = true
         return overlay
     }()
@@ -102,9 +102,10 @@ public final class MainViewController: ViewController {
 
     private func setup() {
         let appearance = UINavigationBarAppearance()
-        appearance.configureWithTransparentBackground()
+        appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = UIColor.gray50
         appearance.shadowColor = .clear
+        appearance.backgroundEffect = nil
 
         navigationController?.navigationBar.standardAppearance = appearance
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
@@ -215,9 +216,7 @@ public final class MainViewController: ViewController {
     private func setupfloatingButton() {
         floatingButton.addAction(UIAction { [weak self] _ in
             guard let self else { return }
-            Task {
-                await self.vm.handleRecordButtonTap()
-            }
+            vm.handleRecordButtonTap()
         }, for: .touchUpInside)
 
         NSLayoutConstraint.activate([
@@ -237,7 +236,6 @@ public final class MainViewController: ViewController {
 
     private func updateInteractionForAlert(isPresented: Bool) {
         collectionView.isUserInteractionEnabled = !isPresented
-        floatingButton.isEnabled = !isPresented
         navigationItem.leftBarButtonItem?.isEnabled = !isPresented
         navigationItem.rightBarButtonItem?.isEnabled = !isPresented
         navigationItem.rightBarButtonItems?.forEach { $0.isEnabled = !isPresented }

--- a/Presentation/Sources/View/Recoding/RecordingViewController.swift
+++ b/Presentation/Sources/View/Recoding/RecordingViewController.swift
@@ -77,7 +77,7 @@ public final class RecordingViewController: ViewController {
         }, for: .touchUpInside)
         return button
     }()
-    
+
     private let cancelAlertButton: GlassButton = .close("아니오")
     private let primaryAlertButton: GlassButton = .primary("저장 후 종료")
     private let completeAlertOverlayView: UIView = {
@@ -174,10 +174,10 @@ public final class RecordingViewController: ViewController {
             recordButton.widthAnchor.constraint(equalToConstant: 120),
             recordButton.heightAnchor.constraint(equalToConstant: 60),
             recordButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -40),
-            recordButton.topAnchor.constraint(greaterThanOrEqualTo: durationLabel.bottomAnchor, constant: 48),
+            recordButton.topAnchor.constraint(greaterThanOrEqualTo: durationLabel.bottomAnchor, constant: 48)
         ])
     }
-    
+
     private func setupCompleteAlert() {
         cancelAlertButton.addAction(UIAction { [weak self] _ in
             self?.viewModel.send(.closeAlertButtonTapped)
@@ -196,7 +196,7 @@ public final class RecordingViewController: ViewController {
             completeAlertView.centerYAnchor.constraint(equalTo: completeAlertOverlayView.centerYAnchor)
         ])
     }
-    
+
     private func updateInteractionForAlert(isPresented: Bool) {
         navigationItem.leftBarButtonItem?.isEnabled = !isPresented
         navigationItem.rightBarButtonItem?.isEnabled = !isPresented

--- a/Presentation/Sources/View/Recoding/RecordingViewController.swift
+++ b/Presentation/Sources/View/Recoding/RecordingViewController.swift
@@ -6,6 +6,32 @@ public final class RecordingViewController: ViewController {
 
     // MARK: - UI Components
 
+    private lazy var cancelButton: GlassButton = {
+        let button = GlassButton()
+        button.configure(
+            type: .plain(),
+            viewModel.state.cancelTitle,
+            typography: .header2,
+            backgroundColor: .color(.clear),
+            foregroundColor: UIColor.gray950
+        )
+
+        return button
+    }()
+
+    private lazy var completeButton: GlassButton = {
+        let button = GlassButton()
+        button.configure(
+            type: .plain(),
+            viewModel.state.completeTitle,
+            typography: .header2,
+            backgroundColor: .color(.clear),
+            foregroundColor: UIColor.point800
+        )
+
+        return button
+    }()
+
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
@@ -33,20 +59,22 @@ public final class RecordingViewController: ViewController {
         return label
     }()
 
-    private lazy var recordButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.layer.cornerRadius = 30
-        button.clipsToBounds = true
-        button.backgroundColor = .gray50
-        button.tintColor = .gray950
+    private lazy var recordButton: GlassButton = {
+        let button = GlassButton()
         button.setPreferredSymbolConfiguration(
-            UIImage.SymbolConfiguration(pointSize: 22, weight: .semibold),
+            UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold),
             forImageIn: .normal
         )
+        button.configure(
+            type: .clearGlass(),
+            nil,
+            typography: .body1,
+            image: .init(imageName: recordButtonSymbolName, type: .system)
+        )
+        button.setCapsuleCornerRadius()
         button.addAction(UIAction { [weak self] _ in
             self?.viewModel.send(.recordButtonTapped)
         }, for: .touchUpInside)
-
         return button
     }()
 
@@ -81,19 +109,20 @@ public final class RecordingViewController: ViewController {
     // MARK: - Private Methods
 
     private func setupNavigation() {
-        navigationItem.leftBarButtonItem = UIBarButtonItem(
-            systemItem: .cancel,
-            primaryAction: UIAction { [weak self] _ in
-                self?.viewModel.send(.cancelButtonTapped)
-            }
-        )
+        cancelButton.addAction(UIAction { [weak self] _ in
+            self?.viewModel.send(.cancelButtonTapped)
+        }, for: .touchUpInside)
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            systemItem: .done,
-            primaryAction: UIAction { [weak self] _ in
-                self?.viewModel.send(.finishButtonTapped)
-            }
-        )
+        completeButton.addAction(UIAction { [weak self] _ in
+            self?.viewModel.send(.finishButtonTapped)
+        }, for: .touchUpInside)
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: cancelButton)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: completeButton)
+
+        for item in [navigationItem.leftBarButtonItem, navigationItem.rightBarButtonItem] {
+            item?.hidesSharedBackground = true
+        }
     }
 
     private func setupUI() {
@@ -135,3 +164,10 @@ public final class RecordingViewController: ViewController {
         }
     }
 }
+
+#if DEBUG
+    #Preview {
+        UINavigationController(rootViewController: RecordingViewController(viewModel: .preview())
+        )
+    }
+#endif

--- a/Presentation/Sources/View/Recoding/RecordingViewController.swift
+++ b/Presentation/Sources/View/Recoding/RecordingViewController.swift
@@ -11,7 +11,7 @@ public final class RecordingViewController: ViewController {
         button.configure(
             type: .plain(),
             viewModel.state.cancelTitle,
-            typography: .header2,
+            typography: .title2,
             backgroundColor: .color(.clear),
             foregroundColor: UIColor.gray950
         )
@@ -24,7 +24,7 @@ public final class RecordingViewController: ViewController {
         button.configure(
             type: .plain(),
             viewModel.state.completeTitle,
-            typography: .header2,
+            typography: .title2,
             backgroundColor: .color(.clear),
             foregroundColor: UIColor.point800
         )

--- a/Presentation/Sources/View/Recoding/RecordingViewController.swift
+++ b/Presentation/Sources/View/Recoding/RecordingViewController.swift
@@ -77,6 +77,23 @@ public final class RecordingViewController: ViewController {
         }, for: .touchUpInside)
         return button
     }()
+    
+    private let cancelAlertButton: GlassButton = .close("아니오")
+    private let primaryAlertButton: GlassButton = .primary("저장 후 종료")
+    private let completeAlertOverlayView: UIView = {
+        let overlay = UIView()
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        overlay.isHidden = true
+        return overlay
+    }()
+
+    private lazy var completeAlertView: AlertView = .init(
+        title: "녹음을 종료하고 저장할까요?",
+        subTitle: "지금까지 녹음한 내용이\n기록됩니다",
+        closeButton: cancelAlertButton,
+        primaryButton: primaryAlertButton
+    )
 
     // MARK: - Initialization
 
@@ -95,6 +112,7 @@ public final class RecordingViewController: ViewController {
         super.viewDidLoad()
         setupNavigation()
         setupUI()
+        setupCompleteAlert()
     }
 
     override public func updateProperties() {
@@ -104,6 +122,13 @@ public final class RecordingViewController: ViewController {
         timestampLabel.setTypography(text: viewModel.state.displayStartDate, style: .subtitle2)
         durationLabel.setTypography(text: viewModel.state.displayDuration, style: .header1)
         recordButton.setImage(UIImage(systemName: recordButtonSymbolName), for: .normal)
+        let shouldShowAlert = viewModel.state.showAlert
+        completeAlertOverlayView.isHidden = !shouldShowAlert
+        completeAlertView.isHidden = !shouldShowAlert
+        updateInteractionForAlert(isPresented: shouldShowAlert)
+        if shouldShowAlert {
+            view.bringSubviewToFront(completeAlertOverlayView)
+        }
     }
 
     // MARK: - Private Methods
@@ -114,7 +139,7 @@ public final class RecordingViewController: ViewController {
         }, for: .touchUpInside)
 
         completeButton.addAction(UIAction { [weak self] _ in
-            self?.viewModel.send(.finishButtonTapped)
+            self?.viewModel.send(.openAlertButtonTapped)
         }, for: .touchUpInside)
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: cancelButton)
@@ -126,7 +151,7 @@ public final class RecordingViewController: ViewController {
     }
 
     private func setupUI() {
-        for item in [titleLabel, durationLabel, recordButton, timestampLabel] {
+        for item in [titleLabel, durationLabel, recordButton, timestampLabel, completeAlertOverlayView] {
             item.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview(item)
         }
@@ -149,8 +174,33 @@ public final class RecordingViewController: ViewController {
             recordButton.widthAnchor.constraint(equalToConstant: 120),
             recordButton.heightAnchor.constraint(equalToConstant: 60),
             recordButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -40),
-            recordButton.topAnchor.constraint(greaterThanOrEqualTo: durationLabel.bottomAnchor, constant: 48)
+            recordButton.topAnchor.constraint(greaterThanOrEqualTo: durationLabel.bottomAnchor, constant: 48),
         ])
+    }
+    
+    private func setupCompleteAlert() {
+        cancelAlertButton.addAction(UIAction { [weak self] _ in
+            self?.viewModel.send(.closeAlertButtonTapped)
+        }, for: .touchUpInside)
+
+        primaryAlertButton.addAction(UIAction { [weak self] _ in
+            self?.viewModel.send(.finishButtonTapped)
+        }, for: .touchUpInside)
+        completeAlertOverlayView.addSubview(completeAlertView)
+        NSLayoutConstraint.activate([
+            completeAlertOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
+            completeAlertOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            completeAlertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            completeAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            completeAlertView.centerXAnchor.constraint(equalTo: completeAlertOverlayView.centerXAnchor),
+            completeAlertView.centerYAnchor.constraint(equalTo: completeAlertOverlayView.centerYAnchor)
+        ])
+    }
+    
+    private func updateInteractionForAlert(isPresented: Bool) {
+        navigationItem.leftBarButtonItem?.isEnabled = !isPresented
+        navigationItem.rightBarButtonItem?.isEnabled = !isPresented
+        navigationItem.rightBarButtonItems?.forEach { $0.isEnabled = !isPresented }
     }
 
     private var recordButtonSymbolName: String {

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -91,7 +91,7 @@ extension MainViewModel {
         }
     }
 
-    func getDidScroll(_ didScroll: Bool) {
+    func setDidScroll(_ didScroll: Bool) {
         self.didScroll = didScroll
     }
 

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -34,7 +34,7 @@ public final class MainViewModel {
     @ObservationIgnored
     private(set) var selectedCategoryIndex: Int = 0
     @ObservationIgnored
-    var didScroll: Bool = false
+    private(set) var didScroll: Bool = false
 
     var shouldGroupSelectedCategory: Bool {
         selectedCategoryIndex == 1
@@ -44,10 +44,13 @@ public final class MainViewModel {
         categoryData[selectedCategoryIndex].items.isEmpty
     }
 
-    var errorMessage: String?
+    private(set) var showAlert: Bool = false
+
+    private(set) var errorMessage: String?
 
     // MARK: - UseCase
 
+    let microphoneRepository: VoiceRecordRepository
     let voiceNoteUseCase: any VoiceNoteUseCase
     let folderUseCase: any FolderUseCase
     let wasteBasketRepository: any WasteBasketRepository
@@ -56,10 +59,12 @@ public final class MainViewModel {
     public weak var mainCoordinator: MainCoordinatorDelegate?
 
     public init(
+        microphoneRepository: any VoiceRecordRepository,
         voiceNoteUseCase: any VoiceNoteUseCase,
         folderUseCase: any FolderUseCase,
         wasteBasketRepository: any WasteBasketRepository
     ) {
+        self.microphoneRepository = microphoneRepository
         self.voiceNoteUseCase = voiceNoteUseCase
         self.folderUseCase = folderUseCase
         self.wasteBasketRepository = wasteBasketRepository
@@ -84,6 +89,18 @@ extension MainViewModel {
             // 화면 이동 후 index를 되돌린다.
             selectedCategoryIndex = 0
         }
+    }
+
+    func getDidScroll(_ didScroll: Bool) {
+        self.didScroll = didScroll
+    }
+
+    func closeAlertView() {
+        showAlert = false
+    }
+
+    func openAlertView() {
+        showAlert = true
     }
 }
 
@@ -162,11 +179,44 @@ extension MainViewModel {
     }
 }
 
+// MARK: - Mic Permission
+
+extension MainViewModel {
+    func handleRecordButtonTap() async {
+        let status = microphoneRepository.checkMicrophonePermission()
+
+        switch status {
+        case .authorized:
+            closeAlertView()
+            presentRecodingView()
+
+        case .notDetermined:
+            do {
+                let requested = try await microphoneRepository.requestMicrophonePermission()
+                if requested == .authorized {
+                    closeAlertView()
+                    presentRecodingView()
+                } else {
+                    openAlertView()
+                }
+            } catch {
+                AppLogger.error(error)
+                errorMessage = error.localizedDescription
+                openAlertView()
+            }
+
+        case .denied:
+            openAlertView()
+        }
+    }
+}
+
 #if DEBUG
     extension MainViewModel {
         static func preview(selectedCategoryIndex: Int = 0) -> MainViewModel {
             let previewData = PreviewData.make()
             let viewModel = MainViewModel(
+                microphoneRepository: PreviewMicrophoneRepository(),
                 voiceNoteUseCase: PreviewVoiceNoteUseCase(
                     recentItems: previewData.recentVoiceNotes,
                     defaultItems: previewData.defaultVoiceNotes
@@ -299,6 +349,46 @@ extension MainViewModel {
                     transcript: summarized ? Transcript(text: "\(title) 전사본") : nil,
                     summary: summarized ? Summary(text: "\(title) 요약") : nil
                 )
+            }
+        }
+
+        struct PreviewMicrophoneRepository: VoiceRecordRepository {
+            func checkMicrophonePermission() -> PermissionStatus {
+                .authorized
+            }
+
+            func requestMicrophonePermission() async throws(Domain.VoiceRecordRepositoryError) -> Domain
+                .PermissionStatus
+            {
+                .authorized
+            }
+
+            func startRecording() async throws(Domain.VoiceRecordRepositoryError) -> AsyncStream<Domain.Waveform> {
+                AsyncStream { continuation in
+                    continuation.yield(Domain.Waveform(amplitudes: [0.12, 0.31, 0.45, 0.22, 0.38]))
+                    continuation.yield(Domain.Waveform(amplitudes: [0.27, 0.51, 0.18, 0.34, 0.42]))
+                    continuation.finish()
+                }
+            }
+
+            func pauseRecording() async throws(Domain.VoiceRecordRepositoryError) {
+                // Preview mock: no-op
+            }
+
+            func resumeRecording() async throws(Domain.VoiceRecordRepositoryError) {
+                // Preview mock: no-op
+            }
+
+            func finishRecording() async throws(Domain.VoiceRecordRepositoryError) -> Domain.VoiceRecord {
+                Domain.VoiceRecord(
+                    createdAt: .now,
+                    audioFilePath: "VoiceRecords/preview.m4a",
+                    duration: 95
+                )
+            }
+
+            func cancelRecording() async throws(Domain.VoiceRecordRepositoryError) {
+                // Preview mock: no-op
             }
         }
 

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -182,31 +182,12 @@ extension MainViewModel {
 // MARK: - Mic Permission
 
 extension MainViewModel {
-    func handleRecordButtonTap() async {
+    func handleRecordButtonTap() {
         let status = microphoneRepository.checkMicrophonePermission()
-
-        switch status {
-        case .authorized:
-            closeAlertView()
-            presentRecodingView()
-
-        case .notDetermined:
-            do {
-                let requested = try await microphoneRepository.requestMicrophonePermission()
-                if requested == .authorized {
-                    closeAlertView()
-                    presentRecodingView()
-                } else {
-                    openAlertView()
-                }
-            } catch {
-                AppLogger.error(error)
-                errorMessage = error.localizedDescription
-                openAlertView()
-            }
-
-        case .denied:
+        if status != .authorized {
             openAlertView()
+        } else {
+            presentRecodingView()
         }
     }
 }
@@ -354,7 +335,7 @@ extension MainViewModel {
 
         struct PreviewMicrophoneRepository: VoiceRecordRepository {
             func checkMicrophonePermission() -> PermissionStatus {
-                .authorized
+                .denied
             }
 
             func requestMicrophonePermission() async throws(Domain.VoiceRecordRepositoryError) -> Domain

--- a/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
@@ -18,6 +18,8 @@ public final class RecordingViewModel {
         }
 
         let title: String = "새 기록"
+        let cancelTitle: String = "취소"
+        let completeTitle: String = "종료"
         var recordingStartDate: Date = .now
         var recordingDuration: TimeInterval = 0
         var amplitude: Float = 0
@@ -168,3 +170,84 @@ public final class RecordingViewModel {
         timerTask = nil
     }
 }
+
+// MARK: - Preview Data
+
+#if DEBUG
+    extension RecordingViewModel {
+        public static func preview() -> RecordingViewModel {
+            RecordingViewModel(
+                repository: PreviewVoiceRecordRepository(),
+                voiceNoteUseCase: PreviewVoiceNoteUseCase()
+            )
+        }
+
+        private struct PreviewVoiceRecordRepository: VoiceRecordRepository {
+            func checkMicrophonePermission() -> PermissionStatus {
+                .authorized
+            }
+
+            func requestMicrophonePermission() async throws(VoiceRecordRepositoryError)
+                -> PermissionStatus
+            {
+                .authorized
+            }
+
+            func startRecording() async throws(VoiceRecordRepositoryError) -> AsyncStream<Waveform> {
+                AsyncStream { continuation in
+                    continuation.finish()
+                }
+            }
+
+            func pauseRecording() async throws(VoiceRecordRepositoryError) {}
+            func resumeRecording() async throws(VoiceRecordRepositoryError) {}
+            func finishRecording() async throws(VoiceRecordRepositoryError) -> VoiceRecord {
+                VoiceRecord(audioFilePath: "", duration: 0)
+            }
+
+            func cancelRecording() async throws(VoiceRecordRepositoryError) {}
+        }
+
+        private struct PreviewVoiceNoteUseCase: VoiceNoteUseCase {
+            func create(_ voiceRecord: VoiceRecord) async throws(VoiceNoteUseCaseError) -> VoiceNote {
+                VoiceNote(
+                    title: "미리보기 기록",
+                    createdAt: .now,
+                    updatedAt: .now,
+                    folderID: UUID(),
+                    voiceRecord: voiceRecord,
+                    keywords: [],
+                    transcript: nil,
+                    summary: nil
+                )
+            }
+
+            func fetchAllFromDefaultFolder() async throws(VoiceNoteUseCaseError) -> [VoiceNote] {
+                []
+            }
+
+            func fetchAll(folderID: UUID) async throws(VoiceNoteUseCaseError) -> [VoiceNote] {
+                []
+            }
+
+            func fetch(byId id: UUID) async throws(VoiceNoteUseCaseError) -> VoiceNote {
+                throw .recordNotFound(id)
+            }
+
+            func fetchRecent(limit: Int) async throws(VoiceNoteUseCaseError) -> [VoiceNote] {
+                []
+            }
+
+            func update(_ voiceNote: VoiceNote) async throws(VoiceNoteUseCaseError) -> VoiceNote {
+                voiceNote
+            }
+
+            func summarize(
+                audioFilePath: String,
+                language: Language
+            ) async throws(VoiceNoteUseCaseError) -> AudioToSummaryResult {
+                AudioToSummaryResult(transcript: Transcript(text: ""), keywords: [], summary: Summary(text: ""))
+            }
+        }
+    }
+#endif

--- a/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
@@ -25,6 +25,7 @@ public final class RecordingViewModel {
         var amplitude: Float = 0
         var recordingState: RecordingState = .idle
         var errorMessage: String?
+        var showAlert: Bool = false
 
         var displayStartDate: String {
             let formatter = DateFormatter()
@@ -48,6 +49,8 @@ public final class RecordingViewModel {
         case recordButtonTapped
         case cancelButtonTapped
         case finishButtonTapped
+        case closeAlertButtonTapped
+        case openAlertButtonTapped
         case errorOccurred(Error)
     }
 
@@ -103,6 +106,10 @@ public final class RecordingViewModel {
                     send(.errorOccurred(error))
                 }
             }
+        case .closeAlertButtonTapped:
+            state.showAlert = false
+        case .openAlertButtonTapped:
+            state.showAlert = true
         case .errorOccurred(let error):
             state.errorMessage = error.localizedDescription
         }

--- a/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
@@ -100,7 +100,7 @@ public final class RecordingViewModel {
                     waveformTask?.cancel()
                     waveformTask = nil
                     let voiceRecord = try await repository.finishRecording()
-                    let voiceNote = try await voiceNoteUseCase.create(voiceRecord)
+                    let voiceNote = try voiceNoteUseCase.create(voiceRecord)
                     coordinator?.finishRecording(voiceNote: voiceNote)
                 } catch {
                     send(.errorOccurred(error))
@@ -216,7 +216,7 @@ public final class RecordingViewModel {
         }
 
         private struct PreviewVoiceNoteUseCase: VoiceNoteUseCase {
-            func create(_ voiceRecord: VoiceRecord) async throws(VoiceNoteUseCaseError) -> VoiceNote {
+            func create(_ voiceRecord: VoiceRecord) throws(VoiceNoteUseCaseError) -> VoiceNote {
                 VoiceNote(
                     title: "미리보기 기록",
                     createdAt: .now,
@@ -229,23 +229,23 @@ public final class RecordingViewModel {
                 )
             }
 
-            func fetchAllFromDefaultFolder() async throws(VoiceNoteUseCaseError) -> [VoiceNote] {
+            func fetchAllFromDefaultFolder() throws(VoiceNoteUseCaseError) -> [VoiceNote] {
                 []
             }
 
-            func fetchAll(folderID: UUID) async throws(VoiceNoteUseCaseError) -> [VoiceNote] {
+            func fetchAll(folderID: UUID) throws(VoiceNoteUseCaseError) -> [VoiceNote] {
                 []
             }
 
-            func fetch(byId id: UUID) async throws(VoiceNoteUseCaseError) -> VoiceNote {
+            func fetch(byId id: UUID) throws(VoiceNoteUseCaseError) -> VoiceNote {
                 throw .recordNotFound(id)
             }
 
-            func fetchRecent(limit: Int) async throws(VoiceNoteUseCaseError) -> [VoiceNote] {
+            func fetchRecent(limit: Int) throws(VoiceNoteUseCaseError) -> [VoiceNote] {
                 []
             }
 
-            func update(_ voiceNote: VoiceNote) async throws(VoiceNoteUseCaseError) -> VoiceNote {
+            func update(_ voiceNote: VoiceNote) throws(VoiceNoteUseCaseError) -> VoiceNote {
                 voiceNote
             }
 

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -122,7 +122,7 @@ final class MainViewModelTests: XCTestCase {
         await sut.mockVoiceRecordRepo.setCheckPermissionResult(.authorized)
         await sut.mockVoiceRecordRepo.expectCheckPermission(callCount: 1)
 
-        await sut.viewModel.handleRecordButtonTap()
+        sut.viewModel.handleRecordButtonTap()
 
         await sut.mockVoiceRecordRepo.verify()
         XCTAssertTrue(sut.mockCoordinator.presentRecodingViewCalled)
@@ -134,25 +134,23 @@ final class MainViewModelTests: XCTestCase {
         await sut.mockVoiceRecordRepo.setCheckPermissionResult(.denied)
         await sut.mockVoiceRecordRepo.expectCheckPermission(callCount: 1)
 
-        await sut.viewModel.handleRecordButtonTap()
+        sut.viewModel.handleRecordButtonTap()
 
         await sut.mockVoiceRecordRepo.verify()
         XCTAssertFalse(sut.mockCoordinator.presentRecodingViewCalled)
         XCTAssertTrue(sut.viewModel.showAlert)
     }
 
-    func test_handleRecordButtonTap_최초요청후허용_녹음화면이동() async {
+    func test_handleRecordButtonTap_권한미결정_알럿노출() async {
         let sut = makeSUT()
         await sut.mockVoiceRecordRepo.setCheckPermissionResult(.notDetermined)
-        await sut.mockVoiceRecordRepo.setRequestPermissionResult(.success(.authorized))
         await sut.mockVoiceRecordRepo.expectCheckPermission(callCount: 1)
-        await sut.mockVoiceRecordRepo.expectRequestPermission(callCount: 1)
 
-        await sut.viewModel.handleRecordButtonTap()
+        sut.viewModel.handleRecordButtonTap()
 
         await sut.mockVoiceRecordRepo.verify()
-        XCTAssertTrue(sut.mockCoordinator.presentRecodingViewCalled)
-        XCTAssertFalse(sut.viewModel.showAlert)
+        XCTAssertFalse(sut.mockCoordinator.presentRecodingViewCalled)
+        XCTAssertTrue(sut.viewModel.showAlert)
     }
 
     // MARK: - Update Tests
@@ -161,15 +159,15 @@ final class MainViewModelTests: XCTestCase {
         // Given
         let sut = makeSUT()
         let expectedNotes = [VoiceNote.stub(title: "노트1"), VoiceNote.stub(title: "노트2")]
-        await sut.mockVoiceNoteRepo.setFetchAllResult(.success(expectedNotes))
-        await sut.mockVoiceNoteRepo.expectFetchAllFromDefaultFolder(callCount: 1)
+        sut.mockVoiceNoteRepo.setFetchAllResult(.success(expectedNotes))
+        sut.mockVoiceNoteRepo.expectFetchAllFromDefaultFolder(callCount: 1)
 
         // When
         sut.viewModel.updateVoiceNoteCategory()
         try? await Task.sleep(nanoseconds: 300_000_000)
 
         // Then
-        await sut.mockVoiceNoteRepo.verify()
+        sut.mockVoiceNoteRepo.verify()
         XCTAssertEqual(sut.viewModel.categoryData[1].items.count, 2)
         if case .voiceNote(let note) = sut.viewModel.categoryData[1].items[0] {
             XCTAssertEqual(note.title, "노트1")
@@ -182,15 +180,15 @@ final class MainViewModelTests: XCTestCase {
         // Given
         let sut = makeSUT()
         let expectedNotes = [VoiceNote.stub(title: "최신1"), VoiceNote.stub(title: "최신2")]
-        await sut.mockVoiceNoteRepo.setFetchRecentResult(.success(expectedNotes))
-        await sut.mockVoiceNoteRepo.expectFetchRecent(callCount: 1)
+        sut.mockVoiceNoteRepo.setFetchRecentResult(.success(expectedNotes))
+        sut.mockVoiceNoteRepo.expectFetchRecent(callCount: 1)
 
         // When
         sut.viewModel.updateRecentCategory()
         try? await Task.sleep(nanoseconds: 300_000_000)
 
         // Then
-        await sut.mockVoiceNoteRepo.verify()
+        sut.mockVoiceNoteRepo.verify()
         XCTAssertEqual(sut.viewModel.categoryData[0].items.count, 2)
         if case .voiceNote(let note) = sut.viewModel.categoryData[0].items[0] {
             XCTAssertEqual(note.title, "최신1")
@@ -206,15 +204,15 @@ final class MainViewModelTests: XCTestCase {
             Folder(name: "테스트 폴더 2")
         ]
 
-        await sut.mockFolderRepo.setFetchAllResult(.success(expectedFolders))
-        await sut.mockFolderRepo.expectFetchAll(callCount: 1)
+        sut.mockFolderRepo.setFetchAllResult(.success(expectedFolders))
+        sut.mockFolderRepo.expectFetchAll(callCount: 1)
 
         sut.viewModel.updateMyFolderCategory()
 
         // Task 내부 비동기 대기
         try? await Task.sleep(nanoseconds: 300_000_000)
 
-        await sut.mockFolderRepo.verify()
+        sut.mockFolderRepo.verify()
         XCTAssertEqual(sut.viewModel.categoryData[2].items.count, 2)
 
         if case .folder(let folder) = sut.viewModel.categoryData[2].items[0] {

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -43,18 +43,21 @@ final class MainViewModelTests: XCTestCase {
 
     private struct SUT {
         let viewModel: MainViewModel
+        let mockVoiceRecordRepo: MockVoiceRecordRepository
         let mockFolderRepo: MockFolderRepository
         let mockVoiceNoteRepo: MockVoiceNoteRepository
         let mockCoordinator: MockMainCoordinatorDelegate
     }
 
     private func makeSUT() -> SUT {
+        let mockVoiceRecordRepo = MockVoiceRecordRepository()
         let mockFolderRepo = MockFolderRepository()
         let mockVoiceNoteRepo = MockVoiceNoteRepository()
         let mockWasteBasketRepo = MockWasteBasketRepository()
         let mockCoordinator = MockMainCoordinatorDelegate()
 
         let viewModel = MainViewModel(
+            microphoneRepository: mockVoiceRecordRepo,
             voiceNoteUseCase: DefaultVoiceNoteUseCase(
                 repository: mockVoiceNoteRepo,
                 sttRepository: MockSTTRepository(),
@@ -67,6 +70,7 @@ final class MainViewModelTests: XCTestCase {
 
         return SUT(
             viewModel: viewModel,
+            mockVoiceRecordRepo: mockVoiceRecordRepo,
             mockFolderRepo: mockFolderRepo,
             mockVoiceNoteRepo: mockVoiceNoteRepo,
             mockCoordinator: mockCoordinator
@@ -111,6 +115,44 @@ final class MainViewModelTests: XCTestCase {
         sut.viewModel.presentRecodingView()
 
         XCTAssertTrue(sut.mockCoordinator.presentRecodingViewCalled)
+    }
+
+    func test_handleRecordButtonTap_권한허용_바로녹음화면이동() async {
+        let sut = makeSUT()
+        await sut.mockVoiceRecordRepo.setCheckPermissionResult(.authorized)
+        await sut.mockVoiceRecordRepo.expectCheckPermission(callCount: 1)
+
+        await sut.viewModel.handleRecordButtonTap()
+
+        await sut.mockVoiceRecordRepo.verify()
+        XCTAssertTrue(sut.mockCoordinator.presentRecodingViewCalled)
+        XCTAssertFalse(sut.viewModel.showAlert)
+    }
+
+    func test_handleRecordButtonTap_권한거부_알럿노출() async {
+        let sut = makeSUT()
+        await sut.mockVoiceRecordRepo.setCheckPermissionResult(.denied)
+        await sut.mockVoiceRecordRepo.expectCheckPermission(callCount: 1)
+
+        await sut.viewModel.handleRecordButtonTap()
+
+        await sut.mockVoiceRecordRepo.verify()
+        XCTAssertFalse(sut.mockCoordinator.presentRecodingViewCalled)
+        XCTAssertTrue(sut.viewModel.showAlert)
+    }
+
+    func test_handleRecordButtonTap_최초요청후허용_녹음화면이동() async {
+        let sut = makeSUT()
+        await sut.mockVoiceRecordRepo.setCheckPermissionResult(.notDetermined)
+        await sut.mockVoiceRecordRepo.setRequestPermissionResult(.success(.authorized))
+        await sut.mockVoiceRecordRepo.expectCheckPermission(callCount: 1)
+        await sut.mockVoiceRecordRepo.expectRequestPermission(callCount: 1)
+
+        await sut.viewModel.handleRecordButtonTap()
+
+        await sut.mockVoiceRecordRepo.verify()
+        XCTAssertTrue(sut.mockCoordinator.presentRecodingViewCalled)
+        XCTAssertFalse(sut.viewModel.showAlert)
     }
 
     // MARK: - Update Tests

--- a/Presentation/Tests/Recording/RecordingViewModelTests.swift
+++ b/Presentation/Tests/Recording/RecordingViewModelTests.swift
@@ -64,6 +64,7 @@ extension RecordingViewModelTests {
         XCTAssertEqual(sut.viewModel.state.amplitude, 0)
         XCTAssertNil(sut.viewModel.state.errorMessage)
         XCTAssertEqual(sut.viewModel.state.recordingDuration, 0)
+        XCTAssertFalse(sut.viewModel.state.showAlert)
     }
 }
 
@@ -208,6 +209,45 @@ extension RecordingViewModelTests {
 // MARK: - 완료
 
 extension RecordingViewModelTests {
+    func test_openAlertButtonTapped_showAlert를true로변경한다() {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        sut.viewModel.send(.openAlertButtonTapped)
+
+        // Then
+        XCTAssertTrue(sut.viewModel.state.showAlert)
+    }
+
+    func test_closeAlertButtonTapped_showAlert를false로변경한다() {
+        // Given
+        let sut = makeSUT()
+        sut.viewModel.send(.openAlertButtonTapped)
+
+        // When
+        sut.viewModel.send(.closeAlertButtonTapped)
+
+        // Then
+        XCTAssertFalse(sut.viewModel.state.showAlert)
+    }
+}
+
+// MARK: - 에러 처리
+
+extension RecordingViewModelTests {
+    func test_errorOccurred_errorMessage를설정한다() {
+        // Given
+        let sut = makeSUT()
+        let expectedError = VoiceRecordRepositoryError.startFailed
+
+        // When
+        sut.viewModel.send(.errorOccurred(expectedError))
+
+        // Then
+        XCTAssertEqual(sut.viewModel.state.errorMessage, expectedError.localizedDescription)
+    }
+
     func test_finishButtonTapped_녹음완료후보이스노트를생성하고coordinator의finishRecording을호출한다() async {
         // Given
         let sut = makeSUT()


### PR DESCRIPTION
---

## ✨ 작업 요약
> 한 줄로 무엇을 추가/변경했는지

사용자 권한 안내 및 녹음 경험 개선을 위한 알럿(Alert) UI를 추가하고, 백그라운드 오디오 모드를 적용했습니다.

## 📋 구체적인 내용
- **추가/변경된 동작**:
  - **메인 화면**: 마이크 권한이 없는(거부 또는 미결정) 상태에서 녹음 버튼을 누를 경우, 권한 요청을 안내하는 알럿 창 추가
  - **녹음 화면**: 사용자가 녹음을 성공적으로 마쳤을 때 확인할 수 있는 '녹음 완료' 알럿 추가
  - **설정/권한**: 앱이 백그라운드 상태로 진입하더라도 오디오(녹음/재생)가 끊기지 않도록 `Info.plist` (혹은 프로젝트 Capability)에 백그라운드 오디오 모드(Background Audio Mode) 추가
- **영향 받는 화면/모듈**:
  - `Main` 뷰/뷰모델 (마이크 권한 핸들링 로직)
  - `Recording` 뷰/뷰모델 (녹음 완료 플로우)
  - 프로젝트 설정/Info

---

## 🔗 연관 이슈

- closed #201

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
  - **권한 핸들링 로직 간소화**: `MainViewModel`에서 직접 권한을 요청하지 않고 상태만 확인한 뒤 실패 시 알럿을 띄우는 형태로 책임을 분리하여 예측 가능한 플로우를 만들었습니다.
  - **백그라운드 지원**: 백그라운드 오디오 모드를 활성화하여 사용자가 녹음 도중 다른 앱으로 전환하더라도 작업이 강제 종료되지 않도록 앱 사용성을 높였습니다.

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [x] 정상 플로우 동작 확인 (권한 승인 시 바로 녹음화면 이동, 거절 시 알럿 노출)
- [x] (UI 변경 시) 스크린샷 또는 GIF 첨부 **<- 리뷰에 스크린샷 캡쳐 후 첨부해주시면 좋습니다!**
- [x] (로직 추가 시) 테스트 추가 여부 (MainViewModelTests 수정 및 통과 확인)

---

## 👀 리뷰 포인트

- [ ] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [x] 예외/에러 핸들링
- [x] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- 권한이 없는 상태일 때 알럿이 적절한 타이밍에 잘 노출되는지 확인 부탁드립니다.
- 녹음 완료 후의 상태 전이 및 알럿 표시 플로우가 자연스러운지 봐주시면 감사하겠습니다.

---

## 📚 참고