### PR TITLE
[상세 폴더] UI/UX 리펙토링

### DIFF
--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -103,7 +103,8 @@ public final class AppDIContainer {
         return FolderDetailViewModel(
             title: folder.name,
             folderID: folder.id,
-            voiceNoteUseCase: voiceNoteUseCase
+            voiceNoteUseCase: voiceNoteUseCase,
+            wasteBasketRepository: wasteBasketRepository
         )
     }
 

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -108,11 +108,12 @@ public final class AppDIContainer {
         )
     }
 
-    public func makeMoveFolderListViewModel(voiceNote: VoiceNote) -> MoveFolderListViewModel {
+    public func makeMoveFolderListViewModel(receive: Receive, dismiss: (() -> Void)? = nil) -> MoveFolderListViewModel {
         return MoveFolderListViewModel(
-            voiceNote: voiceNote,
+            receive: receive,
             folderUseCase: folderUseCase,
-            voiceNoteUseCase: voiceNoteUseCase
+            voiceNoteUseCase: voiceNoteUseCase,
+            onDismiss: dismiss
         )
     }
 

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -92,24 +92,13 @@ extension MainCoordinator: FolderCoordinatorDelegate {
     }
 }
 
+// MARK: DetailFolderCoordinating
+
+extension MainCoordinator: FolderDetailCoordinatorDelegate {}
+
 // MARK: VoiceNoteCoordinating
 
-extension MainCoordinator: VoiceNoteCoordinatorDelegate {
-    func presentFolderList(with voiceNote: VoiceNote) {
-        let viewModel = dependencyContainer.makeMoveFolderListViewModel(voiceNote: voiceNote)
-        viewModel.coordinator = self
-        let viewController = MoveFolderListViewController(viewModel: viewModel)
-        let nav = UINavigationController(rootViewController: viewController)
-        nav.isNavigationBarHidden = true
-
-        if let sheet = nav.sheetPresentationController {
-            sheet.detents = [.medium()]
-            sheet.prefersGrabberVisible = true
-        }
-
-        presenter.present(nav, animated: true)
-    }
-}
+extension MainCoordinator: VoiceNoteCoordinatorDelegate {}
 
 // MARK: - NewFolderCoordinatorDelegate
 
@@ -170,5 +159,21 @@ extension MainCoordinator: BaseCoordinatorDelegate {
 
     func pop() {
         presenter.popViewController(animated: true)
+    }
+    
+    // TODO: Present 폴더 이동 시트 ( 사용 화면 - 음성 노트, 개인 폴더 )
+    func presentFolderList(with receive: Receive, dismiss: (() -> Void)?) {
+        let viewModel = dependencyContainer.makeMoveFolderListViewModel(receive: receive, dismiss: dismiss)
+        viewModel.coordinator = self
+        let viewController = MoveFolderListViewController(viewModel: viewModel)
+        let nav = UINavigationController(rootViewController: viewController)
+        nav.isNavigationBarHidden = true
+
+        if let sheet = nav.sheetPresentationController {
+            sheet.detents = [.medium()]
+            sheet.prefersGrabberVisible = true
+        }
+
+        presenter.present(nav, animated: true)
     }
 }

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -160,7 +160,7 @@ extension MainCoordinator: BaseCoordinatorDelegate {
     func pop() {
         presenter.popViewController(animated: true)
     }
-    
+
     // TODO: Present 폴더 이동 시트 ( 사용 화면 - 음성 노트, 개인 폴더 )
     func presentFolderList(with receive: Receive, dismiss: (() -> Void)?) {
         let viewModel = dependencyContainer.makeMoveFolderListViewModel(receive: receive, dismiss: dismiss)

--- a/Domain/Sources/Entities/VoiceNote.swift
+++ b/Domain/Sources/Entities/VoiceNote.swift
@@ -12,7 +12,7 @@ public struct VoiceNote: Sendable, Identifiable, Hashable {
     public let title: String
     public let createdAt: Date
     public let updatedAt: Date
-    public let folderID: UUID
+    public var folderID: UUID
     public let voiceRecord: VoiceRecord
     public let keywords: [Keyword]
     public var transcript: Transcript?

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
@@ -33,9 +33,6 @@ struct VoiceNoteCardView: View {
             }
 
         }
-        .onChange(of: select) { _,newValue in
-            print("내부 VoiceNote select : \(newValue)")
-        }
         .editCardStyle(isSelected: isSelected)
         .onTapGesture {
             if isEdit {

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import Domain
+import SwiftUI
 
 struct VoiceNoteCardView: View {
     let isSelected: Bool
@@ -20,11 +20,11 @@ struct VoiceNoteCardView: View {
         self.action = action
         self.completeAction = completeAction
     }
-    
+
     var isEdit: Bool {
         select != .none
     }
-    
+
     var body: some View {
         HStack(spacing: 0) {
             if isEdit {
@@ -33,7 +33,6 @@ struct VoiceNoteCardView: View {
             VStack(alignment: .leading, spacing: 6) {
                 cardContent
             }
-
         }
         .editCardStyle(isSelected: isSelected)
         .onTapGesture {
@@ -44,8 +43,7 @@ struct VoiceNoteCardView: View {
             }
         }
     }
-    
-    @ViewBuilder
+
     private var checkIcon: some View {
         VStack(alignment: .center, spacing: 0) {
             Image(systemName: "checkmark.circle.fill")
@@ -59,7 +57,7 @@ struct VoiceNoteCardView: View {
         }
         .padding(.trailing)
     }
-    
+
     @ViewBuilder
     private var cardContent: some View {
         let time: String = Date.now.voiceNoteDay(
@@ -96,8 +94,7 @@ struct VoiceNoteCardView: View {
 
 extension View {
     func editCardStyle(isSelected: Bool) -> some View {
-        self
-        .modifier(
+        modifier(
             EditVoiceNoteCardModifier(
                 isSelected: isSelected
             )
@@ -107,7 +104,7 @@ extension View {
 
 struct EditVoiceNoteCardModifier: ViewModifier {
     let isSelected: Bool
-    
+
     func body(content: Content) -> some View {
         content
             .frame(minHeight: 118)
@@ -124,8 +121,7 @@ struct EditVoiceNoteCardModifier: ViewModifier {
     }
 }
 
-
-//#Preview {
+// #Preview {
 //    VoiceNoteCardView(
 //        select: .none,
 //        voiceNote: .
@@ -133,4 +129,4 @@ struct EditVoiceNoteCardModifier: ViewModifier {
 //    )
 //    .padding()
 //    .background(.gray50)
-//}
+// }

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
@@ -1,44 +1,135 @@
 import SwiftUI
+import Domain
 
 struct VoiceNoteCardView: View {
-    var title: String
-    var subTitle: String
-
+    let isSelected: Bool
+    var select: FolderDetailViewModel.Select
+    let voiceNote: VoiceNote
+    let action: ((VoiceNote, Bool) -> Void)?
+    
+    init(
+        select: FolderDetailViewModel.Select = .none,
+        isSelected: Bool = false,
+        voiceNote: VoiceNote,
+        action: ((VoiceNote, Bool) -> Void)? = nil
+    ) {
+        self.select = select
+        self.isSelected = isSelected
+        self.voiceNote = voiceNote
+        self.action = action
+    }
+    
+    var isEdit: Bool {
+        select != .none
+    }
+    
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Group {
-                Text(title)
-                    .foregroundStyle(.gray950)
-                    .font(.system(size: 18))
-                    .lineSpacing(1.3)
-                Text(subTitle)
-                    .foregroundStyle(.gray800)
-                    .font(.body)
-                    .font(.system(size: 16))
-                    .lineSpacing(1.5)
-                    .tracking(-0.03)
-                Text("요약 필요")
-                    .font(.system(size: 15))
-                    .lineSpacing(1.3)
-                    .tracking(-0.03)
-                    .padding(.vertical, 4)
-                    .padding(.horizontal, 12)
-                    .overlay(
-                        Capsule()
-                            .stroke(Color.point600, lineWidth: 1)
-                    )
-                    .background(.point600.opacity(0.2), in: .capsule)
-                    .foregroundStyle(.gray750)
+        HStack(spacing: 0) {
+            if isEdit {
+                checkIcon
+            }
+            VStack(alignment: .leading, spacing: 6) {
+                cardContent
+            }
+
+        }
+        .onChange(of: select) { _,newValue in
+            print("내부 VoiceNote select : \(newValue)")
+        }
+        .editCardStyle(isSelected: isSelected)
+        .onTapGesture {
+            if isEdit {
+                action?(voiceNote, !isSelected)
             }
         }
-        .frame(minHeight: 118)
-        .frame(maxWidth: .infinity, maxHeight: 120, alignment: .leading)
-        .padding(.horizontal)
-        .background(.point200.opacity(0.2))
-        .glassEffect(.clear, in: .rect(cornerRadius: 20))
+    }
+    
+    @ViewBuilder
+    private var checkIcon: some View {
+        VStack(alignment: .center, spacing: 0) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.gray950, .point600)
+                .overlay {
+                    if !isSelected {
+                        Circle()
+                            .fill(.gray850)
+                    }
+                }
+        }
+        .padding(.trailing)
+    }
+    
+    @ViewBuilder
+    private var cardContent: some View {
+        let time: String = Date.now.voiceNoteDay(
+            createdAt: voiceNote.createdAt,
+            updatedAt: voiceNote.updatedAt,
+            duration: voiceNote.voiceRecord.duration
+        )
+        Group {
+            Text(voiceNote.title)
+                .foregroundStyle(.gray950)
+                .font(.system(size: 18))
+                .lineSpacing(1.3)
+            Text(time)
+                .foregroundStyle(.gray800)
+                .font(.body)
+                .font(.system(size: 16))
+                .lineSpacing(1.5)
+                .tracking(-0.03)
+            Text("요약 필요")
+                .font(.system(size: 15))
+                .lineSpacing(1.3)
+                .tracking(-0.03)
+                .padding(.vertical, 4)
+                .padding(.horizontal, 12)
+                .overlay(
+                    Capsule()
+                        .stroke(Color.point600, lineWidth: 1)
+                )
+                .background(.point600.opacity(0.2), in: .capsule)
+                .foregroundStyle(.gray750)
+        }
     }
 }
 
-// #Preview {
-//    VoiceNoteCardView(title: "test", subTitle: "qqweqfq")
-// }
+extension View {
+    func editCardStyle(isSelected: Bool) -> some View {
+        self
+        .modifier(
+            EditVoiceNoteCardModifier(
+                isSelected: isSelected
+            )
+        )
+    }
+}
+
+struct EditVoiceNoteCardModifier: ViewModifier {
+    let isSelected: Bool
+    
+    func body(content: Content) -> some View {
+        content
+            .frame(minHeight: 118)
+            .frame(maxWidth: .infinity, maxHeight: 120, alignment: .leading)
+            .padding(.horizontal)
+            .background(.point200.opacity(0.2))
+            .glassEffect(.clear, in: .rect(cornerRadius: 20))
+            .overlay {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(.point900, lineWidth: 1)
+                }
+            }
+    }
+}
+
+
+//#Preview {
+//    VoiceNoteCardView(
+//        select: .none,
+//        voiceNote: .
+//        action: nil
+//    )
+//    .padding()
+//    .background(.gray50)
+//}

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
@@ -6,17 +6,19 @@ struct VoiceNoteCardView: View {
     var select: FolderDetailViewModel.Select
     let voiceNote: VoiceNote
     let action: ((VoiceNote, Bool) -> Void)?
-    
+    let completeAction: (() -> Void)?
     init(
         select: FolderDetailViewModel.Select = .none,
         isSelected: Bool = false,
         voiceNote: VoiceNote,
-        action: ((VoiceNote, Bool) -> Void)? = nil
+        action: ((VoiceNote, Bool) -> Void)? = nil,
+        completeAction: (() -> Void)? = nil
     ) {
         self.select = select
         self.isSelected = isSelected
         self.voiceNote = voiceNote
         self.action = action
+        self.completeAction = completeAction
     }
     
     var isEdit: Bool {
@@ -37,6 +39,8 @@ struct VoiceNoteCardView: View {
         .onTapGesture {
             if isEdit {
                 action?(voiceNote, !isSelected)
+            } else {
+                completeAction?()
             }
         }
     }

--- a/Presentation/Sources/DesignSystem/UIView+ToastMessage.swift
+++ b/Presentation/Sources/DesignSystem/UIView+ToastMessage.swift
@@ -1,0 +1,114 @@
+import UIKit
+
+extension UIView {
+    
+    enum ToastType: Hashable {
+        case normal
+        case action
+    }
+    
+    func makeToast(
+        type: ToastType = .action,
+        _ message: String,
+        duration: TimeInterval = 3.0,
+        action: (() -> Void)? = nil
+    ) {
+        let toastContainer = UIView()
+        toastContainer.translatesAutoresizingMaskIntoConstraints = false
+        toastContainer.backgroundColor = UIColor.gray100
+        toastContainer.layer.borderColor = UIColor.gray350.cgColor
+        toastContainer.layer.borderWidth = 1.0
+        toastContainer.layer.cornerRadius = 20
+        toastContainer.alpha = 0.0
+        
+        let msgLabel = UILabel()
+        msgLabel.translatesAutoresizingMaskIntoConstraints = false
+        msgLabel.textColor = UIColor.gray800
+        msgLabel.numberOfLines = 1
+        msgLabel.setTypography(text: message, style: .body2, textAlignment: type == .normal ? .center : .left)
+        
+        let cancelButton = UIButton()
+        cancelButton.translatesAutoresizingMaskIntoConstraints = false
+        cancelButton.setTitle("취소", for: .normal)
+        cancelButton.titleLabel?.setTypography(style: .body2)
+        cancelButton.setTitleColor(.danger, for: .normal)
+        cancelButton.backgroundColor = .clear
+        cancelButton.isHidden = type == .normal
+        // 액션 버튼을 눌렀을 때 이벤트 처리
+        if type == .action {
+            cancelButton.addAction(UIAction { _ in
+                action?()
+                
+                // 버튼을 누르면 대기(delay)를 무시하고 곧바로 내려가면서 사라지도록 처리합니다.
+                UIView.animate(withDuration: 0.3, delay: 0.0, options: [.curveEaseIn, .beginFromCurrentState]) {
+                    toastContainer.alpha = 0.0
+                    toastContainer.transform = CGAffineTransform(translationX: 0, y: 50)
+                } completion: { _ in
+                    toastContainer.removeFromSuperview()
+                }
+            }, for: .touchUpInside)
+        }
+        
+        toastContainer.addSubview(msgLabel)
+        toastContainer.addSubview(cancelButton)
+        
+        let targetView: UIView
+        if let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap({ $0.windows })
+            .first(where: { $0.isKeyWindow }) {
+            targetView = window
+        } else {
+            targetView = self
+        }
+        
+        targetView.addSubview(toastContainer)
+        
+        // 타입에 따라 AutoLayout 제약조건 분기
+        var constraints: [NSLayoutConstraint] = [
+            toastContainer.bottomAnchor.constraint(equalTo: targetView.safeAreaLayoutGuide.bottomAnchor, constant: -20),
+            toastContainer.leadingAnchor.constraint(equalTo: targetView.leadingAnchor, constant: 20),
+            toastContainer.trailingAnchor.constraint(equalTo: targetView.trailingAnchor, constant: -20),
+            toastContainer.heightAnchor.constraint(equalToConstant: 52),
+            
+            msgLabel.centerYAnchor.constraint(equalTo: toastContainer.centerYAnchor),
+            msgLabel.leadingAnchor.constraint(equalTo: toastContainer.leadingAnchor, constant: 16)
+        ]
+        
+        if type == .normal {
+            constraints.append(msgLabel.trailingAnchor.constraint(equalTo: toastContainer.trailingAnchor, constant: -16))
+        } else {
+            constraints.append(contentsOf: [
+                msgLabel.trailingAnchor.constraint(lessThanOrEqualTo: cancelButton.leadingAnchor, constant: -10),
+                cancelButton.centerYAnchor.constraint(equalTo: toastContainer.centerYAnchor),
+                cancelButton.trailingAnchor.constraint(equalTo: toastContainer.trailingAnchor, constant: -16)
+            ])
+        }
+        
+        NSLayoutConstraint.activate(constraints)
+        
+        toastContainer.transform = CGAffineTransform(translationX: 0, y: 50)
+        
+        // 1. 나타날 때 (.allowUserInteraction 옵션 필수! 안 넣으면 delay 중첩 시간 동안 버튼 터치가 완전 무시됩니다.)
+        UIView.animate(withDuration: 0.3, delay: 0.0, options: [.curveEaseOut, .allowUserInteraction]) {
+            toastContainer.alpha = 1.0
+            toastContainer.transform = .identity
+        }
+        
+        // 2. 유지 및 사라질 때 (Task를 사용하여 명시적으로 딜레이시킴으로써 Hit Target 유실 방지)
+        Task {
+            try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+            
+            await MainActor.run {
+                guard toastContainer.superview != nil else { return }
+                
+                UIView.animate(withDuration: 0.3, delay: 0.0, options: [.curveEaseIn, .allowUserInteraction], animations: {
+                    toastContainer.alpha = 0.0
+                    toastContainer.transform = CGAffineTransform(translationX: 0, y: 50)
+                }) { _ in
+                    toastContainer.removeFromSuperview()
+                }
+            }
+        }
+    }
+}

--- a/Presentation/Sources/DesignSystem/UIView+ToastMessage.swift
+++ b/Presentation/Sources/DesignSystem/UIView+ToastMessage.swift
@@ -1,12 +1,11 @@
 import UIKit
 
 extension UIView {
-    
     enum ToastType: Hashable {
         case normal
         case action
     }
-    
+
     func makeToast(
         type: ToastType = .action,
         _ message: String,
@@ -20,13 +19,13 @@ extension UIView {
         toastContainer.layer.borderWidth = 1.0
         toastContainer.layer.cornerRadius = 20
         toastContainer.alpha = 0.0
-        
+
         let msgLabel = UILabel()
         msgLabel.translatesAutoresizingMaskIntoConstraints = false
         msgLabel.textColor = UIColor.gray800
         msgLabel.numberOfLines = 1
         msgLabel.setTypography(text: message, style: .body2, textAlignment: type == .normal ? .center : .left)
-        
+
         let cancelButton = UIButton()
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
         cancelButton.setTitle("취소", for: .normal)
@@ -38,7 +37,7 @@ extension UIView {
         if type == .action {
             cancelButton.addAction(UIAction { _ in
                 action?()
-                
+
                 // 버튼을 누르면 대기(delay)를 무시하고 곧바로 내려가면서 사라지도록 처리합니다.
                 UIView.animate(withDuration: 0.3, delay: 0.0, options: [.curveEaseIn, .beginFromCurrentState]) {
                     toastContainer.alpha = 0.0
@@ -48,35 +47,38 @@ extension UIView {
                 }
             }, for: .touchUpInside)
         }
-        
+
         toastContainer.addSubview(msgLabel)
         toastContainer.addSubview(cancelButton)
-        
-        let targetView: UIView
-        if let window = UIApplication.shared.connectedScenes
+
+        let targetView: UIView = if let window = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
-            .flatMap({ $0.windows })
-            .first(where: { $0.isKeyWindow }) {
-            targetView = window
+            .flatMap(\.windows)
+            .first(where: { $0.isKeyWindow })
+        {
+            window
         } else {
-            targetView = self
+            self
         }
-        
+
         targetView.addSubview(toastContainer)
-        
+
         // 타입에 따라 AutoLayout 제약조건 분기
         var constraints: [NSLayoutConstraint] = [
             toastContainer.bottomAnchor.constraint(equalTo: targetView.safeAreaLayoutGuide.bottomAnchor, constant: -20),
             toastContainer.leadingAnchor.constraint(equalTo: targetView.leadingAnchor, constant: 20),
             toastContainer.trailingAnchor.constraint(equalTo: targetView.trailingAnchor, constant: -20),
             toastContainer.heightAnchor.constraint(equalToConstant: 52),
-            
+
             msgLabel.centerYAnchor.constraint(equalTo: toastContainer.centerYAnchor),
             msgLabel.leadingAnchor.constraint(equalTo: toastContainer.leadingAnchor, constant: 16)
         ]
-        
+
         if type == .normal {
-            constraints.append(msgLabel.trailingAnchor.constraint(equalTo: toastContainer.trailingAnchor, constant: -16))
+            constraints.append(msgLabel.trailingAnchor.constraint(
+                equalTo: toastContainer.trailingAnchor,
+                constant: -16
+            ))
         } else {
             constraints.append(contentsOf: [
                 msgLabel.trailingAnchor.constraint(lessThanOrEqualTo: cancelButton.leadingAnchor, constant: -10),
@@ -84,28 +86,33 @@ extension UIView {
                 cancelButton.trailingAnchor.constraint(equalTo: toastContainer.trailingAnchor, constant: -16)
             ])
         }
-        
+
         NSLayoutConstraint.activate(constraints)
-        
+
         toastContainer.transform = CGAffineTransform(translationX: 0, y: 50)
-        
+
         // 1. 나타날 때 (.allowUserInteraction 옵션 필수! 안 넣으면 delay 중첩 시간 동안 버튼 터치가 완전 무시됩니다.)
         UIView.animate(withDuration: 0.3, delay: 0.0, options: [.curveEaseOut, .allowUserInteraction]) {
             toastContainer.alpha = 1.0
             toastContainer.transform = .identity
         }
-        
+
         // 2. 유지 및 사라질 때 (Task를 사용하여 명시적으로 딜레이시킴으로써 Hit Target 유실 방지)
         Task {
             try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
-            
+
             await MainActor.run {
                 guard toastContainer.superview != nil else { return }
-                
-                UIView.animate(withDuration: 0.3, delay: 0.0, options: [.curveEaseIn, .allowUserInteraction], animations: {
-                    toastContainer.alpha = 0.0
-                    toastContainer.transform = CGAffineTransform(translationX: 0, y: 50)
-                }) { _ in
+
+                UIView.animate(
+                    withDuration: 0.3,
+                    delay: 0.0,
+                    options: [.curveEaseIn, .allowUserInteraction],
+                    animations: {
+                        toastContainer.alpha = 0.0
+                        toastContainer.transform = CGAffineTransform(translationX: 0, y: 50)
+                    }
+                ) { _ in
                     toastContainer.removeFromSuperview()
                 }
             }

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -12,6 +12,8 @@ public final class FolderDetailViewController: CollectionViewController {
 
     private var dataSource: DataSource?
 
+    // MARK: - Component
+    
     private lazy var backButton: UIButton = {
         let btn = UIButton(type: .custom) // .system 대신 .custom을 사용하여 기본 배경 효과 제거
         let symbolConfig = UIImage.SymbolConfiguration(weight: .bold)
@@ -57,9 +59,6 @@ public final class FolderDetailViewController: CollectionViewController {
         return btn
     }()
 
-
-    // MARK: - Component
-
     private lazy var createdAtAction = UIAction(
         title: "생성일 순"
     ) { [weak self] _ in
@@ -86,20 +85,22 @@ public final class FolderDetailViewController: CollectionViewController {
         self?.vm.setSelectionMode(.all)
     }
     
-    private lazy var moveAction = UIAction(
-        title: "파일 이동하기",
-        image: nil
-    ) { [weak self] _ in
-        
-    }
-    
-    private lazy var deleteAction = UIAction(
-        title: "삭제하기",
-        image: nil,
-        attributes: .destructive
-    ) { [weak self] _ in
-        
-    }
+    private let cancelAlertButton: GlassButton = .close("취소")
+    private let primaryAlertButton: GlassButton = .danger("삭제")
+    private let removeAlertOverlayView: UIView = {
+        let overlay = UIView()
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        overlay.isHidden = true
+        return overlay
+    }()
+
+    private lazy var removeAlertView: AlertView = .init(
+        title: "기록을 삭제할까요?",
+        subTitle: "휴지통으로 이동되며,\n직접 비우기 전까지 보관돼요.",
+        closeButton: cancelAlertButton,
+        primaryButton: primaryAlertButton
+    )
 
     private let vm: FolderDetailViewModel
 
@@ -129,6 +130,7 @@ public final class FolderDetailViewController: CollectionViewController {
         super.viewDidLoad()
         collectionView.allowsSelection = false
         setupNavigation()
+        setupRemoveAlert()
         setupDataSource()
         updateDataSource()
     }
@@ -147,6 +149,8 @@ public final class FolderDetailViewController: CollectionViewController {
         updateNavigationItems(vm.select)
         // dataSource
         updateDataSource(reconfigure: true)
+        // Remove Alert
+        updateRemoveAlert()
     }
 
     private func setupNavigation() {
@@ -193,6 +197,30 @@ public final class FolderDetailViewController: CollectionViewController {
             children: [dateSection, selectSection]
         )
         moreAndActionButton.menu = menu
+    }
+    
+    private func setupRemoveAlert() {
+        cancelAlertButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            vm.closeAlertView()
+        }, for: .touchUpInside)
+
+        primaryAlertButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            vm.move()
+            vm.closeAlertView()
+        }, for: .touchUpInside)
+
+        view.addSubview(removeAlertOverlayView)
+        removeAlertOverlayView.addSubview(removeAlertView)
+        NSLayoutConstraint.activate([
+            removeAlertOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
+            removeAlertOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            removeAlertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            removeAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            removeAlertView.centerXAnchor.constraint(equalTo: removeAlertOverlayView.centerXAnchor),
+            removeAlertView.centerYAnchor.constraint(equalTo: removeAlertOverlayView.centerYAnchor)
+        ])
     }
     
     private func setupDataSource() {
@@ -314,11 +342,20 @@ extension FolderDetailViewController {
         }
         dataSource?.apply(snapshot, animatingDifferences: true)
     }
+    
+    private func updateRemoveAlert() {
+        let shouldShowAlert = vm.showAlert
+        removeAlertOverlayView.isHidden = !shouldShowAlert
+        updateInteractionForAlert(isPresented: shouldShowAlert)
+        if shouldShowAlert {
+            view.bringSubviewToFront(removeAlertOverlayView)
+        }
+    }
 }
 
 // MARK: - Helper Method
 
-extension FolderDetailViewController {
+private extension FolderDetailViewController {
     func backButtonAction() -> UIAction {
         UIAction { [weak self] _ in
             guard let self else { return }
@@ -341,7 +378,7 @@ extension FolderDetailViewController {
             case .single, .all:
                 // TODO: 삭제 로직 실행
                 print("삭제 버튼 탭됨")
-                vm.setSelectionMode(.none)
+                vm.openAlertView()
             }
         }
     }
@@ -359,6 +396,13 @@ extension FolderDetailViewController {
                 vm.setSelectionMode(.none)
             }
         }
+    }
+    
+    func updateInteractionForAlert(isPresented: Bool) {
+        collectionView.isUserInteractionEnabled = !isPresented
+        backButton.isUserInteractionEnabled = !isPresented
+        moreAndActionButton.isUserInteractionEnabled = !isPresented
+        searchAndMoveButton.isUserInteractionEnabled = !isPresented
     }
 }
 

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -86,13 +86,6 @@ public final class FolderDetailViewController: CollectionViewController {
         self?.vm.setSelectionMode(.all)
     }
     
-    private lazy var cancelAction = UIAction(
-        title: "취소하기",
-        image: nil
-    ) { [weak self] _ in
-        self?.vm.setSelectionMode(.none)
-    }
-    
     private lazy var moveAction = UIAction(
         title: "파일 이동하기",
         image: nil
@@ -201,25 +194,6 @@ public final class FolderDetailViewController: CollectionViewController {
         )
         moreAndActionButton.menu = menu
     }
-
-    private func updateRightBarButtonMenu(_ select: FolderDetailViewModel.Select) {
-        let dateSection: UIMenu = .init(
-            title: "",
-            options: .displayInline,
-            children: updateDateSectionChildren
-        )
-
-        let selectSection: UIMenu = .init(
-            title: "",
-            options: .displayInline,
-            children: updateSelectSectionChildren
-        )
-        let menu: UIMenu = .init(
-            title: "",
-            children: [dateSection, selectSection]
-        )
-        moreAndActionButton.menu = menu
-    }
     
     private func setupDataSource() {
         let cellRegistration = UICollectionView.CellRegistration {[weak self](
@@ -284,6 +258,43 @@ extension FolderDetailViewController {
         }
     }
     
+    private func updateRightBarButtonMenu(_ select: FolderDetailViewModel.Select) {
+            let dateSection: UIMenu = .init(
+                title: "",
+                options: .displayInline,
+                children: updateDateSectionChildren
+            )
+
+            let selectSection: UIMenu = .init(
+                title: "",
+                options: .displayInline,
+                children: updateSelectSectionChildren
+            )
+            let menu: UIMenu = .init(
+                title: "",
+                children: [dateSection, selectSection]
+            )
+            moreAndActionButton.menu = menu
+        }
+    
+        private var updateDateSectionChildren: [UIMenuElement] {
+            switch vm.select {
+            case .none:
+                [createdAtAction, updatedAtAction]
+            case .all, .single:
+                []
+            }
+        }
+        
+        private var updateSelectSectionChildren: [UIMenuElement] {
+            switch vm.select {
+            case .none:
+                [selectAction, selectAllAction]
+            case .all, .single:
+                []
+            }
+        }
+    
     private func updateNavigationItems(_ select: FolderDetailViewModel.Select) {
         let isEditMode = (select != .none)
         [backButton, moreAndActionButton, searchAndMoveButton].forEach {
@@ -292,24 +303,6 @@ extension FolderDetailViewController {
             $0.sizeToFit()
         }
         moreAndActionButton.showsMenuAsPrimaryAction = !isEditMode
-    }
-    
-    private var updateDateSectionChildren: [UIMenuElement] {
-        switch vm.select {
-        case .none:
-            [createdAtAction, updatedAtAction]
-        case .all, .single:
-            []
-        }
-    }
-    
-    private var updateSelectSectionChildren: [UIMenuElement] {
-        switch vm.select {
-        case .none:
-            [selectAction, selectAllAction]
-        case .all, .single:
-            [cancelAction, moveAction, deleteAction]
-        }
     }
     
     private func updateDataSource(reconfigure: Bool = false) {
@@ -343,11 +336,12 @@ extension FolderDetailViewController {
             guard let self else { return }
             switch vm.select {
             case .none:
-                // TODO: 더 보기 로직 실행
+                // TODO: 더 보기 로직 실행 ( 실행 X )
                 print("더 보기 버튼 탭됨")
-            case .all, .single:
+            case .single, .all:
                 // TODO: 삭제 로직 실행
                 print("삭제 버튼 탭됨")
+                vm.setSelectionMode(.none)
             }
         }
     }
@@ -362,6 +356,7 @@ extension FolderDetailViewController {
             case .all, .single:
                 // TODO: 이동 로직 실행
                 print("이동 버튼 탭됨")
+                vm.setSelectionMode(.none)
             }
         }
     }

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -2,7 +2,7 @@ import Domain
 import SwiftUI
 import UIKit
 
-public final class FolderDetailViewController: UICollectionViewController {
+public final class FolderDetailViewController: CollectionViewController {
     enum Section {
         case main
     }
@@ -13,15 +13,50 @@ public final class FolderDetailViewController: UICollectionViewController {
     private var dataSource: DataSource?
 
     private lazy var backButton: UIButton = {
-        let btn = UIButton(type: .system)
+        let btn = UIButton(type: .custom) // .system 대신 .custom을 사용하여 기본 배경 효과 제거
+        let symbolConfig = UIImage.SymbolConfiguration(weight: .bold)
         let backImage = UIImage(systemName: "chevron.left")?
-            .withConfiguration(UIImage.SymbolConfiguration(weight: .bold))
+            .withConfiguration(symbolConfig)
         btn.setImage(backImage, for: .normal)
+        btn.setImage(
+            UIImage(systemName: "xmark")?.withConfiguration(symbolConfig),
+            for: .selected
+        )
         btn.setTitle(vm.title, for: .normal)
+        btn.setTitle("", for: .selected) // nil 대신 ""을 사용하여 .normal 타이틀이 나오는 것을 방지
         btn.titleLabel?.setTypography(style: .title1)
         btn.tintColor = UIColor.gray950
         return btn
     }()
+
+    private lazy var moreAndActionButton: UIButton = {
+        let btn = UIButton(type: .custom)
+        let symbolConfig = UIImage.SymbolConfiguration(weight: .bold)
+        btn.setImage(UIImage(systemName: "ellipsis")?.withConfiguration(symbolConfig), for: .normal)
+        btn.setImage(UIImage(), for: .selected)
+        btn.setTitle(nil, for: .normal)
+        btn.setTitle("삭제", for: .selected)
+        btn.setTitleColor(UIColor.gray950, for: .normal)
+        btn.setTitleColor(UIColor.danger, for: .selected)
+        btn.titleLabel?.setTypography(style: .title1)
+        btn.tintColor = UIColor.gray950
+        return btn
+    }()
+
+    private lazy var searchAndMoveButton: UIButton = {
+        let btn = UIButton(type: .custom)
+        let symbolConfig = UIImage.SymbolConfiguration(weight: .bold)
+        btn.setImage(UIImage(systemName: "magnifyingglass")?.withConfiguration(symbolConfig), for: .normal)
+        btn.setImage(UIImage(), for: .selected)
+        btn.setTitle(nil, for: .normal)
+        btn.setTitle("이동", for: .selected)
+        btn.setTitleColor(UIColor.gray950, for: .normal)
+        btn.setTitleColor(UIColor.gray950, for: .selected)
+        btn.titleLabel?.setTypography(style: .title1)
+        btn.tintColor = UIColor.gray950
+        return btn
+    }()
+
 
     // MARK: - Component
 
@@ -81,9 +116,12 @@ public final class FolderDetailViewController: UICollectionViewController {
             var listConfiguration = UICollectionLayoutListConfiguration(appearance: .plain)
             listConfiguration.headerMode = .none
             listConfiguration.showsSeparators = false
-            listConfiguration.backgroundColor = .gray50
+            listConfiguration.backgroundColor = .clear
 
-            return NSCollectionLayoutSection.list(using: listConfiguration, layoutEnvironment: layoutEnvironment)
+            return NSCollectionLayoutSection.list(
+                using: listConfiguration,
+                layoutEnvironment: layoutEnvironment
+            )
         }
         super.init(collectionViewLayout: layout)
     }
@@ -111,9 +149,11 @@ public final class FolderDetailViewController: UICollectionViewController {
         super.updateProperties()
         // menu
         updateOrder(vm.order)
+        updateRightBarButtonMenu(vm.select)
+        // navigation Item
+        updateNavigationItems(vm.select)
         // dataSource
         updateDataSource(reconfigure: true)
-        updateRightBarButtonMenu(vm.select)
     }
 
     private func setupNavigation() {
@@ -128,15 +168,14 @@ public final class FolderDetailViewController: UICollectionViewController {
         let leftItem = UIBarButtonItem(customView: backButton)
         navigationItem.leftBarButtonItem = leftItem
 
-        backButton.addAction(
-            UIAction { [weak self] _ in
-                self?.vm.didTapBack()
-            }, for: .touchUpInside
-        )
+        backButton.addAction(backButtonAction(), for: .touchUpInside)
         navigationItem.rightBarButtonItems = [
-            UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: nil),
-            UIBarButtonItem(image: UIImage(systemName: "magnifyingglass"), menu: nil)
+            UIBarButtonItem(customView: moreAndActionButton),
+            UIBarButtonItem(customView: searchAndMoveButton)
         ]
+        moreAndActionButton.addAction(moreAndActionButtonAction(), for: .touchUpInside)
+        searchAndMoveButton.addAction(searchAndMoveButtonAction(), for: .touchUpInside)
+
         setupRightBarButtonMenu()
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
         navigationItem.rightBarButtonItems?.forEach {
@@ -160,15 +199,35 @@ public final class FolderDetailViewController: UICollectionViewController {
             title: "",
             children: [dateSection, selectSection]
         )
-        navigationItem.rightBarButtonItems?.first?.menu = menu
+        moreAndActionButton.menu = menu
+    }
+
+    private func updateRightBarButtonMenu(_ select: FolderDetailViewModel.Select) {
+        let dateSection: UIMenu = .init(
+            title: "",
+            options: .displayInline,
+            children: updateDateSectionChildren
+        )
+
+        let selectSection: UIMenu = .init(
+            title: "",
+            options: .displayInline,
+            children: updateSelectSectionChildren
+        )
+        let menu: UIMenu = .init(
+            title: "",
+            children: [dateSection, selectSection]
+        )
+        moreAndActionButton.menu = menu
     }
     
     private func setupDataSource() {
-        let cellRegistration = UICollectionView.CellRegistration {(
+        let cellRegistration = UICollectionView.CellRegistration {[weak self](
             cell: UICollectionViewListCell,
             indexPath: IndexPath,
             itemIdentifier: LibraryItem
         ) in
+            guard let self else { return }
             var backgroundConfig = UIBackgroundConfiguration.listCell()
             backgroundConfig.backgroundColor = .clear
             cell.backgroundConfiguration = backgroundConfig
@@ -176,17 +235,24 @@ public final class FolderDetailViewController: UICollectionViewController {
             switch itemIdentifier {
             case .folder(let folder):
                 cell.contentConfiguration = UIHostingConfiguration {
-                    VoiceNoteCardView(
-                        title: folder.name,
-                        subTitle: folder.createdAt.description
+                    FolderCardView(
+                        name: folder.name,
+                        totalCount: folder.content.count
                     )
                 }
             case .voiceNote(let voiceNote):
                 cell.contentConfiguration = UIHostingConfiguration {
                     VoiceNoteCardView(
-                        title: voiceNote.title,
-                        subTitle: voiceNote.createdAt.description
-                    )
+                        select: vm.select,
+                        isSelected: vm.selectedItems.contains(voiceNote),
+                        voiceNote: voiceNote
+                    ) { [weak self] data, state in
+                        if state {
+                            self?.vm.selectItem(data)
+                        } else {
+                            self?.vm.deselectItem(data)
+                        }
+                    }
                 }
             }
         }
@@ -218,23 +284,14 @@ extension FolderDetailViewController {
         }
     }
     
-    private func updateRightBarButtonMenu(_ select: FolderDetailViewModel.Select) {
-        let dateSection: UIMenu = .init(
-            title: "",
-            options: .displayInline,
-            children: updateDateSectionChildren
-        )
-
-        let selectSection: UIMenu = .init(
-            title: "",
-            options: .displayInline,
-            children: updateSelectSectionChildren
-        )
-        let menu: UIMenu = .init(
-            title: "",
-            children: [dateSection, selectSection]
-        )
-        navigationItem.rightBarButtonItems?.first?.menu = menu
+    private func updateNavigationItems(_ select: FolderDetailViewModel.Select) {
+        let isEditMode = (select != .none)
+        [backButton, moreAndActionButton, searchAndMoveButton].forEach {
+            $0.isSelected = isEditMode
+            $0.invalidateIntrinsicContentSize()
+            $0.sizeToFit()
+        }
+        moreAndActionButton.showsMenuAsPrimaryAction = !isEditMode
     }
     
     private var updateDateSectionChildren: [UIMenuElement] {
@@ -266,20 +323,52 @@ extension FolderDetailViewController {
     }
 }
 
-// MARK: - Delegate
+// MARK: - Helper Method
 
-public extension FolderDetailViewController {
-    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
+extension FolderDetailViewController {
+    func backButtonAction() -> UIAction {
+        UIAction { [weak self] _ in
+            guard let self else { return }
+            switch vm.select {
+            case .none:
+                vm.didTapBack()
+            case .all, .single:
+                vm.setSelectionMode(.none)
+            }
+        }
     }
 
-    override func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        
+    func moreAndActionButtonAction() -> UIAction {
+        UIAction { [weak self] _ in
+            guard let self else { return }
+            switch vm.select {
+            case .none:
+                // TODO: 더 보기 로직 실행
+                print("더 보기 버튼 탭됨")
+            case .all, .single:
+                // TODO: 삭제 로직 실행
+                print("삭제 버튼 탭됨")
+            }
+        }
+    }
+
+    func searchAndMoveButtonAction() -> UIAction {
+        UIAction { [weak self] _ in
+            guard let self else { return }
+            switch vm.select {
+            case .none:
+                // TODO: 검색 로직 실행
+                print("검색 버튼 탭됨")
+            case .all, .single:
+                // TODO: 이동 로직 실행
+                print("이동 버튼 탭됨")
+            }
+        }
     }
 }
 
 #if DEBUG
-    #Preview("개인 폴더 상세") {
+    #Preview("폴더 상세") {
         UINavigationController(
             rootViewController: FolderDetailViewController(
                 vm: .preview()

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -207,8 +207,12 @@ public final class FolderDetailViewController: CollectionViewController {
 
         primaryAlertButton.addAction(UIAction { [weak self] _ in
             guard let self else { return }
+            let restoreItems: [VoiceNote] = vm.selectedItems
             vm.move()
             vm.closeAlertView()
+            chagokBackgroundView.makeToast("휴지통으로 이동되었어요.") { [weak self] in
+                self?.vm.restore(items: restoreItems)
+            }
         }, for: .touchUpInside)
 
         view.addSubview(removeAlertOverlayView)
@@ -392,7 +396,7 @@ private extension FolderDetailViewController {
                 print("검색 버튼 탭됨")
             case .all, .single:
                 // TODO: 이동 로직 실행
-                print("이동 버튼 탭됨")
+                
                 vm.setSelectionMode(.none)
             }
         }

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -258,6 +258,8 @@ public final class FolderDetailViewController: CollectionViewController {
                         } else {
                             self?.vm.deselectItem(data)
                         }
+                    } completeAction: { [weak self] in
+                        self?.vm.pushVoiceNote(voiceNote: voiceNote)
                     }
                 }
             }
@@ -396,7 +398,7 @@ private extension FolderDetailViewController {
                 print("검색 버튼 탭됨")
             case .all, .single:
                 // TODO: 이동 로직 실행
-                
+                vm.presentMoveFolder()
                 vm.setSelectionMode(.none)
             }
         }

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -27,21 +27,50 @@ public final class FolderDetailViewController: UICollectionViewController {
 
     private lazy var createdAtAction = UIAction(
         title: "생성일 순"
-    ) { _ in
-        self.vm.touchCreatedAction()
+    ) { [weak self] _ in
+        self?.vm.setOrder(.createdAt)
     }
 
     private lazy var updatedAtAction = UIAction(
         title: "수정일 순"
-    ) { _ in
-        self.vm.touchUpdatedAction()
+    ) { [weak self] _ in
+        self?.vm.setOrder(.updatedAt)
     }
 
     private lazy var selectAction = UIAction(
-        title: vm.isSelectionMode ? "완료" : "선택하기",
-        image: UIImage(systemName: "checkmark.circle")
+        title: "선택하기",
+        image: nil
     ) { [weak self] _ in
-        self?.vm.toggleSelectionMode()
+        self?.vm.setSelectionMode(.single)
+    }
+    
+    private lazy var selectAllAction = UIAction(
+        title: "전체 선택하기",
+        image: nil
+    ) { [weak self] _ in
+        self?.vm.setSelectionMode(.all)
+    }
+    
+    private lazy var cancelAction = UIAction(
+        title: "취소하기",
+        image: nil
+    ) { [weak self] _ in
+        self?.vm.setSelectionMode(.none)
+    }
+    
+    private lazy var moveAction = UIAction(
+        title: "파일 이동하기",
+        image: nil
+    ) { [weak self] _ in
+        
+    }
+    
+    private lazy var deleteAction = UIAction(
+        title: "삭제하기",
+        image: nil,
+        attributes: .destructive
+    ) { [weak self] _ in
+        
     }
 
     private let vm: FolderDetailViewModel
@@ -81,32 +110,10 @@ public final class FolderDetailViewController: UICollectionViewController {
     override public func updateProperties() {
         super.updateProperties()
         // menu
-        switch vm.selectedOrder {
-        case .createdAt:
-            createdAtAction.image = UIImage(systemName: "checkmark")
-            updatedAtAction.image = nil
-        case .updatedAt:
-            createdAtAction.image = nil
-            updatedAtAction.image = UIImage(systemName: "checkmark")
-        }
-        selectAction.title = vm.isSelectionMode ? "완료" : "선택하기"
+        updateOrder(vm.order)
         // dataSource
-        collectionView.allowsMultipleSelection = vm.isSelectionMode
-        if !vm.isSelectionMode {
-            collectionView.indexPathsForSelectedItems?.forEach {
-                collectionView.deselectItem(at: $0, animated: false)
-            }
-        }
         updateDataSource(reconfigure: true)
-        updateRightBarButtonMenu()
-    }
-
-    private func updateRightBarButtonMenu() {
-        let menu = UIMenu(
-            title: "",
-            children: [createdAtAction, updatedAtAction, selectAction]
-        )
-        navigationItem.rightBarButtonItems?.first?.menu = menu
+        updateRightBarButtonMenu(vm.select)
     }
 
     private func setupNavigation() {
@@ -130,25 +137,41 @@ public final class FolderDetailViewController: UICollectionViewController {
             UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: nil),
             UIBarButtonItem(image: UIImage(systemName: "magnifyingglass"), menu: nil)
         ]
-        updateRightBarButtonMenu()
+        setupRightBarButtonMenu()
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
         navigationItem.rightBarButtonItems?.forEach {
             $0.hidesSharedBackground = true
         }
     }
 
+    private func setupRightBarButtonMenu() {
+        let dateSection: UIMenu = .init(
+            title: "",
+            options: .displayInline,
+            children: [createdAtAction, updatedAtAction]
+        )
+        
+        let selectSection: UIMenu = .init(
+            title: "",
+            options: .displayInline,
+            children: [selectAction, selectAllAction]
+        )
+        let menu: UIMenu = .init(
+            title: "",
+            children: [dateSection, selectSection]
+        )
+        navigationItem.rightBarButtonItems?.first?.menu = menu
+    }
+    
     private func setupDataSource() {
-        let cellRegistration = UICollectionView.CellRegistration { [weak self] (
+        let cellRegistration = UICollectionView.CellRegistration {(
             cell: UICollectionViewListCell,
             indexPath: IndexPath,
             itemIdentifier: LibraryItem
         ) in
-            guard let self else { return }
             var backgroundConfig = UIBackgroundConfiguration.listCell()
             backgroundConfig.backgroundColor = .clear
             cell.backgroundConfiguration = backgroundConfig
-
-            cell.accessories = vm.isSelectionMode ? [.multiselect(displayed: .always)] : []
 
             switch itemIdentifier {
             case .folder(let folder):
@@ -179,7 +202,59 @@ public final class FolderDetailViewController: UICollectionViewController {
             }
         )
     }
+}
 
+// MARK: - Update Method
+
+extension FolderDetailViewController {
+    private func updateOrder(_ order: FolderDetailViewModel.Order) {
+        switch order {
+        case .createdAt:
+            createdAtAction.image = UIImage(systemName: "checkmark")
+            updatedAtAction.image = nil
+        case .updatedAt:
+            createdAtAction.image = nil
+            updatedAtAction.image = UIImage(systemName: "checkmark")
+        }
+    }
+    
+    private func updateRightBarButtonMenu(_ select: FolderDetailViewModel.Select) {
+        let dateSection: UIMenu = .init(
+            title: "",
+            options: .displayInline,
+            children: updateDateSectionChildren
+        )
+
+        let selectSection: UIMenu = .init(
+            title: "",
+            options: .displayInline,
+            children: updateSelectSectionChildren
+        )
+        let menu: UIMenu = .init(
+            title: "",
+            children: [dateSection, selectSection]
+        )
+        navigationItem.rightBarButtonItems?.first?.menu = menu
+    }
+    
+    private var updateDateSectionChildren: [UIMenuElement] {
+        switch vm.select {
+        case .none:
+            [createdAtAction, updatedAtAction]
+        case .all, .single:
+            []
+        }
+    }
+    
+    private var updateSelectSectionChildren: [UIMenuElement] {
+        switch vm.select {
+        case .none:
+            [selectAction, selectAllAction]
+        case .all, .single:
+            [cancelAction, moveAction, deleteAction]
+        }
+    }
+    
     private func updateDataSource(reconfigure: Bool = false) {
         var snapshot = SnapShot()
         snapshot.appendSections([.main])
@@ -195,18 +270,20 @@ public final class FolderDetailViewController: UICollectionViewController {
 
 public extension FolderDetailViewController {
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard vm.isSelectionMode, let item = dataSource?.itemIdentifier(for: indexPath) else { return }
-
-        if case .voiceNote(let voiceNote) = item {
-            vm.selectItem(voiceNote)
-        }
+        
     }
 
     override func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        guard vm.isSelectionMode, let item = dataSource?.itemIdentifier(for: indexPath) else { return }
-
-        if case .voiceNote(let voiceNote) = item {
-            vm.deselectItem(voiceNote)
-        }
+        
     }
 }
+
+#if DEBUG
+    #Preview("개인 폴더 상세") {
+        UINavigationController(
+            rootViewController: FolderDetailViewController(
+                vm: .preview()
+            )
+        )
+    }
+#endif

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -13,7 +13,7 @@ public final class FolderDetailViewController: CollectionViewController {
     private var dataSource: DataSource?
 
     // MARK: - Component
-    
+
     private lazy var backButton: UIButton = {
         let btn = UIButton(type: .custom) // .system 대신 .custom을 사용하여 기본 배경 효과 제거
         let symbolConfig = UIImage.SymbolConfiguration(weight: .bold)
@@ -77,14 +77,14 @@ public final class FolderDetailViewController: CollectionViewController {
     ) { [weak self] _ in
         self?.vm.setSelectionMode(.single)
     }
-    
+
     private lazy var selectAllAction = UIAction(
         title: "전체 선택하기",
         image: nil
     ) { [weak self] _ in
         self?.vm.setSelectionMode(.all)
     }
-    
+
     private let cancelAlertButton: GlassButton = .close("취소")
     private let primaryAlertButton: GlassButton = .danger("삭제")
     private let removeAlertOverlayView: UIView = {
@@ -186,7 +186,7 @@ public final class FolderDetailViewController: CollectionViewController {
             options: .displayInline,
             children: [createdAtAction, updatedAtAction]
         )
-        
+
         let selectSection: UIMenu = .init(
             title: "",
             options: .displayInline,
@@ -198,7 +198,7 @@ public final class FolderDetailViewController: CollectionViewController {
         )
         moreAndActionButton.menu = menu
     }
-    
+
     private func setupRemoveAlert() {
         cancelAlertButton.addAction(UIAction { [weak self] _ in
             guard let self else { return }
@@ -226,9 +226,9 @@ public final class FolderDetailViewController: CollectionViewController {
             removeAlertView.centerYAnchor.constraint(equalTo: removeAlertOverlayView.centerYAnchor)
         ])
     }
-    
+
     private func setupDataSource() {
-        let cellRegistration = UICollectionView.CellRegistration {[weak self](
+        let cellRegistration = UICollectionView.CellRegistration { [weak self] (
             cell: UICollectionViewListCell,
             indexPath: IndexPath,
             itemIdentifier: LibraryItem
@@ -291,54 +291,54 @@ extension FolderDetailViewController {
             updatedAtAction.image = UIImage(systemName: "checkmark")
         }
     }
-    
-    private func updateRightBarButtonMenu(_ select: FolderDetailViewModel.Select) {
-            let dateSection: UIMenu = .init(
-                title: "",
-                options: .displayInline,
-                children: updateDateSectionChildren
-            )
 
-            let selectSection: UIMenu = .init(
-                title: "",
-                options: .displayInline,
-                children: updateSelectSectionChildren
-            )
-            let menu: UIMenu = .init(
-                title: "",
-                children: [dateSection, selectSection]
-            )
-            moreAndActionButton.menu = menu
+    private func updateRightBarButtonMenu(_ select: FolderDetailViewModel.Select) {
+        let dateSection: UIMenu = .init(
+            title: "",
+            options: .displayInline,
+            children: updateDateSectionChildren
+        )
+
+        let selectSection: UIMenu = .init(
+            title: "",
+            options: .displayInline,
+            children: updateSelectSectionChildren
+        )
+        let menu: UIMenu = .init(
+            title: "",
+            children: [dateSection, selectSection]
+        )
+        moreAndActionButton.menu = menu
+    }
+
+    private var updateDateSectionChildren: [UIMenuElement] {
+        switch vm.select {
+        case .none:
+            [createdAtAction, updatedAtAction]
+        case .all, .single:
+            []
         }
-    
-        private var updateDateSectionChildren: [UIMenuElement] {
-            switch vm.select {
-            case .none:
-                [createdAtAction, updatedAtAction]
-            case .all, .single:
-                []
-            }
+    }
+
+    private var updateSelectSectionChildren: [UIMenuElement] {
+        switch vm.select {
+        case .none:
+            [selectAction, selectAllAction]
+        case .all, .single:
+            []
         }
-        
-        private var updateSelectSectionChildren: [UIMenuElement] {
-            switch vm.select {
-            case .none:
-                [selectAction, selectAllAction]
-            case .all, .single:
-                []
-            }
-        }
-    
+    }
+
     private func updateNavigationItems(_ select: FolderDetailViewModel.Select) {
         let isEditMode = (select != .none)
-        [backButton, moreAndActionButton, searchAndMoveButton].forEach {
-            $0.isSelected = isEditMode
-            $0.invalidateIntrinsicContentSize()
-            $0.sizeToFit()
+        for item in [backButton, moreAndActionButton, searchAndMoveButton] {
+            item.isSelected = isEditMode
+            item.invalidateIntrinsicContentSize()
+            item.sizeToFit()
         }
         moreAndActionButton.showsMenuAsPrimaryAction = !isEditMode
     }
-    
+
     private func updateDataSource(reconfigure: Bool = false) {
         var snapshot = SnapShot()
         snapshot.appendSections([.main])
@@ -348,7 +348,7 @@ extension FolderDetailViewController {
         }
         dataSource?.apply(snapshot, animatingDifferences: true)
     }
-    
+
     private func updateRemoveAlert() {
         let shouldShowAlert = vm.showAlert
         removeAlertOverlayView.isHidden = !shouldShowAlert
@@ -403,7 +403,7 @@ private extension FolderDetailViewController {
             }
         }
     }
-    
+
     func updateInteractionForAlert(isPresented: Bool) {
         collectionView.isUserInteractionEnabled = !isPresented
         backButton.isUserInteractionEnabled = !isPresented

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -221,12 +221,7 @@ extension FolderViewController {
                         )
                     case .voiceNote(let data):
                         VoiceNoteCardView(
-                            title: data.title,
-                            subTitle: Date.now.voiceNoteDay(
-                                createdAt: data.createdAt,
-                                updatedAt: data.updatedAt,
-                                duration: data.voiceRecord.duration
-                            )
+                            voiceNote: data
                         )
                     }
                 }

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -159,6 +159,7 @@ public final class FolderViewController: CollectionViewController {
         cancelButton.addAction(
             UIAction { [weak self] _ in
                 guard let self else { return }
+                textField.endEditing(true)
                 textField.field.text = ""
                 vm.closeTextField()
             },
@@ -177,6 +178,7 @@ public final class FolderViewController: CollectionViewController {
                 case .edit:
                     vm.update(name: name)
                 }
+                textField.endEditing(true)
                 textField.field.text = ""
             },
             for: .touchUpInside

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -164,11 +164,11 @@ public final class MainViewController: ViewController {
                     )
                 case .voiceNote(let data):
                     VoiceNoteCardView(
-                        voiceNote: data
+                        voiceNote: data,
+                        completeAction: { [weak self] in
+                            self?.vm.pushVoiceNoteView(voiceNote: data)
+                        }
                     )
-                    .onTapGesture { [weak self] in
-                        self?.vm.pushVoiceNoteView(voiceNote: data)
-                    }
                 }
             }
             .margins(.all, 0)

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -158,18 +158,13 @@ public final class MainViewController: ViewController {
             cell.contentConfiguration = UIHostingConfiguration {
                 switch item {
                 case .folder(let data):
-                    VoiceNoteCardView(
-                        title: data.name,
-                        subTitle: data.createdAt.description
+                    FolderCardView(
+                        name: data.name,
+                        totalCount: data.content.count
                     )
                 case .voiceNote(let data):
                     VoiceNoteCardView(
-                        title: data.title,
-                        subTitle: Date.now.voiceNoteDay(
-                            createdAt: data.createdAt,
-                            updatedAt: data.updatedAt,
-                            duration: data.voiceRecord.duration
-                        )
+                        voiceNote: data
                     )
                     .onTapGesture { [weak self] in
                         self?.vm.pushVoiceNoteView(voiceNote: data)

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -194,16 +194,12 @@ public final class TrashViewController: UICollectionViewController {
             switch itemIdentifier {
             case .folder(let folder):
                 cell.contentConfiguration = UIHostingConfiguration {
-                    VoiceNoteCardView(
-                        title: folder.name,
-                        subTitle: folder.createdAt.description
-                    )
+                    FolderCardView(name: folder.name, totalCount: folder.content.count)
                 }
             case .voiceNote(let voiceNote):
                 cell.contentConfiguration = UIHostingConfiguration {
                     VoiceNoteCardView(
-                        title: voiceNote.title,
-                        subTitle: voiceNote.createdAt.description
+                        voiceNote: voiceNote
                     )
                 }
             }

--- a/Presentation/Sources/ViewModel/CoordinatorDelegate/BaseCoordinatorDelegate.swift
+++ b/Presentation/Sources/ViewModel/CoordinatorDelegate/BaseCoordinatorDelegate.swift
@@ -1,6 +1,21 @@
 import Foundation
+import Domain
 
 @MainActor
 public protocol BaseCoordinatorDelegate: AnyObject {
+    /// 뒤로가기
     func pop()
+    /// 폴더 Sheet 열기
+    func presentFolderList(with: Receive, dismiss: (() -> Void)?)
+}
+
+public enum Receive: Hashable {
+    case single(VoiceNote)
+    case multiple([VoiceNote])
+}
+
+public extension BaseCoordinatorDelegate {
+    func presentFolderList(with receive: Receive) {
+        presentFolderList(with: receive, dismiss: nil)
+    }
 }

--- a/Presentation/Sources/ViewModel/CoordinatorDelegate/BaseCoordinatorDelegate.swift
+++ b/Presentation/Sources/ViewModel/CoordinatorDelegate/BaseCoordinatorDelegate.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Domain
+import Foundation
 
 @MainActor
 public protocol BaseCoordinatorDelegate: AnyObject {

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -25,6 +25,7 @@ public final class FolderDetailViewModel {
     private(set) var order: Order = .createdAt
     private(set) var select: Select = .none
     private(set) var selectedItems: [VoiceNote] = []
+    private(set) var showAlert: Bool = false
 
     public weak var coordinator: BaseCoordinatorDelegate?
 
@@ -93,6 +94,14 @@ extension FolderDetailViewModel {
     private func allClearSelected() {
         selectedItems = []
     }
+
+    func closeAlertView() {
+        self.showAlert = false
+    }
+    
+    func openAlertView() {
+        self.showAlert = true
+    }
 }
 
 // MARK: - Fetch
@@ -138,7 +147,7 @@ extension FolderDetailViewModel {
 // MARK: - Move ( delete )
 extension FolderDetailViewModel {
     func move() {
-        let items: [WasteBasketItem] = items.map(\.toWasteBasketItem)
+        let items: [WasteBasketItem] = selectedItems.map{ .voiceNote(obj: $0) }
         do {
             try wasteBasketRepository.moveAllToWasteBasket(items: items)
         } catch {

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -7,6 +7,12 @@ import Foundation
 public final class FolderDetailViewModel {
     // MARK: - State
 
+    enum Select {
+        case none
+        case all
+        case single
+    }
+    
     enum Order {
         case createdAt
         case updatedAt
@@ -16,8 +22,8 @@ public final class FolderDetailViewModel {
     let folderID: UUID
     private(set) var items: [LibraryItem] = []
     private(set) var errorMessage: String?
-    private(set) var selectedOrder: Order = .createdAt
-    private(set) var isSelectionMode: Bool = false
+    private(set) var order: Order = .createdAt
+    private(set) var select: Select = .none
     private(set) var selectedItems: [VoiceNote] = []
 
     var isEmpty: Bool {
@@ -47,13 +53,13 @@ public final class FolderDetailViewModel {
 // MARK: - Setter / Getter
 
 extension FolderDetailViewModel {
-    private func setSelectedOrder(_ order: Order) {
-        selectedOrder = order
+    func setOrder(_ order: Order) {
+        self.order = order
         sortItems()
     }
 
     private func sortItems() {
-        switch selectedOrder {
+        switch order {
         case .createdAt:
             items.sort {
                 switch ($0, $1) {
@@ -75,11 +81,8 @@ extension FolderDetailViewModel {
         }
     }
 
-    func toggleSelectionMode() {
-        isSelectionMode.toggle()
-        if !isSelectionMode {
-            selectedItems.removeAll()
-        }
+    func setSelectionMode(_ select: Select) {
+        self.select = select
     }
 
     func selectItem(_ item: VoiceNote) {
@@ -88,14 +91,6 @@ extension FolderDetailViewModel {
 
     func deselectItem(_ item: VoiceNote) {
         selectedItems.removeAll { $0.id == item.id }
-    }
-
-    func touchCreatedAction() {
-        setSelectedOrder(.createdAt)
-    }
-
-    func touchUpdatedAction() {
-        setSelectedOrder(.updatedAt)
     }
 }
 
@@ -113,7 +108,7 @@ extension FolderDetailViewModel {
     func fetchItems() {
         Task {
             do {
-                let voiceNotes: [VoiceNote] = try await voiceNoteUseCase.fetchAll(folderID: folderID)
+                let voiceNotes: [VoiceNote] = try voiceNoteUseCase.fetchAll(folderID: folderID)
                 self.items = voiceNotes.map { .voiceNote($0) }
                 sortItems()
             } catch {
@@ -123,3 +118,95 @@ extension FolderDetailViewModel {
         }
     }
 }
+
+#if DEBUG
+    extension FolderDetailViewModel {
+        static func preview(
+            title: String = "개인 폴더",
+            folderID: UUID = UUID()
+        ) -> FolderDetailViewModel {
+            let previewData = PreviewData.make(folderID: folderID)
+
+            return FolderDetailViewModel(
+                title: title,
+                folderID: folderID,
+                voiceNoteUseCase: PreviewVoiceNoteUseCase(items: previewData.items)
+            )
+        }
+    }
+
+    private extension FolderDetailViewModel {
+        struct PreviewData {
+            let items: [VoiceNote]
+
+            static func make(folderID: UUID, now: Date = .now) -> Self {
+                let items: [VoiceNote] = (0 ..< 12).map { index in
+                    let createdOffset = TimeInterval((index + 1) * 3600) * -1
+                    let updatedOffset = TimeInterval((index + 1) * 1800) * -1
+                    return VoiceNote(
+                        title: "폴더 상세 메모 \(index + 1)",
+                        createdAt: now.addingTimeInterval(createdOffset),
+                        updatedAt: now.addingTimeInterval(updatedOffset),
+                        folderID: folderID,
+                        voiceRecord: VoiceRecord(
+                            audioFilePath: "preview-\(index + 1).m4a",
+                            duration: Double(90 + (index * 15))
+                        )
+                    )
+                }
+                return PreviewData(items: items)
+            }
+        }
+
+        struct PreviewVoiceNoteUseCase: VoiceNoteUseCase {
+            let items: [VoiceNote]
+
+            func create(_ voiceRecord: VoiceRecord) throws(VoiceNoteUseCaseError) -> VoiceNote {
+                VoiceNote(
+                    title: "미리보기 기록",
+                    createdAt: .now,
+                    updatedAt: .now,
+                    folderID: UUID(),
+                    voiceRecord: voiceRecord,
+                    keywords: [],
+                    transcript: nil,
+                    summary: nil
+                )
+            }
+
+            func fetchAllFromDefaultFolder() throws(VoiceNoteUseCaseError) -> [VoiceNote] {
+                items
+            }
+
+            func fetchAll(folderID: UUID) throws(VoiceNoteUseCaseError) -> [VoiceNote] {
+                items.filter { $0.folderID == folderID }
+            }
+
+            func fetch(byId id: UUID) throws(VoiceNoteUseCaseError) -> VoiceNote {
+                guard let item = items.first(where: { $0.id == id }) else {
+                    throw .recordNotFound(id)
+                }
+                return item
+            }
+
+            func fetchRecent(limit: Int) throws(VoiceNoteUseCaseError) -> [VoiceNote] {
+                Array(items.prefix(limit))
+            }
+
+            func update(_ voiceNote: VoiceNote) throws(VoiceNoteUseCaseError) -> VoiceNote {
+                voiceNote
+            }
+
+            func summarize(
+                audioFilePath: String,
+                language: Language
+            ) async throws(VoiceNoteUseCaseError) -> AudioToSummaryResult {
+                AudioToSummaryResult(
+                    transcript: Transcript(text: ""),
+                    keywords: [],
+                    summary: Summary(text: "")
+                )
+            }
+        }
+    }
+#endif

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -6,8 +6,8 @@ import Foundation
 @Observable
 public final class FolderDetailViewModel {
     // MARK: - State
-
-    enum Select {
+    
+    enum Select: Equatable {
         case none
         case all
         case single
@@ -23,7 +23,7 @@ public final class FolderDetailViewModel {
     private(set) var items: [LibraryItem] = []
     private(set) var errorMessage: String?
     private(set) var order: Order = .createdAt
-    private(set) var select: Select = .none
+    var select: Select = .none
     private(set) var selectedItems: [VoiceNote] = []
 
     var isEmpty: Bool {
@@ -86,7 +86,7 @@ extension FolderDetailViewModel {
     }
 
     func selectItem(_ item: VoiceNote) {
-        selectedItems.insert(item, at: 0)
+        selectedItems.append(item)
     }
 
     func deselectItem(_ item: VoiceNote) {
@@ -122,7 +122,7 @@ extension FolderDetailViewModel {
 #if DEBUG
     extension FolderDetailViewModel {
         static func preview(
-            title: String = "개인 폴더",
+            title: String = "폴더 상세",
             folderID: UUID = UUID()
         ) -> FolderDetailViewModel {
             let previewData = PreviewData.make(folderID: folderID)

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -147,13 +147,37 @@ extension FolderDetailViewModel {
 // MARK: - Move ( delete )
 extension FolderDetailViewModel {
     func move() {
-        let items: [WasteBasketItem] = selectedItems.map{ .voiceNote(obj: $0) }
+        guard !selectedItems.isEmpty else { return }
+        let wasteBasketItems: [WasteBasketItem] = selectedItems.map { .voiceNote(obj: $0) }
         do {
-            try wasteBasketRepository.moveAllToWasteBasket(items: items)
+            try wasteBasketRepository.moveAllToWasteBasket(items: wasteBasketItems)
+            // 성공 시, 로컬 items에서 제거하여 UI에 즉시 반영
+            let selectedIDs = Set(selectedItems.map { $0.id })
+            items.removeAll { item in
+                if case .voiceNote(let v) = item { return selectedIDs.contains(v.id) }
+                return false
+            }
+            setSelectionMode(.none)
         } catch {
             AppLogger.error(error)
             errorMessage = error.errorDescription
         }
+    }
+}
+
+// MARK: - Restore (휴지통 이동 복구)
+extension FolderDetailViewModel {
+    func restore(items: [VoiceNote]) {
+        for item in items {
+            let wasteBasket: WasteBasketItem = .voiceNote(obj: item)
+            do {
+                try wasteBasketRepository.restore(item: wasteBasket)
+            } catch {
+                AppLogger.error(error)
+                errorMessage = error.errorDescription
+            }
+        }
+        fetchItems()
     }
 }
 
@@ -248,15 +272,50 @@ extension FolderDetailViewModel {
             }
         }
 
-        struct PreviewWasteBasketRepository: WasteBasketRepository {
-            func allClear() throws(DeleteWasteBasketRepositoryError) {}
-            func delete(item: WasteBasketItem) throws(DeleteWasteBasketRepositoryError) {}
-            func deleteAll(items: [WasteBasketItem]) throws(DeleteWasteBasketRepositoryError) {}
-            func moveToWasteBasket(item: WasteBasketItem) throws(MoveWasteBasketRepositoryError) {}
-            func moveAllToWasteBasket(items: [WasteBasketItem]) throws(MoveWasteBasketRepositoryError) {}
-            func fetchAll() throws(FetchWasteBasketRepositoryError) -> [WasteBasketItem] { [] }
-            func restore(item: WasteBasketItem) throws(RestoreWasteBasketRepositoryError) {}
-            func restoreAll(items: [WasteBasketItem]) throws(RestoreWasteBasketRepositoryError) {}
+        final class PreviewWasteBasketRepository: WasteBasketRepository {
+            private var wasteBasket: [WasteBasketItem] = []
+
+            func allClear() throws(DeleteWasteBasketRepositoryError) {
+                wasteBasket.removeAll()
+                print("[Preview] 휴지통 비우기 완료")
+            }
+
+            func delete(item: WasteBasketItem) throws(DeleteWasteBasketRepositoryError) {
+                wasteBasket.removeAll { $0 == item }
+                print("[Preview] 영구 삭제: \(item)")
+            }
+
+            func deleteAll(items: [WasteBasketItem]) throws(DeleteWasteBasketRepositoryError) {
+                let itemSet = Set(items)
+                wasteBasket.removeAll { itemSet.contains($0) }
+                print("[Preview] 영구 삭제: \(items.count)개")
+            }
+
+            func moveToWasteBasket(item: WasteBasketItem) throws(MoveWasteBasketRepositoryError) {
+                wasteBasket.append(item)
+                print("[Preview] 휴지통 이동: \(item)")
+            }
+
+            func moveAllToWasteBasket(items: [WasteBasketItem]) throws(MoveWasteBasketRepositoryError) {
+                wasteBasket.append(contentsOf: items)
+                print("[Preview] 휴지통 이동: \(items.count)개 (현재 휴지통: \(wasteBasket.count)개)")
+            }
+
+            func fetchAll() throws(FetchWasteBasketRepositoryError) -> [WasteBasketItem] {
+                print("[Preview] 휴지통 조회: \(wasteBasket.count)개")
+                return wasteBasket
+            }
+
+            func restore(item: WasteBasketItem) throws(RestoreWasteBasketRepositoryError) {
+                wasteBasket.removeAll { $0 == item }
+                print("[Preview] 복원: \(item)")
+            }
+
+            func restoreAll(items: [WasteBasketItem]) throws(RestoreWasteBasketRepositoryError) {
+                let itemSet = Set(items)
+                wasteBasket.removeAll { itemSet.contains($0) }
+                print("[Preview] 복원: \(items.count)개")
+            }
         }
     }
 

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -11,13 +11,13 @@ public protocol FolderDetailCoordinatorDelegate: BaseCoordinatorDelegate {
 @Observable
 public final class FolderDetailViewModel {
     // MARK: - State
-    
+
     enum Select: Equatable {
         case none
         case all
         case single
     }
-    
+
     enum Order {
         case createdAt
         case updatedAt
@@ -88,12 +88,12 @@ extension FolderDetailViewModel {
     func didTapBack() {
         coordinator?.pop()
     }
-    
+
     /// 음성 노트 화면 전환
     func pushVoiceNote(voiceNote: VoiceNote) {
         coordinator?.pushVoiceNoteView(voiceNote: voiceNote)
     }
-    
+
     /// 폴더 이동 Present
     func presentMoveFolder() {
         guard !selectedItems.isEmpty else { return }
@@ -101,7 +101,7 @@ extension FolderDetailViewModel {
             self?.fetchItems()
         })
     }
-    
+
     /// 전체 선택
     private func allSelected() {
         selectedItems = items.compactMap {
@@ -109,17 +109,18 @@ extension FolderDetailViewModel {
             return nil
         }
     }
+
     /// 전체 선택 해제
     private func allClearSelected() {
         selectedItems = []
     }
 
     func closeAlertView() {
-        self.showAlert = false
+        showAlert = false
     }
-    
+
     func openAlertView() {
-        self.showAlert = true
+        showAlert = true
     }
 }
 
@@ -138,7 +139,7 @@ extension FolderDetailViewModel {
             }
         }
     }
-    
+
     private func sortItems() {
         switch order {
         case .createdAt:
@@ -164,6 +165,7 @@ extension FolderDetailViewModel {
 }
 
 // MARK: - Move ( delete )
+
 extension FolderDetailViewModel {
     func move() {
         guard !selectedItems.isEmpty else { return }
@@ -171,7 +173,7 @@ extension FolderDetailViewModel {
         do {
             try wasteBasketRepository.moveAllToWasteBasket(items: wasteBasketItems)
             // 성공 시, 로컬 items에서 제거하여 UI에 즉시 반영
-            let selectedIDs = Set(selectedItems.map { $0.id })
+            let selectedIDs = Set(selectedItems.map(\.id))
             items.removeAll { item in
                 if case .voiceNote(let v) = item { return selectedIDs.contains(v.id) }
                 return false
@@ -185,6 +187,7 @@ extension FolderDetailViewModel {
 }
 
 // MARK: - Restore (휴지통 이동 복구)
+
 extension FolderDetailViewModel {
     func restore(items: [VoiceNote]) {
         for item in items {

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -23,29 +23,28 @@ public final class FolderDetailViewModel {
     private(set) var items: [LibraryItem] = []
     private(set) var errorMessage: String?
     private(set) var order: Order = .createdAt
-    var select: Select = .none
+    private(set) var select: Select = .none
     private(set) var selectedItems: [VoiceNote] = []
-
-    var isEmpty: Bool {
-        items.isEmpty
-    }
 
     public weak var coordinator: BaseCoordinatorDelegate?
 
     // MARK: - UseCase
 
     private let voiceNoteUseCase: any VoiceNoteUseCase
+    private let wasteBasketRepository: any WasteBasketRepository
 
     // MARK: - Initialize
 
     public init(
         title: String,
         folderID: UUID,
-        voiceNoteUseCase: any VoiceNoteUseCase
+        voiceNoteUseCase: any VoiceNoteUseCase,
+        wasteBasketRepository: any WasteBasketRepository
     ) {
         self.title = title
         self.folderID = folderID
         self.voiceNoteUseCase = voiceNoteUseCase
+        self.wasteBasketRepository = wasteBasketRepository
         sortItems()
     }
 }
@@ -58,6 +57,60 @@ extension FolderDetailViewModel {
         sortItems()
     }
 
+    func setSelectionMode(_ select: Select) {
+        self.select = select
+        if select == .none {
+            allClearSelected()
+        } else if select == .all {
+            allSelected()
+        }
+    }
+
+    func selectItem(_ item: VoiceNote) {
+        selectedItems.append(item)
+    }
+
+    func deselectItem(_ item: VoiceNote) {
+        selectedItems.removeAll { $0.id == item.id }
+    }
+}
+
+// MARK: Action
+
+extension FolderDetailViewModel {
+    /// 뒤로가기
+    func didTapBack() {
+        coordinator?.pop()
+    }
+    /// 전체 선택
+    private func allSelected() {
+        selectedItems = items.compactMap {
+            if case .voiceNote(let voiceNote) = $0 { return voiceNote }
+            return nil
+        }
+    }
+    /// 전체 선택 해제
+    private func allClearSelected() {
+        selectedItems = []
+    }
+}
+
+// MARK: - Fetch
+
+extension FolderDetailViewModel {
+    func fetchItems() {
+        Task {
+            do {
+                let voiceNotes: [VoiceNote] = try voiceNoteUseCase.fetchAll(folderID: folderID)
+                self.items = voiceNotes.map { .voiceNote($0) }
+                sortItems()
+            } catch {
+                AppLogger.error(error)
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+    
     private func sortItems() {
         switch order {
         case .createdAt:
@@ -80,41 +133,17 @@ extension FolderDetailViewModel {
             }
         }
     }
-
-    func setSelectionMode(_ select: Select) {
-        self.select = select
-    }
-
-    func selectItem(_ item: VoiceNote) {
-        selectedItems.append(item)
-    }
-
-    func deselectItem(_ item: VoiceNote) {
-        selectedItems.removeAll { $0.id == item.id }
-    }
 }
 
-// MARK: Action
-
+// MARK: - Move ( delete )
 extension FolderDetailViewModel {
-    func didTapBack() {
-        coordinator?.pop()
-    }
-}
-
-// MARK: - Fetch
-
-extension FolderDetailViewModel {
-    func fetchItems() {
-        Task {
-            do {
-                let voiceNotes: [VoiceNote] = try voiceNoteUseCase.fetchAll(folderID: folderID)
-                self.items = voiceNotes.map { .voiceNote($0) }
-                sortItems()
-            } catch {
-                AppLogger.error(error)
-                errorMessage = error.localizedDescription
-            }
+    func move() {
+        let items: [WasteBasketItem] = items.map(\.toWasteBasketItem)
+        do {
+            try wasteBasketRepository.moveAllToWasteBasket(items: items)
+        } catch {
+            AppLogger.error(error)
+            errorMessage = error.errorDescription
         }
     }
 }
@@ -130,7 +159,8 @@ extension FolderDetailViewModel {
             return FolderDetailViewModel(
                 title: title,
                 folderID: folderID,
-                voiceNoteUseCase: PreviewVoiceNoteUseCase(items: previewData.items)
+                voiceNoteUseCase: PreviewVoiceNoteUseCase(items: previewData.items),
+                wasteBasketRepository: PreviewWasteBasketRepository()
             )
         }
     }
@@ -208,5 +238,17 @@ extension FolderDetailViewModel {
                 )
             }
         }
+
+        struct PreviewWasteBasketRepository: WasteBasketRepository {
+            func allClear() throws(DeleteWasteBasketRepositoryError) {}
+            func delete(item: WasteBasketItem) throws(DeleteWasteBasketRepositoryError) {}
+            func deleteAll(items: [WasteBasketItem]) throws(DeleteWasteBasketRepositoryError) {}
+            func moveToWasteBasket(item: WasteBasketItem) throws(MoveWasteBasketRepositoryError) {}
+            func moveAllToWasteBasket(items: [WasteBasketItem]) throws(MoveWasteBasketRepositoryError) {}
+            func fetchAll() throws(FetchWasteBasketRepositoryError) -> [WasteBasketItem] { [] }
+            func restore(item: WasteBasketItem) throws(RestoreWasteBasketRepositoryError) {}
+            func restoreAll(items: [WasteBasketItem]) throws(RestoreWasteBasketRepositoryError) {}
+        }
     }
+
 #endif

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -2,6 +2,11 @@ import Core
 import Domain
 import Foundation
 
+public protocol FolderDetailCoordinatorDelegate: BaseCoordinatorDelegate {
+    /// 음성노트로 이동
+    func pushVoiceNoteView(voiceNote: VoiceNote)
+}
+
 @MainActor
 @Observable
 public final class FolderDetailViewModel {
@@ -27,7 +32,7 @@ public final class FolderDetailViewModel {
     private(set) var selectedItems: [VoiceNote] = []
     private(set) var showAlert: Bool = false
 
-    public weak var coordinator: BaseCoordinatorDelegate?
+    public weak var coordinator: FolderDetailCoordinatorDelegate?
 
     // MARK: - UseCase
 
@@ -83,6 +88,20 @@ extension FolderDetailViewModel {
     func didTapBack() {
         coordinator?.pop()
     }
+    
+    /// 음성 노트 화면 전환
+    func pushVoiceNote(voiceNote: VoiceNote) {
+        coordinator?.pushVoiceNoteView(voiceNote: voiceNote)
+    }
+    
+    /// 폴더 이동 Present
+    func presentMoveFolder() {
+        guard !selectedItems.isEmpty else { return }
+        coordinator?.presentFolderList(with: .multiple(selectedItems), dismiss: { [weak self] in
+            self?.fetchItems()
+        })
+    }
+    
     /// 전체 선택
     private func allSelected() {
         selectedItems = items.compactMap {

--- a/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
@@ -55,12 +55,11 @@ public final class MoveFolderListViewModel {
 
     private func fetchFolders() async {
         do {
-            var voiceNote: VoiceNote
-            switch receive {
+            var voiceNote: VoiceNote = switch receive {
             case .single(let item):
-                voiceNote = item
+                item
             case .multiple(let items):
-                voiceNote = items.first!
+                items.first!
             }
             let folders = try folderUseCase.fetchAll()
             let otherFolders = folders.filter { $0.id != voiceNote.folderID }
@@ -77,7 +76,7 @@ public final class MoveFolderListViewModel {
             case .single(var voiceNote):
                 voiceNote.folderID = selectedFolder.id
                 _ = try voiceNoteUseCase.update(voiceNote)
-                
+
             case .multiple(let voiceNotes):
                 for var voiceNote in voiceNotes {
                     voiceNote.folderID = selectedFolder.id

--- a/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
@@ -13,18 +13,21 @@ public final class MoveFolderListViewModel {
     public weak var coordinator: MoveFolderListCoordinatorDelegate?
     private(set) var state: State = .init()
 
-    private let voiceNote: VoiceNote
+    private let receive: Receive
     private let folderUseCase: any FolderUseCase
     private let voiceNoteUseCase: any VoiceNoteUseCase
+    private let onDismiss: (() -> Void)?
 
     public init(
-        voiceNote: VoiceNote,
+        receive: Receive,
         folderUseCase: any FolderUseCase,
-        voiceNoteUseCase: any VoiceNoteUseCase
+        voiceNoteUseCase: any VoiceNoteUseCase,
+        onDismiss: (() -> Void)? = nil
     ) {
-        self.voiceNote = voiceNote
+        self.receive = receive
         self.folderUseCase = folderUseCase
         self.voiceNoteUseCase = voiceNoteUseCase
+        self.onDismiss = onDismiss
     }
 
     func send(_ action: Action) {
@@ -52,7 +55,14 @@ public final class MoveFolderListViewModel {
 
     private func fetchFolders() async {
         do {
-            let folders = try await folderUseCase.fetchAll()
+            var voiceNote: VoiceNote
+            switch receive {
+            case .single(let item):
+                voiceNote = item
+            case .multiple(let items):
+                voiceNote = items.first!
+            }
+            let folders = try folderUseCase.fetchAll()
             let otherFolders = folders.filter { $0.id != voiceNote.folderID }
             send(.internal(.foldersLoaded(otherFolders)))
         } catch {
@@ -63,18 +73,18 @@ public final class MoveFolderListViewModel {
     private func moveVoiceNote() async {
         guard let selectedFolder = state.selectedFolder else { return }
         do {
-            let updatedVoiceNote = VoiceNote(
-                id: voiceNote.id,
-                title: voiceNote.title,
-                createdAt: voiceNote.createdAt,
-                updatedAt: voiceNote.updatedAt,
-                folderID: selectedFolder.id,
-                voiceRecord: voiceNote.voiceRecord,
-                keywords: voiceNote.keywords,
-                transcript: voiceNote.transcript,
-                summary: voiceNote.summary
-            )
-            _ = try await voiceNoteUseCase.update(updatedVoiceNote)
+            switch receive {
+            case .single(var voiceNote):
+                voiceNote.folderID = selectedFolder.id
+                _ = try voiceNoteUseCase.update(voiceNote)
+                
+            case .multiple(let voiceNotes):
+                for var voiceNote in voiceNotes {
+                    voiceNote.folderID = selectedFolder.id
+                    _ = try voiceNoteUseCase.update(voiceNote)
+                }
+            }
+            onDismiss?()
             coordinator?.dismiss()
         } catch {
             AppLogger.error(error)

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -2,9 +2,7 @@ import Core
 import Domain
 import Foundation
 
-public protocol VoiceNoteCoordinatorDelegate: BaseCoordinatorDelegate {
-    func presentFolderList(with: VoiceNote)
-}
+public protocol VoiceNoteCoordinatorDelegate: BaseCoordinatorDelegate {}
 
 @MainActor
 @Observable
@@ -95,7 +93,7 @@ public final class VoiceNoteViewModel {
             case .pop:
                 coordinator?.pop()
             case .moveVoiceNoteButtonTapped:
-                coordinator?.presentFolderList(with: state.voiceNote)
+                coordinator?.presentFolderList(with: .single(state.voiceNote))
             case .deleteVoiceNoteButtonTapped:
                 Task { await moveToWasteBasket() }
             }

--- a/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
@@ -127,13 +127,13 @@ final class FolderDetailViewModelTests: XCTestCase {
             VoiceNote.stub(title: "노트2")
         ]
 
-        await sut.mockVoiceNoteRepo.setFetchAllResult(.success(expectedNotes))
-        await sut.mockVoiceNoteRepo.expectFetchAll(callCount: 1, folderID: sut.testFolderID)
+        sut.mockVoiceNoteRepo.setFetchAllResult(.success(expectedNotes))
+        sut.mockVoiceNoteRepo.expectFetchAll(callCount: 1, folderID: sut.testFolderID)
 
         sut.viewModel.fetchItems()
         try? await Task.sleep(nanoseconds: 300_000_000)
 
-        await sut.mockVoiceNoteRepo.verify()
+        sut.mockVoiceNoteRepo.verify()
         XCTAssertEqual(sut.viewModel.items.count, 2)
 
         // 정렬 확인 (초기 createdAt 기준 내림차순)
@@ -183,8 +183,8 @@ final class FolderDetailViewModelTests: XCTestCase {
             updatedAt: Date().addingTimeInterval(-1000) // update 기준으로는 더 이전
         )
 
-        await sut.mockVoiceNoteRepo.setFetchAllResult(.success([olderNote, newerNote]))
-        await sut.mockVoiceNoteRepo.expectFetchAll(callCount: 1, folderID: sut.testFolderID)
+        sut.mockVoiceNoteRepo.setFetchAllResult(.success([olderNote, newerNote]))
+        sut.mockVoiceNoteRepo.expectFetchAll(callCount: 1, folderID: sut.testFolderID)
 
         sut.viewModel.fetchItems()
         try? await Task.sleep(nanoseconds: 300_000_000)
@@ -205,20 +205,20 @@ final class FolderDetailViewModelTests: XCTestCase {
         let sut = makeSUT()
         let note = VoiceNote.stub(title: "삭제할 노트")
         
-        await sut.mockVoiceNoteRepo.setFetchAllResult(.success([note]))
-        await sut.mockVoiceNoteRepo.expectFetchAll(callCount: 1, folderID: sut.testFolderID)
+        sut.mockVoiceNoteRepo.setFetchAllResult(.success([note]))
+        sut.mockVoiceNoteRepo.expectFetchAll(callCount: 1, folderID: sut.testFolderID)
         sut.viewModel.fetchItems()
         try? await Task.sleep(nanoseconds: 300_000_000)
         
         sut.viewModel.selectItem(note)
         
-        await sut.mockWasteBasketRepo.setMoveResult(.success(()))
-        await sut.mockWasteBasketRepo.expectMoveAllToWasteBasket(callCount: 1)
+        sut.mockWasteBasketRepo.setMoveResult(.success(()))
+        sut.mockWasteBasketRepo.expectMoveAllToWasteBasket(callCount: 1)
         
         sut.viewModel.move()
         try? await Task.sleep(nanoseconds: 300_000_000)
         
-        await sut.mockWasteBasketRepo.verify()
+        sut.mockWasteBasketRepo.verify()
         XCTAssertTrue(sut.viewModel.items.isEmpty)
         XCTAssertEqual(sut.viewModel.select, .none)
     }
@@ -227,17 +227,17 @@ final class FolderDetailViewModelTests: XCTestCase {
         let sut = makeSUT()
         let note = VoiceNote.stub(title: "복원할 노트")
         
-        await sut.mockWasteBasketRepo.setRestoreResult(.success(()))
-        await sut.mockWasteBasketRepo.expectRestore(callCount: 1)
+        sut.mockWasteBasketRepo.setRestoreResult(.success(()))
+        sut.mockWasteBasketRepo.expectRestore(callCount: 1)
         
-        await sut.mockVoiceNoteRepo.setFetchAllResult(.success([note]))
-        await sut.mockVoiceNoteRepo.expectFetchAll(callCount: 1, folderID: sut.testFolderID)
+        sut.mockVoiceNoteRepo.setFetchAllResult(.success([note]))
+        sut.mockVoiceNoteRepo.expectFetchAll(callCount: 1, folderID: sut.testFolderID)
         
         sut.viewModel.restore(items: [note])
         try? await Task.sleep(nanoseconds: 300_000_000)
         
-        await sut.mockWasteBasketRepo.verify()
-        await sut.mockVoiceNoteRepo.verify()
+        sut.mockWasteBasketRepo.verify()
+        sut.mockVoiceNoteRepo.verify()
         XCTAssertEqual(sut.viewModel.items.count, 1)
     }
 }

--- a/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
@@ -8,6 +8,8 @@ final class MockFolderDetailCoordinatorDelegate: FolderDetailCoordinatorDelegate
     var popCalled = false
     var pushedVoiceNote: VoiceNote?
 
+    var presentFolderListCalled = false
+
     func pop() {
         popCalled = true
     }
@@ -16,7 +18,9 @@ final class MockFolderDetailCoordinatorDelegate: FolderDetailCoordinatorDelegate
         pushedVoiceNote = voiceNote
     }
 
-    func presentFolderList(with receive: Receive, dismiss: (() -> Void)?) {}
+    func presentFolderList(with receive: Receive, dismiss: (() -> Void)?) {
+        presentFolderListCalled = true
+    }
 }
 
 @MainActor
@@ -77,6 +81,43 @@ final class FolderDetailViewModelTests: XCTestCase {
         sut.viewModel.didTapBack()
 
         XCTAssertTrue(sut.mockCoordinator.popCalled)
+    }
+
+    func test_pushVoiceNote_호출시_화면전환() {
+        let sut = makeSUT()
+        let note = VoiceNote.stub(title: "테스트 노트")
+
+        sut.viewModel.pushVoiceNote(voiceNote: note)
+
+        XCTAssertEqual(sut.mockCoordinator.pushedVoiceNote?.id, note.id)
+    }
+
+    func test_presentMoveFolder_버튼탭시_선택항목존재하면_시트오픈() {
+        let sut = makeSUT()
+        let note = VoiceNote.stub(title: "테스트 노트")
+        
+        sut.viewModel.selectItem(note)
+        sut.viewModel.presentMoveFolder()
+
+        XCTAssertTrue(sut.mockCoordinator.presentFolderListCalled)
+    }
+
+    func test_presentMoveFolder_버튼탭시_선택항목없으면_무시() {
+        let sut = makeSUT()
+        
+        sut.viewModel.presentMoveFolder()
+
+        XCTAssertFalse(sut.mockCoordinator.presentFolderListCalled)
+    }
+
+    func test_AlertView_상태변경() {
+        let sut = makeSUT()
+
+        sut.viewModel.openAlertView()
+        XCTAssertTrue(sut.viewModel.showAlert)
+
+        sut.viewModel.closeAlertView()
+        XCTAssertFalse(sut.viewModel.showAlert)
     }
 
     func test_fetchItems_호출시_보이스노트로드확인() async {
@@ -158,5 +199,45 @@ final class FolderDetailViewModelTests: XCTestCase {
         if case .voiceNote(let topNote) = sut.viewModel.items[0] {
             XCTAssertEqual(topNote.id, olderNote.id) // olderNote의 updatedAt이 최신
         }
+    }
+
+    func test_move_호출시_아이템제거및_선택모드해제() async {
+        let sut = makeSUT()
+        let note = VoiceNote.stub(title: "삭제할 노트")
+        
+        await sut.mockVoiceNoteRepo.setFetchAllResult(.success([note]))
+        await sut.mockVoiceNoteRepo.expectFetchAll(callCount: 1, folderID: sut.testFolderID)
+        sut.viewModel.fetchItems()
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        
+        sut.viewModel.selectItem(note)
+        
+        await sut.mockWasteBasketRepo.setMoveResult(.success(()))
+        await sut.mockWasteBasketRepo.expectMoveAllToWasteBasket(callCount: 1)
+        
+        sut.viewModel.move()
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        
+        await sut.mockWasteBasketRepo.verify()
+        XCTAssertTrue(sut.viewModel.items.isEmpty)
+        XCTAssertEqual(sut.viewModel.select, .none)
+    }
+
+    func test_restore_호출시_복원후_fetch재호출() async {
+        let sut = makeSUT()
+        let note = VoiceNote.stub(title: "복원할 노트")
+        
+        await sut.mockWasteBasketRepo.setRestoreResult(.success(()))
+        await sut.mockWasteBasketRepo.expectRestore(callCount: 1)
+        
+        await sut.mockVoiceNoteRepo.setFetchAllResult(.success([note]))
+        await sut.mockVoiceNoteRepo.expectFetchAll(callCount: 1, folderID: sut.testFolderID)
+        
+        sut.viewModel.restore(items: [note])
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        
+        await sut.mockWasteBasketRepo.verify()
+        await sut.mockVoiceNoteRepo.verify()
+        XCTAssertEqual(sut.viewModel.items.count, 1)
     }
 }

--- a/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
@@ -95,7 +95,7 @@ final class FolderDetailViewModelTests: XCTestCase {
     func test_presentMoveFolder_버튼탭시_선택항목존재하면_시트오픈() {
         let sut = makeSUT()
         let note = VoiceNote.stub(title: "테스트 노트")
-        
+
         sut.viewModel.selectItem(note)
         sut.viewModel.presentMoveFolder()
 
@@ -104,7 +104,7 @@ final class FolderDetailViewModelTests: XCTestCase {
 
     func test_presentMoveFolder_버튼탭시_선택항목없으면_무시() {
         let sut = makeSUT()
-        
+
         sut.viewModel.presentMoveFolder()
 
         XCTAssertFalse(sut.mockCoordinator.presentFolderListCalled)
@@ -204,20 +204,20 @@ final class FolderDetailViewModelTests: XCTestCase {
     func test_move_호출시_아이템제거및_선택모드해제() async {
         let sut = makeSUT()
         let note = VoiceNote.stub(title: "삭제할 노트")
-        
+
         sut.mockVoiceNoteRepo.setFetchAllResult(.success([note]))
         sut.mockVoiceNoteRepo.expectFetchAll(callCount: 1, folderID: sut.testFolderID)
         sut.viewModel.fetchItems()
         try? await Task.sleep(nanoseconds: 300_000_000)
-        
+
         sut.viewModel.selectItem(note)
-        
+
         sut.mockWasteBasketRepo.setMoveResult(.success(()))
         sut.mockWasteBasketRepo.expectMoveAllToWasteBasket(callCount: 1)
-        
+
         sut.viewModel.move()
         try? await Task.sleep(nanoseconds: 300_000_000)
-        
+
         sut.mockWasteBasketRepo.verify()
         XCTAssertTrue(sut.viewModel.items.isEmpty)
         XCTAssertEqual(sut.viewModel.select, .none)
@@ -226,16 +226,16 @@ final class FolderDetailViewModelTests: XCTestCase {
     func test_restore_호출시_복원후_fetch재호출() async {
         let sut = makeSUT()
         let note = VoiceNote.stub(title: "복원할 노트")
-        
+
         sut.mockWasteBasketRepo.setRestoreResult(.success(()))
         sut.mockWasteBasketRepo.expectRestore(callCount: 1)
-        
+
         sut.mockVoiceNoteRepo.setFetchAllResult(.success([note]))
         sut.mockVoiceNoteRepo.expectFetchAll(callCount: 1, folderID: sut.testFolderID)
-        
+
         sut.viewModel.restore(items: [note])
         try? await Task.sleep(nanoseconds: 300_000_000)
-        
+
         sut.mockWasteBasketRepo.verify()
         sut.mockVoiceNoteRepo.verify()
         XCTAssertEqual(sut.viewModel.items.count, 1)

--- a/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
@@ -4,19 +4,37 @@ import DomainTesting
 import XCTest
 
 @MainActor
+final class MockFolderDetailCoordinatorDelegate: FolderDetailCoordinatorDelegate {
+    var popCalled = false
+    var pushedVoiceNote: VoiceNote?
+
+    func pop() {
+        popCalled = true
+    }
+
+    func pushVoiceNoteView(voiceNote: Domain.VoiceNote) {
+        pushedVoiceNote = voiceNote
+    }
+
+    func presentFolderList(with receive: Receive, dismiss: (() -> Void)?) {}
+}
+
+@MainActor
 final class FolderDetailViewModelTests: XCTestCase {
     // MARK: - SUT
 
     private struct SUT {
         let viewModel: FolderDetailViewModel
         let mockVoiceNoteRepo: MockVoiceNoteRepository
-        let mockCoordinator: MockBaseCoordinatorDelegate
+        let mockWasteBasketRepo: MockWasteBasketRepository
+        let mockCoordinator: MockFolderDetailCoordinatorDelegate
         let testFolderID: UUID
     }
 
     private func makeSUT(title: String = "상세 폴더", folderID: UUID = UUID()) -> SUT {
         let mockVoiceNoteRepo = MockVoiceNoteRepository()
-        let mockCoordinator = MockBaseCoordinatorDelegate()
+        let mockWasteBasketRepo = MockWasteBasketRepository()
+        let mockCoordinator = MockFolderDetailCoordinatorDelegate()
 
         let viewModel = FolderDetailViewModel(
             title: title,
@@ -25,13 +43,15 @@ final class FolderDetailViewModelTests: XCTestCase {
                 repository: mockVoiceNoteRepo,
                 sttRepository: MockSTTRepository(),
                 summaryRepository: MockSummaryRepository()
-            )
+            ),
+            wasteBasketRepository: mockWasteBasketRepo
         )
         viewModel.coordinator = mockCoordinator
 
         return SUT(
             viewModel: viewModel,
             mockVoiceNoteRepo: mockVoiceNoteRepo,
+            mockWasteBasketRepo: mockWasteBasketRepo,
             mockCoordinator: mockCoordinator,
             testFolderID: folderID
         )
@@ -46,8 +66,7 @@ final class FolderDetailViewModelTests: XCTestCase {
         XCTAssertEqual(sut.viewModel.title, "테스트 폴더")
         XCTAssertEqual(sut.viewModel.folderID, folderID)
         XCTAssertTrue(sut.viewModel.items.isEmpty)
-        XCTAssertTrue(sut.viewModel.isEmpty)
-        XCTAssertFalse(sut.viewModel.isSelectionMode)
+        XCTAssertEqual(sut.viewModel.select, .none)
     }
 
     // MARK: - UI Action Tests
@@ -75,7 +94,6 @@ final class FolderDetailViewModelTests: XCTestCase {
 
         await sut.mockVoiceNoteRepo.verify()
         XCTAssertEqual(sut.viewModel.items.count, 2)
-        XCTAssertFalse(sut.viewModel.isEmpty)
 
         // 정렬 확인 (초기 createdAt 기준 내림차순)
         if case .voiceNote(let note1) = sut.viewModel.items[0],
@@ -92,8 +110,8 @@ final class FolderDetailViewModelTests: XCTestCase {
         let voiceNote = VoiceNote.stub(title: "테스트 노트")
 
         // 선택 모드 켜기
-        sut.viewModel.toggleSelectionMode()
-        XCTAssertTrue(sut.viewModel.isSelectionMode)
+        sut.viewModel.setSelectionMode(.single)
+        XCTAssertEqual(sut.viewModel.select, .single)
 
         // 아이템 선택
         sut.viewModel.selectItem(voiceNote)
@@ -106,8 +124,8 @@ final class FolderDetailViewModelTests: XCTestCase {
 
         // 아이템 선택 후 선택 모드 종료 시 초기화 확인
         sut.viewModel.selectItem(voiceNote)
-        sut.viewModel.toggleSelectionMode()
-        XCTAssertFalse(sut.viewModel.isSelectionMode)
+        sut.viewModel.setSelectionMode(.none)
+        XCTAssertEqual(sut.viewModel.select, .none)
         XCTAssertTrue(sut.viewModel.selectedItems.isEmpty)
     }
 
@@ -136,7 +154,7 @@ final class FolderDetailViewModelTests: XCTestCase {
         }
 
         // 수정일 순으로 변경 (updatedAt 내림차순)
-        sut.viewModel.touchUpdatedAction()
+        sut.viewModel.setOrder(.updatedAt)
         if case .voiceNote(let topNote) = sut.viewModel.items[0] {
             XCTAssertEqual(topNote.id, olderNote.id) // olderNote의 updatedAt이 최신
         }

--- a/Presentation/Tests/Folder/FolderViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderViewModelTests.swift
@@ -15,6 +15,8 @@ final class MockFolderCoordinatorDelegate: FolderCoordinatorDelegate {
     func pushMyFolderDetailView(_ folder: Folder) {
         pushedFolder = folder
     }
+
+    func presentFolderList(with receive: Receive, dismiss: (() -> Void)?) {}
 }
 
 @MainActor

--- a/Presentation/Tests/Folder/FolderViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderViewModelTests.swift
@@ -76,6 +76,15 @@ final class FolderViewModelTests: XCTestCase {
         XCTAssertTrue(sut.mockCoordinator.popCalled)
     }
 
+    func test_pushDetail_호출시_화면전환() {
+        let sut = makeSUT()
+        let folder = Folder(name: "테스트")
+
+        sut.viewModel.pushDetail(folder)
+
+        XCTAssertEqual(sut.mockCoordinator.pushedFolder?.id, folder.id)
+    }
+
     func test_openTextFieldView_호출시_상태변경() {
         let sut = makeSUT()
         let folder = Folder(name: "수정 폴더")
@@ -114,6 +123,25 @@ final class FolderViewModelTests: XCTestCase {
         await sut.mockFolderRepo.verify()
         XCTAssertEqual(sut.viewModel.category.items.count, 1)
         XCTAssertFalse(sut.viewModel.showTextField)
+    }
+
+    func test_fetchAll_정상로드() async {
+        let sut = makeSUT()
+        let expectedFolders = [
+            Folder(name: "새 폴더 1", isDeletable: true),
+            Folder(name: "기본 폴더", isDeletable: false), // isDeletable = false는 제외되어야 함
+            Folder(name: "새 폴더 2", isDeletable: true)
+        ]
+
+        await sut.mockFolderRepo.setFetchAllResult(.success(expectedFolders))
+        await sut.mockFolderRepo.expectFetchAll(callCount: 1)
+
+        sut.viewModel.fetchAll()
+
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        await sut.mockFolderRepo.verify()
+        XCTAssertEqual(sut.viewModel.category.items.count, 2)
     }
 
     func test_move_성공시_리스트에서제거() async {

--- a/Presentation/Tests/Folder/FolderViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderViewModelTests.swift
@@ -112,15 +112,15 @@ final class FolderViewModelTests: XCTestCase {
         let folderName = "신규 폴더"
         let createdFolder = Folder(name: folderName)
 
-        await sut.mockFolderRepo.setCreateResult(.success(createdFolder))
-        await sut.mockFolderRepo.expectCreate(name: folderName, callCount: 1)
+        sut.mockFolderRepo.setCreateResult(.success(createdFolder))
+        sut.mockFolderRepo.expectCreate(name: folderName, callCount: 1)
 
         sut.viewModel.create(name: folderName)
 
         // Task 대기
         try? await Task.sleep(nanoseconds: 300_000_000)
 
-        await sut.mockFolderRepo.verify()
+        sut.mockFolderRepo.verify()
         XCTAssertEqual(sut.viewModel.category.items.count, 1)
         XCTAssertFalse(sut.viewModel.showTextField)
     }
@@ -133,14 +133,14 @@ final class FolderViewModelTests: XCTestCase {
             Folder(name: "새 폴더 2", isDeletable: true)
         ]
 
-        await sut.mockFolderRepo.setFetchAllResult(.success(expectedFolders))
-        await sut.mockFolderRepo.expectFetchAll(callCount: 1)
+        sut.mockFolderRepo.setFetchAllResult(.success(expectedFolders))
+        sut.mockFolderRepo.expectFetchAll(callCount: 1)
 
         sut.viewModel.fetchAll()
 
         try? await Task.sleep(nanoseconds: 300_000_000)
 
-        await sut.mockFolderRepo.verify()
+        sut.mockFolderRepo.verify()
         XCTAssertEqual(sut.viewModel.category.items.count, 2)
     }
 
@@ -148,15 +148,15 @@ final class FolderViewModelTests: XCTestCase {
         let folder = Folder(name: "이동 폴더")
         let sut = makeSUT(initialItems: [.folder(folder)])
 
-        await sut.mockWasteBasketRepo.setMoveResult(.success(()))
-        await sut.mockWasteBasketRepo.expectMoveToWasteBasket(
+        sut.mockWasteBasketRepo.setMoveResult(.success(()))
+        sut.mockWasteBasketRepo.expectMoveToWasteBasket(
             item: .folder(obj: folder), callCount: 1
         )
 
         sut.viewModel.move(folder: folder)
         try? await Task.sleep(nanoseconds: 300_000_000)
 
-        await sut.mockWasteBasketRepo.verify()
+        sut.mockWasteBasketRepo.verify()
         XCTAssertTrue(sut.viewModel.category.items.isEmpty)
     }
 
@@ -174,8 +174,8 @@ final class FolderViewModelTests: XCTestCase {
             deletedAt: initialFolder.deletedAt
         )
 
-        await sut.mockFolderRepo.setUpdateResult(.success(updatedFolder))
-        await sut.mockFolderRepo.expectUpdate(folderID: initialFolder.id, callCount: 1)
+        sut.mockFolderRepo.setUpdateResult(.success(updatedFolder))
+        sut.mockFolderRepo.expectUpdate(folderID: initialFolder.id, callCount: 1)
 
         // 수정 모드 진입
         sut.viewModel.openTextField(for: initialFolder)
@@ -185,7 +185,7 @@ final class FolderViewModelTests: XCTestCase {
         // Task 대기
         try? await Task.sleep(nanoseconds: 300_000_000)
 
-        await sut.mockFolderRepo.verify()
+        sut.mockFolderRepo.verify()
 
         if case .folder(let folder) = sut.viewModel.category.items[0] {
             XCTAssertEqual(folder.name, newName)

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -131,10 +131,10 @@ final class MainViewModelTests: XCTestCase {
 
     func test_didScroll_상태변경() {
         let sut = makeSUT()
-        
+
         sut.viewModel.setDidScroll(true)
         XCTAssertTrue(sut.viewModel.didScroll)
-        
+
         sut.viewModel.setDidScroll(false)
         XCTAssertFalse(sut.viewModel.didScroll)
     }

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -260,8 +260,8 @@ final class MainViewModelTests: XCTestCase {
             WasteBasketItem.voiceNote(obj: VoiceNote.stub(title: "삭제된 노트"))
         ]
 
-        await sut.mockWasteBasketRepo.setFetchAllResult(.success(expectedTrash))
-        await sut.mockWasteBasketRepo.expectFetchAll(callCount: 1)
+        sut.mockWasteBasketRepo.setFetchAllResult(.success(expectedTrash))
+        sut.mockWasteBasketRepo.expectFetchAll(callCount: 1)
 
         sut.viewModel.updateTrashCategory()
 

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -46,6 +46,7 @@ final class MainViewModelTests: XCTestCase {
         let mockVoiceRecordRepo: MockVoiceRecordRepository
         let mockFolderRepo: MockFolderRepository
         let mockVoiceNoteRepo: MockVoiceNoteRepository
+        let mockWasteBasketRepo: MockWasteBasketRepository
         let mockCoordinator: MockMainCoordinatorDelegate
     }
 
@@ -73,6 +74,7 @@ final class MainViewModelTests: XCTestCase {
             mockVoiceRecordRepo: mockVoiceRecordRepo,
             mockFolderRepo: mockFolderRepo,
             mockVoiceNoteRepo: mockVoiceNoteRepo,
+            mockWasteBasketRepo: mockWasteBasketRepo,
             mockCoordinator: mockCoordinator
         )
     }
@@ -115,6 +117,36 @@ final class MainViewModelTests: XCTestCase {
         sut.viewModel.presentRecodingView()
 
         XCTAssertTrue(sut.mockCoordinator.presentRecodingViewCalled)
+    }
+
+    func test_pushVoiceNoteView_호출시_화면전환() {
+        let sut = makeSUT()
+        let note = VoiceNote.stub(title: "테스트 노트")
+
+        sut.viewModel.pushVoiceNoteView(voiceNote: note)
+
+        XCTAssertTrue(sut.mockCoordinator.pushVoiceNoteViewCalled)
+        XCTAssertEqual(sut.mockCoordinator.pushedVoiceNote?.id, note.id)
+    }
+
+    func test_didScroll_상태변경() {
+        let sut = makeSUT()
+        
+        sut.viewModel.setDidScroll(true)
+        XCTAssertTrue(sut.viewModel.didScroll)
+        
+        sut.viewModel.setDidScroll(false)
+        XCTAssertFalse(sut.viewModel.didScroll)
+    }
+
+    func test_AlertView_상태변경() {
+        let sut = makeSUT()
+
+        sut.viewModel.openAlertView()
+        XCTAssertTrue(sut.viewModel.showAlert)
+
+        sut.viewModel.closeAlertView()
+        XCTAssertFalse(sut.viewModel.showAlert)
     }
 
     func test_handleRecordButtonTap_권한허용_바로녹음화면이동() async {
@@ -219,6 +251,28 @@ final class MainViewModelTests: XCTestCase {
             XCTAssertEqual(folder.name, "테스트 폴더 1")
         } else {
             XCTFail("Folder 타입이 아닙니다.")
+        }
+    }
+
+    func test_updateTrashCategory_호출시_데이터로드확인() async {
+        let sut = makeSUT()
+        let expectedTrash = [
+            WasteBasketItem.voiceNote(obj: VoiceNote.stub(title: "삭제된 노트"))
+        ]
+
+        await sut.mockWasteBasketRepo.setFetchAllResult(.success(expectedTrash))
+        await sut.mockWasteBasketRepo.expectFetchAll(callCount: 1)
+
+        sut.viewModel.updateTrashCategory()
+
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        // Mock은 이미 verify되었음을 가정하거나 직접 체크
+        XCTAssertEqual(sut.viewModel.categoryData[3].items.count, 1)
+        if case .voiceNote(let note) = sut.viewModel.categoryData[3].items[0] {
+            XCTAssertEqual(note.title, "삭제된 노트")
+        } else {
+            XCTFail("VoiceNote 타입이 아닙니다.")
         }
     }
 }

--- a/Presentation/Tests/Mocks/MockBaseCoordinatorDelegate.swift
+++ b/Presentation/Tests/Mocks/MockBaseCoordinatorDelegate.swift
@@ -4,6 +4,11 @@ import Foundation
 @MainActor
 final class MockBaseCoordinatorDelegate: BaseCoordinatorDelegate {
     var popCalled = false
+    var presentFolderListCalled = false
+    
+    func presentFolderList(with: Presentation.Receive, dismiss: (() -> Void)?) {
+        presentFolderListCalled = true
+    }
 
     func pop() {
         popCalled = true

--- a/Presentation/Tests/Mocks/MockBaseCoordinatorDelegate.swift
+++ b/Presentation/Tests/Mocks/MockBaseCoordinatorDelegate.swift
@@ -5,7 +5,7 @@ import Foundation
 final class MockBaseCoordinatorDelegate: BaseCoordinatorDelegate {
     var popCalled = false
     var presentFolderListCalled = false
-    
+
     func presentFolderList(with: Presentation.Receive, dismiss: (() -> Void)?) {
         presentFolderListCalled = true
     }

--- a/Presentation/Tests/OnBoarding/OnBoardingViewModelTests.swift
+++ b/Presentation/Tests/OnBoarding/OnBoardingViewModelTests.swift
@@ -121,8 +121,8 @@ final class OnBoardingViewModelTests: XCTestCase {
         sut.viewModel.syncPageState(nextStep: Step.finish.rawValue)
 
         sut.mockCheckFirstLaunchRepo.setReturnValue(true)
-        await sut.mockFolderRepo.setCreateResult(.success(Folder(name: Policy.defaultFolderName, isDeletable: false)))
-        await sut.mockFolderRepo.expectCreate(name: Policy.defaultFolderName, isDeletable: false, callCount: 1)
+        sut.mockFolderRepo.setCreateResult(.success(Folder(name: Policy.defaultFolderName, isDeletable: false)))
+        sut.mockFolderRepo.expectCreate(name: Policy.defaultFolderName, isDeletable: false, callCount: 1)
 
         let expectation = XCTestExpectation(description: "finishOnBoarding 호출")
         sut.mockNavDelegate.finishOnBoardingExpectation = expectation
@@ -134,15 +134,15 @@ final class OnBoardingViewModelTests: XCTestCase {
         XCTAssertTrue(sut.mockNavDelegate.finishOnBoardingCalled)
 
         // 언어 저장 확인
-        await sut.mockLanguageRepo.expectSave(language: .ko, callCount: 1)
-        await sut.mockLanguageRepo.verify()
+        sut.mockLanguageRepo.expectSave(language: .ko, callCount: 1)
+        sut.mockLanguageRepo.verify()
 
         // 첫 실행 마킹 확인
         sut.mockCheckFirstLaunchRepo.expectCheckAndMarkFirstLaunch(callCount: 1)
         sut.mockCheckFirstLaunchRepo.verify()
 
         // 기본 폴더 생성 확인
-        await sut.mockFolderRepo.verify()
+        sut.mockFolderRepo.verify()
     }
 
     func test_secondButtonAction_첫스텝에서_건너뛰기를_누르면_마이크권한화면으로_이동한다() {

--- a/Presentation/Tests/Recording/RecordingViewModelTests.swift
+++ b/Presentation/Tests/Recording/RecordingViewModelTests.swift
@@ -254,7 +254,7 @@ extension RecordingViewModelTests {
         let voiceRecordStub = VoiceRecord.stub()
         let voiceNoteStub = VoiceNote.stub(voiceRecord: voiceRecordStub)
         await sut.repository.setFinishResult(.success(voiceRecordStub))
-        await sut.voiceNoteRepository.setCreateResult(.success(voiceNoteStub))
+        sut.voiceNoteRepository.setCreateResult(.success(voiceNoteStub))
 
         // When
         sut.viewModel.send(.finishButtonTapped)
@@ -283,7 +283,7 @@ extension RecordingViewModelTests {
         // Given
         let sut = makeSUT()
         await sut.repository.setFinishResult(.success(.stub()))
-        await sut.voiceNoteRepository.setCreateResult(.failure(.createFailed))
+        sut.voiceNoteRepository.setCreateResult(.failure(.createFailed))
 
         // When
         sut.viewModel.send(.finishButtonTapped)

--- a/Presentation/Tests/Trash/TrashViewModelTests.swift
+++ b/Presentation/Tests/Trash/TrashViewModelTests.swift
@@ -128,15 +128,15 @@ final class TrashViewModelTests: XCTestCase {
             ))
         ]
 
-        await sut.mockRepo.setFetchAllResult(.success(fetchResult))
-        await sut.mockRepo.expectFetchAll(callCount: 1)
+        sut.mockRepo.setFetchAllResult(.success(fetchResult))
+        sut.mockRepo.expectFetchAll(callCount: 1)
 
         // When
         sut.viewModel.fetchItems()
         try? await Task.sleep(nanoseconds: 300_000_000)
 
         // Then
-        await sut.mockRepo.verify()
+        sut.mockRepo.verify()
         XCTAssertEqual(sut.viewModel.items.count, 2, "2개의 항목을 정상적으로 불러와야 합니다.")
     }
 
@@ -148,9 +148,9 @@ final class TrashViewModelTests: XCTestCase {
         let fetchResult: [WasteBasketItem] = [
             .folder(obj: Folder(name: "테스트 폴더"))
         ]
-        await sut.mockRepo.setFetchAllResult(.success(fetchResult))
-        await sut.mockRepo.setDeleteResult(.success(()))
-        await sut.mockRepo.expectAllClear(callCount: 1)
+        sut.mockRepo.setFetchAllResult(.success(fetchResult))
+        sut.mockRepo.setDeleteResult(.success(()))
+        sut.mockRepo.expectAllClear(callCount: 1)
 
         sut.viewModel.fetchItems()
         try? await Task.sleep(nanoseconds: 300_000_000)
@@ -161,7 +161,7 @@ final class TrashViewModelTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 300_000_000)
 
         // Then
-        await sut.mockRepo.verify()
+        sut.mockRepo.verify()
         XCTAssertTrue(sut.viewModel.items.isEmpty, "전체 삭제 진행 후 items 배열이 비워져야 합니다.")
     }
 
@@ -169,9 +169,9 @@ final class TrashViewModelTests: XCTestCase {
         // Given
         let sut = makeSUT()
         let item = WasteBasketItem.folder(obj: Folder(name: "삭제용 폴더"))
-        await sut.mockRepo.setFetchAllResult(.success([item]))
-        await sut.mockRepo.setDeleteResult(.success(()))
-        await sut.mockRepo.expectDelete(item: item, callCount: 1)
+        sut.mockRepo.setFetchAllResult(.success([item]))
+        sut.mockRepo.setDeleteResult(.success(()))
+        sut.mockRepo.expectDelete(item: item, callCount: 1)
 
         sut.viewModel.fetchItems()
         try? await Task.sleep(nanoseconds: 300_000_000)
@@ -181,7 +181,7 @@ final class TrashViewModelTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 300_000_000)
 
         // Then
-        await sut.mockRepo.verify()
+        sut.mockRepo.verify()
         XCTAssertTrue(sut.viewModel.items.isEmpty, "단일 삭제 진행 후 항목이 리스트에서 지워져야 합니다.")
     }
 
@@ -189,9 +189,9 @@ final class TrashViewModelTests: XCTestCase {
         // Given
         let sut = makeSUT()
         let item = WasteBasketItem.folder(obj: Folder(name: "복구용 폴더"))
-        await sut.mockRepo.setFetchAllResult(.success([item]))
-        await sut.mockRepo.setRestoreResult(.success(()))
-        await sut.mockRepo.expectRestore(item: item, callCount: 1)
+        sut.mockRepo.setFetchAllResult(.success([item]))
+        sut.mockRepo.setRestoreResult(.success(()))
+        sut.mockRepo.expectRestore(item: item, callCount: 1)
 
         sut.viewModel.fetchItems()
         try? await Task.sleep(nanoseconds: 300_000_000)
@@ -201,7 +201,7 @@ final class TrashViewModelTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 300_000_000)
 
         // Then
-        await sut.mockRepo.verify()
+        sut.mockRepo.verify()
         XCTAssertTrue(sut.viewModel.items.isEmpty, "복원 후 휴지통 목록에서 항목이 제거되어야 합니다.")
     }
 }


### PR DESCRIPTION
---

## ✨ 작업 요약
- 폴더 및 휴지통 UX 리팩토링 및 대규모 전역 UI 컴포넌트(Toast) 구현 및 안정화

## 📋 구체적인 내용
- **추가/변경된 동작**:
    - **도메인 모델 변경**: `VoiceNote`의 `folderID`를 `let`에서 `var`로 변경하여 가변성을 확보하고 업데이트 로직 가독성 개선.
    - **선택 기능 리팩토링**: `UICollectionView` 기본 delegate 방식 대신 `VoiceNoteCardView` 직접 제어 방식으로 변경하여 정교한 선택 상태 관리 구현 (`Select` 상태값 도입).
    - **전역 Toast 알림**: `UIView` 최상단 레이어에 부착되는 Factory 기반 전역 토스트 시스템 구현. 휴지통 이동 시 복구가 가능한 시나리오 반영.
    - **폴더 이동 flow 확장**: 상세 폴더에서 여러 개의 음성 노트를 한꺼번에 이동할 수 있도록 Coordinator 구조 개선 및 enum 연관 값을 통한 주입 방식 채택.
    - **버그 수정**: 제스처 내부로 내비게이션 로직을 옮기는 과정에서 발생한 화면 전환 오류 해결.
- **영향 받는 화면/모듈**:
    - **Presentation**: `Main`, `FolderDetail`, `MoveFolderList`, `Trash` 전반
    - **Domain**: `VoiceNote` 모델 구조 변경
    - **Tests**: 전체 뷰모델 테스트 코드(PresentationTests) 최신화 및 안정화

---

## 🔗 연관 이슈
- closed #207

---

## 🧩 설계·구현 노트

- **선택한 방식**
    - **Domain 객체 직접 전달**: UI 컴포넌트(`VoiceNoteCardView`)에 단순 텍스트가 아닌 Domain 객체 전체를 전달하여, ViewModel의 `selectedItems` 관리 로직과의 정렬을 맞췄습니다.
    - **백업 방식의 멱등성 보장**: 휴지통 이동 중 취소 로직의 예외 케이스를 줄이기 위해, 이동 완료 후 필요 시 백업하는 방식으로 변경하여 시스템의 안정성을 확보했습니다.
    - **테스트 동기화**: 아키텍처 변경에 맞춰 누락되었던 유닛 테스트를 대거 추가하고, 동기식 목업 호출에서 불필요한 `await`을 제거하여 빌드 경고를 0으로 유지했습니다.

---

## ✅ 확인 사항
- [x] 전역 Toast 애니메이션 및 동작 확인
- [x] 폴더 간 이동 및 휴지통 복구 시나리오 동작 확인
- [x] SwiftFormat 적용 및 컨벤션 준수 확인
- [x] `tuist test` (PresentationTests 66개 케이스) 전원 통과 확인

---

## 👀 리뷰 포인트

- [x] **선택 상태 관리**: `selectionMode`를 삭제하고 `Select` 상태값으로 통합한 구조가 적절한지 공유 바랍니다.
- [x] **도메인 가변성**: `folderID`를 `var`로 연 것이 추후 발생할 수 있는 부작용이 없을지 검토 부탁드립니다.
- [x] **전역 컴포넌트**: `UIView` 확장을 통한 Toast 구현 방식이 다른 화면에서도 재사용하기 편리한 구조인지 봐주세요.

---

## 📚 참고