### PR TITLE
보이스노트 제목 편집 기능을 추가합니다.

### DIFF
--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -17,8 +17,6 @@ public final class AppDIContainer {
     /// Repository
     private lazy var languageRepository = DefaultLanguageRepository(store: store)
     private lazy var voiceRecordRepository = DefaultVoiceRecordRepository(storageService: storageService)
-    private lazy var voiceRecordPlaybackRepository =
-        DefaultVoiceRecordPlaybackRepository(storageService: storageService)
     private lazy var checkFirstLaunchRepository = DefaultCheckFirstLaunchRepository(store: store)
     private lazy var folderRepository = DefaultFolderRepository(store: localDataBase)
     private lazy var voiceNoteRepository = DefaultVoiceNoteRepository(store: localDataBase)
@@ -71,7 +69,7 @@ public final class AppDIContainer {
             voiceNoteUseCase: voiceNoteUseCase,
             folderUseCase: folderUseCase,
             languageRepository: languageRepository,
-            playbackRepository: voiceRecordPlaybackRepository,
+            playbackRepository: DefaultVoiceRecordPlaybackRepository(storageService: storageService),
             wasteBasketRepository: wasteBasketRepository
         )
     }

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -51,6 +51,7 @@ public final class AppDIContainer {
         OnBoardingViewModel(
             languageRepository: languageRepository,
             voiceRecordRepository: voiceRecordRepository,
+            sttRepository: sttRepository,
             checkFirstLaunchRepository: checkFirstLaunchRepository,
             folderUseCase: folderUseCase
         )

--- a/Data/Sources/Infrastructure/CoreData/CoreDataLocalDataBase.swift
+++ b/Data/Sources/Infrastructure/CoreData/CoreDataLocalDataBase.swift
@@ -135,4 +135,42 @@ public extension CoreDataLocalDataBase {
             throw .deleteFailed
         }
     }
+
+    func observe<MO: ManagedObjectMapping>(
+        byID id: MO.ModelType.ID,
+        as entity: MO.Type
+    ) throws(CoreDataStorageError) -> AsyncStream<MO.ModelType> {
+        let context = container.viewContext
+        guard let initialEntity = try? MO.find(byID: id, in: context) else {
+            throw .fetchFailed
+        }
+        let initial = initialEntity.toModel()
+
+        return AsyncStream { continuation in
+            continuation.yield(initial)
+
+            let task = Task { @MainActor in
+                let notifications = NotificationCenter.default.notifications(
+                    named: NSManagedObjectContext.didSaveObjectsNotification,
+                    object: context
+                )
+                for await notification in notifications {
+                    let changed: Set<NSManagedObject> = [NSUpdatedObjectsKey, NSInsertedObjectsKey]
+                        .compactMap { notification.userInfo?[$0] as? Set<NSManagedObject> }
+                        .reduce(into: []) { $0.formUnion($1) }
+
+                    guard changed.contains(where: { ($0 as? MO)?.toModel().id == id }) else { continue }
+
+                    if let refreshed = try? MO.find(byID: id, in: context) {
+                        continuation.yield(refreshed.toModel())
+                    } else {
+                        continuation.finish()
+                        break
+                    }
+                }
+            }
+
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
 }

--- a/Data/Sources/Repositories/VoiceNotes/DefaultSTTRepository.swift
+++ b/Data/Sources/Repositories/VoiceNotes/DefaultSTTRepository.swift
@@ -83,11 +83,18 @@ public actor DefaultSTTRepository: STTRepository {
         continuation: CheckedContinuation<Transcript, any Error>
     ) throws(STTRepositoryError) {
         guard !Task.isCancelled else { throw .cancelled }
-        guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
+        
+        guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "ko-KR")) else {
+            AppLogger.error("SFSpeechRecognizer 초기화 실패 (ko-KR)")
             throw .transcribeFailed
         }
 
+        if !recognizer.isAvailable {
+            AppLogger.warning("SFSpeechRecognizer를 현재 사용할 수 없는 상태입니다. (isAvailable = false)")
+        }
+
         let request = SFSpeechURLRecognitionRequest(url: audioFileURL)
+        request.requiresOnDeviceRecognition = false
         currentContinuation = continuation
 
         currentTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
@@ -152,6 +159,18 @@ public actor DefaultSTTRepository: STTRepository {
             return .transcribeFailed
         }
 
+        // 추가 전사 오류 처리 (kLSRErrorDomain 300, kAFAssistantErrorDomain 1101)
+        if nsError.domain == "kLSRErrorDomain", nsError.code == 300 {
+            AppLogger.error("전사 실패: kLSRErrorDomain (300)")
+            return .transcribeFailed
+        }
+
+        if nsError.domain == "kAFAssistantErrorDomain", nsError.code == 1101 {
+            AppLogger.error("전사 실패: kAFAssistantErrorDomain (1101)")
+            return .transcribeFailed
+        }
+
+        AppLogger.error("알 수 없는 전사 오류: \(error.localizedDescription) (Domain: \(nsError.domain), Code: \(nsError.code))")
         return .unknown(error)
     }
 }

--- a/Data/Sources/Repositories/VoiceNotes/DefaultSTTRepository.swift
+++ b/Data/Sources/Repositories/VoiceNotes/DefaultSTTRepository.swift
@@ -83,7 +83,7 @@ public actor DefaultSTTRepository: STTRepository {
         continuation: CheckedContinuation<Transcript, any Error>
     ) throws(STTRepositoryError) {
         guard !Task.isCancelled else { throw .cancelled }
-        
+
         guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "ko-KR")) else {
             AppLogger.error("SFSpeechRecognizer 초기화 실패 (ko-KR)")
             throw .transcribeFailed
@@ -170,7 +170,8 @@ public actor DefaultSTTRepository: STTRepository {
             return .transcribeFailed
         }
 
-        AppLogger.error("알 수 없는 전사 오류: \(error.localizedDescription) (Domain: \(nsError.domain), Code: \(nsError.code))")
+        AppLogger
+            .error("알 수 없는 전사 오류: \(error.localizedDescription) (Domain: \(nsError.domain), Code: \(nsError.code))")
         return .unknown(error)
     }
 }

--- a/Data/Sources/Repositories/VoiceNotes/DefaultVoiceNoteRepository.swift
+++ b/Data/Sources/Repositories/VoiceNotes/DefaultVoiceNoteRepository.swift
@@ -85,6 +85,15 @@ public struct DefaultVoiceNoteRepository: VoiceNoteRepository {
         }
     }
 
+    public func observe(id: UUID) throws(VoiceNoteRepositoryError) -> AsyncStream<VoiceNote> {
+        do {
+            return try store.observe(byID: id, as: VoiceNoteEntity.self)
+        } catch {
+            AppLogger.error(error)
+            throw .fetchFailed(id: id)
+        }
+    }
+
     private func fetchDefaultFolder() throws(VoiceNoteRepositoryError) -> Folder {
         do {
             let folders = try store.fetchAll(FolderEntity.self)

--- a/Data/Tests/Repositories/VoiceNotes/DefaultVoiceNoteRepositoryTest.swift
+++ b/Data/Tests/Repositories/VoiceNotes/DefaultVoiceNoteRepositoryTest.swift
@@ -8,7 +8,8 @@ final class DefaultVoiceNoteRepositoryTest: XCTestCase {
     private var store: CoreDataLocalDataBase!
     private var sut: DefaultVoiceNoteRepository!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
+        try await super.setUp()
         store = try CoreDataLocalDataBase(inMemory: true)
         sut = DefaultVoiceNoteRepository(store: store)
     }
@@ -49,7 +50,8 @@ final class DefaultVoiceNoteRepositoryTest: XCTestCase {
             voiceRecord: note.voiceRecord,
             keywords: [],
             transcript: Transcript(text: "전사"),
-            summary: Summary(text: "요약")
+            summary: Summary(text: "요약"),
+            analysisState: .completed
         )
 
         // When

--- a/Domain/Sources/Entities/VoiceNote.swift
+++ b/Domain/Sources/Entities/VoiceNote.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum AnalysisState: Sendable, Hashable {
     case pending
     case analyzing
+    case transcribed
     case completed
     case failed
 }
@@ -43,6 +44,14 @@ public struct VoiceNote: Sendable, Identifiable, Hashable {
         self.transcript = transcript
         self.summary = summary
         self.deletedAt = deletedAt
-        self.analysisState = analysisState ?? (summary != nil && transcript != nil ? .completed : .pending)
+        if let analysisState {
+            self.analysisState = analysisState
+        } else if summary != nil, transcript != nil {
+            self.analysisState = .completed
+        } else if transcript != nil {
+            self.analysisState = .transcribed
+        } else {
+            self.analysisState = .pending
+        }
     }
 }

--- a/Domain/Sources/Interfaces/VoiceNotes/VoiceNoteRepository.swift
+++ b/Domain/Sources/Interfaces/VoiceNotes/VoiceNoteRepository.swift
@@ -20,4 +20,7 @@ public protocol VoiceNoteRepository: Sendable {
 
     /// 최근 생성된 음성 메모를 조회합니다.
     func fetchRecent(limit: Int) throws(VoiceNoteRepositoryError) -> [VoiceNote]
+
+    /// ID로 음성 메모를 관찰합니다. 첫 emit은 현재 상태이며, 이후 변경 시 재emit됩니다.
+    func observe(id: UUID) throws(VoiceNoteRepositoryError) -> AsyncStream<VoiceNote>
 }

--- a/Domain/Sources/Policy.swift
+++ b/Domain/Sources/Policy.swift
@@ -35,7 +35,7 @@ public enum Policy {
     public static let playbackProgressUpdateInterval: UInt64 = 100_000_000
 
     /// 재생 빨리감기/뒤로가기 이동 간격 (초)
-    public static let playbackSkipInterval: TimeInterval = 10
+    public static let playbackSkipInterval: TimeInterval = 5
 
     /// 세그먼트 간 공백이 이 값(초)을 초과하면 새 섹션으로 분리
     public static let scriptGroupingPauseThreshold: TimeInterval = 2.0

--- a/Domain/Sources/UseCases/VoiceNotes/VoiceNoteUseCase.swift
+++ b/Domain/Sources/UseCases/VoiceNotes/VoiceNoteUseCase.swift
@@ -25,6 +25,9 @@ public protocol VoiceNoteUseCase: Sendable {
     /// 오디오 파일을 분석하여 전사·키워드·요약 결과를 반환합니다.
     func summarize(audioFilePath: String, language: Language) async throws(VoiceNoteUseCaseError)
         -> AudioToSummaryResult
+
+    /// ID로 음성 메모를 관찰합니다. 첫 emit은 현재 상태이며, 이후 변경 시 재emit됩니다.
+    func observe(id: UUID) throws(VoiceNoteUseCaseError) -> AsyncStream<VoiceNote>
 }
 
 /// 음성 메모 통합 유스케이스 구현체.
@@ -139,6 +142,16 @@ public struct DefaultVoiceNoteUseCase: VoiceNoteUseCase {
 
         do {
             return try repository.update(updatedNote)
+        } catch {
+            throw VoiceNoteUseCaseError(error)
+        }
+    }
+
+    // MARK: - Observe
+
+    public func observe(id: UUID) throws(VoiceNoteUseCaseError) -> AsyncStream<VoiceNote> {
+        do {
+            return try repository.observe(id: id)
         } catch {
             throw VoiceNoteUseCaseError(error)
         }

--- a/Domain/Sources/UseCases/VoiceNotes/VoiceNoteUseCase.swift
+++ b/Domain/Sources/UseCases/VoiceNotes/VoiceNoteUseCase.swift
@@ -22,9 +22,12 @@ public protocol VoiceNoteUseCase: Sendable {
     /// 음성 메모 정보를 업데이트합니다.
     func update(_ voiceNote: VoiceNote) throws(VoiceNoteUseCaseError) -> VoiceNote
 
-    /// 오디오 파일을 분석하여 전사·키워드·요약 결과를 반환합니다.
-    func summarize(audioFilePath: String, language: Language) async throws(VoiceNoteUseCaseError)
-        -> AudioToSummaryResult
+    /// 오디오 파일을 전사하여 Transcript를 반환합니다.
+    func transcribe(audioFilePath: String) async throws(VoiceNoteUseCaseError) -> Transcript
+
+    /// Transcript를 분석하여 키워드와 요약을 반환합니다.
+    func summarize(transcript: Transcript, language: Language) async throws(VoiceNoteUseCaseError)
+        -> (keywords: [Keyword], summary: Summary)
 
     /// ID로 음성 메모를 관찰합니다. 첫 emit은 현재 상태이며, 이후 변경 시 재emit됩니다.
     func observe(id: UUID) throws(VoiceNoteUseCaseError) -> AsyncStream<VoiceNote>
@@ -137,7 +140,8 @@ public struct DefaultVoiceNoteUseCase: VoiceNoteUseCase {
             keywords: voiceNote.keywords,
             transcript: voiceNote.transcript,
             summary: voiceNote.summary,
-            deletedAt: voiceNote.deletedAt
+            deletedAt: voiceNote.deletedAt,
+            analysisState: voiceNote.analysisState
         )
 
         do {
@@ -157,27 +161,28 @@ public struct DefaultVoiceNoteUseCase: VoiceNoteUseCase {
         }
     }
 
-    // MARK: - Analysis (Summarize)
+    // MARK: - Transcribe
 
-    public func summarize(audioFilePath: String, language: Language) async throws(VoiceNoteUseCaseError)
-        -> AudioToSummaryResult
-    {
+    public func transcribe(audioFilePath: String) async throws(VoiceNoteUseCaseError) -> Transcript {
         do {
             try Task.checkCancellation()
+            return try await sttRepository.transcribe(audioFilePath: audioFilePath)
+        } catch {
+            if Task.isCancelled { throw .cancelled }
+            AppLogger.error(error)
+            throw VoiceNoteUseCaseError.analysisFailed(error)
+        }
+    }
 
-            let transcript = try await sttRepository.transcribe(audioFilePath: audioFilePath)
+    // MARK: - Summarize
 
+    public func summarize(
+        transcript: Transcript,
+        language: Language
+    ) async throws(VoiceNoteUseCaseError) -> (keywords: [Keyword], summary: Summary) {
+        do {
             try Task.checkCancellation()
-
-            let (keywords, summary) = try await summaryRepository.summarize(transcript: transcript, language: language)
-
-            try Task.checkCancellation()
-
-            return AudioToSummaryResult(
-                transcript: transcript,
-                keywords: keywords,
-                summary: summary
-            )
+            return try await summaryRepository.summarize(transcript: transcript, language: language)
         } catch {
             if Task.isCancelled { throw .cancelled }
             AppLogger.error(error)

--- a/Domain/Testing/Entities/Stubs/VoiceNote+Stub.swift
+++ b/Domain/Testing/Entities/Stubs/VoiceNote+Stub.swift
@@ -12,7 +12,8 @@ public extension VoiceNote {
         keywords: [Keyword] = [],
         transcript: Transcript? = nil,
         summary: Summary? = nil,
-        deletedAt: Date? = nil
+        deletedAt: Date? = nil,
+        analysisState: AnalysisState? = nil
     ) -> VoiceNote {
         VoiceNote(
             id: id,
@@ -24,7 +25,8 @@ public extension VoiceNote {
             keywords: keywords,
             transcript: transcript,
             summary: summary,
-            deletedAt: deletedAt
+            deletedAt: deletedAt,
+            analysisState: analysisState
         )
     }
 }

--- a/Domain/Testing/Interfaces/Mocks/VoiceNote/MockVoiceNoteRepository.swift
+++ b/Domain/Testing/Interfaces/Mocks/VoiceNote/MockVoiceNoteRepository.swift
@@ -9,6 +9,7 @@ public final class MockVoiceNoteRepository: VoiceNoteRepository {
     private var fetchResult: Result<VoiceNote, VoiceNoteRepositoryError>?
     private var fetchAllResult: Result<[VoiceNote], VoiceNoteRepositoryError>?
     private var fetchRecentResult: Result<[VoiceNote], VoiceNoteRepositoryError>?
+    private var observeResult: Result<AsyncStream<VoiceNote>, VoiceNoteRepositoryError>?
 
     public init() {}
 
@@ -19,6 +20,7 @@ public final class MockVoiceNoteRepository: VoiceNoteRepository {
     private var fetchAllFromDefaultFolderCallCount = 0
     private var fetchAllCallCount = 0
     private var fetchRecentCallCount = 0
+    private var observeCallCount = 0
 
     // Actual Inputs
     private var actualVoiceRecord: VoiceRecord?
@@ -35,6 +37,7 @@ public final class MockVoiceNoteRepository: VoiceNoteRepository {
     private var expectedFetchAllCallCount: Int?
     private var expectedFetchAllFolderID: UUID?
     private var expectedFetchRecentCallCount: Int?
+    private var expectedObserveCallCount: Int?
 
     /// Set Results
     public func setCreateResult(_ result: Result<VoiceNote, VoiceNoteRepositoryError>) {
@@ -55,6 +58,10 @@ public final class MockVoiceNoteRepository: VoiceNoteRepository {
 
     public func setFetchRecentResult(_ result: Result<[VoiceNote], VoiceNoteRepositoryError>) {
         fetchRecentResult = result
+    }
+
+    public func setObserveResult(_ result: Result<AsyncStream<VoiceNote>, VoiceNoteRepositoryError>) {
+        observeResult = result
     }
 
     /// Expect Methods
@@ -81,6 +88,10 @@ public final class MockVoiceNoteRepository: VoiceNoteRepository {
 
     public func expectFetchRecent(callCount: Int) {
         expectedFetchRecentCallCount = callCount
+    }
+
+    public func expectObserve(callCount: Int) {
+        expectedObserveCallCount = callCount
     }
 
     public func verify(file: StaticString = #filePath, line: UInt = #line) {
@@ -130,6 +141,13 @@ public final class MockVoiceNoteRepository: VoiceNoteRepository {
             fetchRecentCallCount,
             exp,
             "fetchRecent 호출 횟수 불일치",
+            file: file,
+            line: line
+        ) }
+        if let exp = expectedObserveCallCount { XCTAssertEqual(
+            observeCallCount,
+            exp,
+            "observe 호출 횟수 불일치",
             file: file,
             line: line
         ) }
@@ -198,6 +216,16 @@ public final class MockVoiceNoteRepository: VoiceNoteRepository {
         case .success(let val): return val
         case .failure(let err): throw err
         case .none: XCTFail("fetchRecentResult 미설정")
+            throw .unknown(NSError(domain: "Mock", code: -1))
+        }
+    }
+
+    public func observe(id: UUID) throws(VoiceNoteRepositoryError) -> AsyncStream<VoiceNote> {
+        observeCallCount += 1
+        switch observeResult {
+        case .success(let stream): return stream
+        case .failure(let err): throw err
+        case .none: XCTFail("observeResult 미설정")
             throw .unknown(NSError(domain: "Mock", code: -1))
         }
     }

--- a/Domain/Tests/UseCases/Folders/FolderUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Folders/FolderUseCaseTest.swift
@@ -66,7 +66,7 @@ extension FolderUseCaseTest {
                 _ = try sut.create(name: name)
                 XCTFail("FolderUseCaseError.invalidName 에러를 throw 해야 합니다. (input: '\(name)')")
             } catch {
-                guard case .invalidName = error as? FolderUseCaseError else {
+                guard case .invalidName = error else {
                     XCTFail(
                         "예상한 에러는 FolderUseCaseError.invalidName 이지만, 실제 받은 에러는 \(error) 입니다. (input: '\(name)')"
                     )

--- a/Domain/Tests/UseCases/Folders/FolderUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Folders/FolderUseCaseTest.swift
@@ -1,5 +1,5 @@
-import Core
 @testable import Domain
+import Core
 import DomainTesting
 import XCTest
 
@@ -165,7 +165,7 @@ extension FolderUseCaseTest {
             _ = try sut.create(name: "Unknown Test")
             XCTFail("FolderUseCaseError.unknown 에러를 throw 해야 합니다.")
         } catch {
-            guard case let .unknown(wrappedError) = error else {
+            guard case .unknown(let wrappedError) = error else {
                 XCTFail(
                     "예상한 에러는 FolderUseCaseError.unknown 이지만, 실제 받은 에러는 \(error) 입니다."
                 )
@@ -190,7 +190,7 @@ extension FolderUseCaseTest {
             Folder.stub(name: "기본 폴더", isDeletable: false),
             Folder.stub(name: "휴지통에 있는 폴더", deletedAt: Date()),
             Folder.stub(name: "Folder 1", isDeletable: true),
-            Folder.stub(name: "Folder 2", isDeletable: true),
+            Folder.stub(name: "Folder 2", isDeletable: true)
         ]
         repository.setFetchAllResult(.success(expectedFolders))
         repository.expectFetchAll(callCount: 1)
@@ -215,7 +215,7 @@ extension FolderUseCaseTest {
             Folder.stub(name: "기본 폴더", isDeletable: false),
             Folder.stub(name: "휴지통에 있는 폴더", deletedAt: Date()),
             Folder.stub(name: "Folder 1", isDeletable: true),
-            Folder.stub(name: "Folder 2", isDeletable: true),
+            Folder.stub(name: "Folder 2", isDeletable: true)
         ]
         repository.setFetchAllResult(.success(expectedFolders))
         repository.expectFetchAll(callCount: 1)

--- a/Domain/Tests/UseCases/Folders/FolderUseCaseTest.swift
+++ b/Domain/Tests/UseCases/Folders/FolderUseCaseTest.swift
@@ -1,5 +1,5 @@
-@testable import Domain
 import Core
+@testable import Domain
 import DomainTesting
 import XCTest
 
@@ -165,7 +165,7 @@ extension FolderUseCaseTest {
             _ = try sut.create(name: "Unknown Test")
             XCTFail("FolderUseCaseError.unknown 에러를 throw 해야 합니다.")
         } catch {
-            guard case .unknown(let wrappedError) = error else {
+            guard case let .unknown(wrappedError) = error else {
                 XCTFail(
                     "예상한 에러는 FolderUseCaseError.unknown 이지만, 실제 받은 에러는 \(error) 입니다."
                 )
@@ -190,7 +190,7 @@ extension FolderUseCaseTest {
             Folder.stub(name: "기본 폴더", isDeletable: false),
             Folder.stub(name: "휴지통에 있는 폴더", deletedAt: Date()),
             Folder.stub(name: "Folder 1", isDeletable: true),
-            Folder.stub(name: "Folder 2", isDeletable: true)
+            Folder.stub(name: "Folder 2", isDeletable: true),
         ]
         repository.setFetchAllResult(.success(expectedFolders))
         repository.expectFetchAll(callCount: 1)
@@ -215,7 +215,7 @@ extension FolderUseCaseTest {
             Folder.stub(name: "기본 폴더", isDeletable: false),
             Folder.stub(name: "휴지통에 있는 폴더", deletedAt: Date()),
             Folder.stub(name: "Folder 1", isDeletable: true),
-            Folder.stub(name: "Folder 2", isDeletable: true)
+            Folder.stub(name: "Folder 2", isDeletable: true),
         ]
         repository.setFetchAllResult(.success(expectedFolders))
         repository.expectFetchAll(callCount: 1)
@@ -333,7 +333,7 @@ extension FolderUseCaseTest {
                 _ = try sut.update(folder)
                 XCTFail("FolderUseCaseError.invalidName 에러를 throw 해야 합니다. (input: '\(name)')")
             } catch {
-                guard case .invalidName = error as? FolderUseCaseError else {
+                guard case .invalidName = error else {
                     XCTFail(
                         "예상한 에러는 FolderUseCaseError.invalidName 이지만, 실제 받은 에러는 \(error) 입니다. (input: '\(name)')"
                     )

--- a/Domain/Tests/UseCases/VoiceNotes/VoiceNoteUseCaseTest.swift
+++ b/Domain/Tests/UseCases/VoiceNotes/VoiceNoteUseCaseTest.swift
@@ -106,37 +106,64 @@ extension VoiceNoteUseCaseTest {
     }
 }
 
-// MARK: - Summarize
+// MARK: - Transcribe
 
 extension VoiceNoteUseCaseTest {
-    func test_summarize_정상호출시_STT및요약을순차적으로수행한다() async throws {
+    func test_transcribe_정상호출시_전사본을반환한다() async throws {
         let sut = makeSUT()
         let audioPath = "test.m4a"
         let transcript = Transcript.stub(text: "전사본")
-        let summary = Summary.stub(text: "요약본")
-        let keywords = [Keyword.stub(word: "키워드")]
 
         await sut.sttRepository.setResult(.success(transcript))
         await sut.sttRepository.expectTranscribe(callCount: 1, audioFilePath: audioPath)
 
-        await sut.summaryRepository.setResult(.success((keywords, summary)))
-        await sut.summaryRepository.expectSummarize(callCount: 1, transcriptText: transcript.text)
+        let result = try await sut.useCase.transcribe(audioFilePath: audioPath)
 
-        let result = try await sut.useCase.summarize(audioFilePath: audioPath, language: .ko)
-
-        XCTAssertEqual(result.transcript.text, "전사본")
-        XCTAssertEqual(result.summary.text, "요약본")
-        XCTAssertEqual(result.keywords.first?.word, "키워드")
+        XCTAssertEqual(result.text, "전사본")
         await sut.sttRepository.verify()
-        await sut.summaryRepository.verify()
     }
 
-    func test_summarize_STT실패시_analysisFailed에러를던진다() async {
+    func test_transcribe_STT실패시_analysisFailed에러를던진다() async {
         let sut = makeSUT()
         await sut.sttRepository.setResult(.failure(.transcribeFailed))
 
         do {
-            _ = try await sut.useCase.summarize(audioFilePath: "test.m4a", language: .ko)
+            _ = try await sut.useCase.transcribe(audioFilePath: "test.m4a")
+            XCTFail("에러가 발생해야 합니다.")
+        } catch {
+            guard case VoiceNoteUseCaseError.analysisFailed = error else {
+                return XCTFail("잘못된 에러 타입: \(error)")
+            }
+        }
+    }
+}
+
+// MARK: - Summarize
+
+extension VoiceNoteUseCaseTest {
+    func test_summarize_정상호출시_키워드와요약을반환한다() async throws {
+        let sut = makeSUT()
+        let transcript = Transcript.stub(text: "전사본")
+        let summary = Summary.stub(text: "요약본")
+        let keywords = [Keyword.stub(word: "키워드")]
+
+        await sut.summaryRepository.setResult(.success((keywords, summary)))
+        await sut.summaryRepository.expectSummarize(callCount: 1, transcriptText: transcript.text)
+
+        let result = try await sut.useCase.summarize(transcript: transcript, language: .ko)
+
+        XCTAssertEqual(result.summary.text, "요약본")
+        XCTAssertEqual(result.keywords.first?.word, "키워드")
+        await sut.summaryRepository.verify()
+    }
+
+    func test_summarize_요약실패시_analysisFailed에러를던진다() async {
+        let sut = makeSUT()
+        let transcript = Transcript.stub(text: "전사본")
+        await sut.summaryRepository.setResult(.failure(.summarizeFailed))
+
+        do {
+            _ = try await sut.useCase.summarize(transcript: transcript, language: .ko)
             XCTFail("에러가 발생해야 합니다.")
         } catch {
             guard case VoiceNoteUseCaseError.analysisFailed = error else {

--- a/Presentation/Sources/View/Recoding/RecordingViewController.swift
+++ b/Presentation/Sources/View/Recoding/RecordingViewController.swift
@@ -174,7 +174,7 @@ public final class RecordingViewController: ViewController {
             recordButton.widthAnchor.constraint(equalToConstant: 120),
             recordButton.heightAnchor.constraint(equalToConstant: 60),
             recordButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -40),
-            recordButton.topAnchor.constraint(greaterThanOrEqualTo: durationLabel.bottomAnchor, constant: 48),
+            recordButton.topAnchor.constraint(greaterThanOrEqualTo: durationLabel.bottomAnchor, constant: 48)
         ])
     }
 
@@ -193,7 +193,7 @@ public final class RecordingViewController: ViewController {
             completeAlertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             completeAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             completeAlertView.centerXAnchor.constraint(equalTo: completeAlertOverlayView.centerXAnchor),
-            completeAlertView.centerYAnchor.constraint(equalTo: completeAlertOverlayView.centerYAnchor),
+            completeAlertView.centerYAnchor.constraint(equalTo: completeAlertOverlayView.centerYAnchor)
         ])
     }
 

--- a/Presentation/Sources/View/Recoding/RecordingViewController.swift
+++ b/Presentation/Sources/View/Recoding/RecordingViewController.swift
@@ -174,7 +174,7 @@ public final class RecordingViewController: ViewController {
             recordButton.widthAnchor.constraint(equalToConstant: 120),
             recordButton.heightAnchor.constraint(equalToConstant: 60),
             recordButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -40),
-            recordButton.topAnchor.constraint(greaterThanOrEqualTo: durationLabel.bottomAnchor, constant: 48)
+            recordButton.topAnchor.constraint(greaterThanOrEqualTo: durationLabel.bottomAnchor, constant: 48),
         ])
     }
 
@@ -193,7 +193,7 @@ public final class RecordingViewController: ViewController {
             completeAlertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             completeAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             completeAlertView.centerXAnchor.constraint(equalTo: completeAlertOverlayView.centerXAnchor),
-            completeAlertView.centerYAnchor.constraint(equalTo: completeAlertOverlayView.centerYAnchor)
+            completeAlertView.centerYAnchor.constraint(equalTo: completeAlertOverlayView.centerYAnchor),
         ])
     }
 
@@ -214,10 +214,3 @@ public final class RecordingViewController: ViewController {
         }
     }
 }
-
-#if DEBUG
-    #Preview {
-        UINavigationController(rootViewController: RecordingViewController(viewModel: .preview())
-        )
-    }
-#endif

--- a/Presentation/Sources/View/VoiceNote/ScriptCell.swift
+++ b/Presentation/Sources/View/VoiceNote/ScriptCell.swift
@@ -106,7 +106,8 @@ final class ScriptContentView: UIView, UIContentView {
 
         // 문단 내용이 바뀌거나 편집 모드가 전환될 때만 뷰 재구성
         let currentIsEditing = paragraphRows.first?.view is UITextView
-        let needsRebuild = paragraphRows.isEmpty || paragraphRows.count != config.paragraphs.count || currentIsEditing != config.isEditing
+        let needsRebuild = paragraphRows.isEmpty || paragraphRows.count != config.paragraphs
+            .count || currentIsEditing != config.isEditing
 
         if needsRebuild {
             paragraphsStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
@@ -155,7 +156,7 @@ final class ScriptContentView: UIView, UIContentView {
                 }
             }
         }
-        
+
         applyHighlight(paragraphIndex: config.highlightedParagraphIndex)
     }
 
@@ -181,9 +182,11 @@ extension ScriptContentView: UITextViewDelegate {
         guard let config = configuration as? ScriptContentConfiguration else { return }
         let text = textView.text ?? ""
         config.onParagraphEdited?(config.sectionIndex, textView.tag, text)
-        
+
         // UITextView 높이가 바뀔 때 CollectionView 셀 높이를 재계산하도록 유도
-        if let collectionView = self.firstAvailableViewController()?.view.subviews.first(where: { $0 is UICollectionView }) as? UICollectionView {
+        if let collectionView = firstAvailableViewController()?.view.subviews
+            .first(where: { $0 is UICollectionView }) as? UICollectionView
+        {
             UIView.performWithoutAnimation {
                 collectionView.collectionViewLayout.invalidateLayout()
             }

--- a/Presentation/Sources/View/VoiceNote/ScriptCell.swift
+++ b/Presentation/Sources/View/VoiceNote/ScriptCell.swift
@@ -7,7 +7,7 @@ struct ScriptContentConfiguration: UIContentConfiguration {
     var timestamp: String = ""
     var timestampSeconds: TimeInterval = 0
     var paragraphs: [String] = []
-    var highlight: VoiceNoteViewModel.PlaybackHighlight?
+    var highlightedParagraphIndex: Int?
     var isEditing: Bool = false
     var onParagraphEdited: ((Int, Int, String) -> Void)?
     /// 타임스탬프 탭 콜백
@@ -97,15 +97,6 @@ final class ScriptContentView: UIView, UIContentView {
         config.onTimestampTapped?(config.timestampSeconds)
     }
 
-    // MARK: - UIView Update Cycle
-
-    /// @Observable PlaybackHighlight를 자동 추적합니다.
-    /// playingParagraphInfo가 변경될 때마다 UIKit이 재호출합니다.
-    override func updateProperties() {
-        super.updateProperties()
-        updateHighlight()
-    }
-
     // MARK: - Apply
 
     private func apply(configuration: UIContentConfiguration) {
@@ -165,18 +156,10 @@ final class ScriptContentView: UIView, UIContentView {
             }
         }
         
-        // 뷰 구성 직후 현재 하이라이트 상태 즉시 적용
-        updateHighlight()
+        applyHighlight(paragraphIndex: config.highlightedParagraphIndex)
     }
 
     // MARK: - Highlight
-
-    private func updateHighlight() {
-        guard let config = configuration as? ScriptContentConfiguration else { return }
-        let info = config.highlight?.playingParagraphInfo
-        let index = info?.sectionIndex == config.sectionIndex ? info?.paragraphIndex : nil
-        applyHighlight(paragraphIndex: index)
-    }
 
     private func applyHighlight(paragraphIndex: Int?) {
         for (index, row) in paragraphRows.enumerated() {

--- a/Presentation/Sources/View/VoiceNote/ScriptCell.swift
+++ b/Presentation/Sources/View/VoiceNote/ScriptCell.swift
@@ -8,6 +8,8 @@ struct ScriptContentConfiguration: UIContentConfiguration {
     var timestampSeconds: TimeInterval = 0
     var paragraphs: [String] = []
     var highlight: VoiceNoteViewModel.PlaybackHighlight?
+    var isEditing: Bool = false
+    var onParagraphEdited: ((Int, Int, String) -> Void)?
     /// 타임스탬프 탭 콜백
     var onTimestampTapped: ((TimeInterval) -> Void)?
 
@@ -51,8 +53,8 @@ final class ScriptContentView: UIView, UIContentView {
         return stack
     }()
 
-    /// 문단별 (배경 컨테이너, 텍스트 레이블) 쌍. 하이라이트 직접 업데이트에 사용
-    private var paragraphRows: [(background: UIView, label: UILabel)] = []
+    /// 문단별 (배경 컨테이너, 텍스트 레이블 또는 텍스트 뷰) 쌍. 하이라이트 직접 업데이트에 사용
+    private var paragraphRows: [(background: UIView, view: UIView)] = []
 
     // MARK: - Init
 
@@ -116,27 +118,47 @@ final class ScriptContentView: UIView, UIContentView {
 
         if needsRebuild {
             paragraphsStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
-            paragraphRows = config.paragraphs.map { para in
-                let label = UILabel()
-                label.setTypography(text: para, style: .body1)
-                label.numberOfLines = 0
-                label.translatesAutoresizingMaskIntoConstraints = false
+            paragraphRows = config.paragraphs.enumerated().map { pIdx, para in
+                let contentView: UIView
+                if config.isEditing {
+                    let textView = UITextView()
+                    textView.text = para
+                    textView.font = Typography.body1.font
+                    textView.textColor = UIColor.gray950
+                    textView.backgroundColor = .clear
+                    textView.isScrollEnabled = false
+                    textView.textContainerInset = .zero
+                    textView.textContainer.lineFragmentPadding = 0
+                    textView.delegate = self
+                    textView.tag = pIdx
+                    contentView = textView
+                } else {
+                    let label = UILabel()
+                    label.setTypography(text: para, style: .body1)
+                    label.numberOfLines = 0
+                    contentView = label
+                }
+                contentView.translatesAutoresizingMaskIntoConstraints = false
 
                 let background = UIView()
                 background.layer.cornerRadius = 8
-                background.addSubview(label)
+                background.addSubview(contentView)
                 NSLayoutConstraint.activate([
-                    label.topAnchor.constraint(equalTo: background.topAnchor, constant: 8),
-                    label.bottomAnchor.constraint(equalTo: background.bottomAnchor, constant: -8),
-                    label.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: 12),
-                    label.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -12)
+                    contentView.topAnchor.constraint(equalTo: background.topAnchor, constant: 8),
+                    contentView.bottomAnchor.constraint(equalTo: background.bottomAnchor, constant: -8),
+                    contentView.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: 12),
+                    contentView.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -12)
                 ])
                 paragraphsStack.addArrangedSubview(background)
-                return (background, label)
+                return (background, contentView)
             }
         } else {
             for (row, para) in zip(paragraphRows, config.paragraphs) {
-                row.label.setTypography(text: para, style: .body1)
+                if let label = row.view as? UILabel {
+                    label.setTypography(text: para, style: .body1)
+                } else if let textView = row.view as? UITextView {
+                    textView.text = para
+                }
             }
         }
     }
@@ -147,7 +169,41 @@ final class ScriptContentView: UIView, UIContentView {
         for (index, row) in paragraphRows.enumerated() {
             let isHighlighted = paragraphIndex == index
             row.background.backgroundColor = isHighlighted ? UIColor.point600.withAlphaComponent(0.3) : .clear
-            row.label.textColor = isHighlighted ? .white : UIColor.gray600
+            if let label = row.view as? UILabel {
+                label.textColor = isHighlighted ? .white : UIColor.gray600
+            } else if let textView = row.view as? UITextView {
+                textView.textColor = isHighlighted ? .white : UIColor.gray600
+            }
         }
+    }
+}
+
+// MARK: - UITextViewDelegate
+
+extension ScriptContentView: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        guard let config = configuration as? ScriptContentConfiguration else { return }
+        let text = textView.text ?? ""
+        config.onParagraphEdited?(config.sectionIndex, textView.tag, text)
+        
+        // UITextView 높이가 바뀔 때 CollectionView 셀 높이를 재계산하도록 유도
+        if let collectionView = self.firstAvailableViewController()?.view.subviews.first(where: { $0 is UICollectionView }) as? UICollectionView {
+            UIView.performWithoutAnimation {
+                collectionView.collectionViewLayout.invalidateLayout()
+            }
+        }
+    }
+}
+
+private extension UIView {
+    func firstAvailableViewController() -> UIViewController? {
+        var responder: UIResponder? = self
+        while responder != nil {
+            if let viewController = responder as? UIViewController {
+                return viewController
+            }
+            responder = responder?.next
+        }
+        return nil
     }
 }

--- a/Presentation/Sources/View/VoiceNote/ScriptCell.swift
+++ b/Presentation/Sources/View/VoiceNote/ScriptCell.swift
@@ -117,7 +117,7 @@ final class ScriptContentView: UIView, UIContentView {
                     textView.text = para
                     textView.font = Typography.body1.font
                     textView.textColor = UIColor.gray950
-                    textView.backgroundColor = UIColor.gray100 // 편집 중임을 알기 쉽게 배경색 살짝 추가
+                    textView.backgroundColor = .clear
                     textView.layer.cornerRadius = 4
                     textView.isEditable = true
                     textView.isScrollEnabled = false

--- a/Presentation/Sources/View/VoiceNote/ScriptCell.swift
+++ b/Presentation/Sources/View/VoiceNote/ScriptCell.swift
@@ -53,6 +53,8 @@ final class ScriptContentView: UIView, UIContentView {
         return stack
     }()
 
+    private lazy var tapGesture = UITapGestureRecognizer(target: self, action: #selector(timestampTapped))
+
     /// 문단별 (배경 컨테이너, 텍스트 레이블 또는 텍스트 뷰) 쌍. 하이라이트 직접 업데이트에 사용
     private var paragraphRows: [(background: UIView, view: UIView)] = []
 
@@ -77,8 +79,7 @@ final class ScriptContentView: UIView, UIContentView {
         containerStack.addArrangedSubview(paragraphsStack)
         addSubview(containerStack)
 
-        let tap = UITapGestureRecognizer(target: self, action: #selector(timestampTapped))
-        containerStack.addGestureRecognizer(tap)
+        containerStack.addGestureRecognizer(tapGesture)
         containerStack.isUserInteractionEnabled = true
 
         NSLayoutConstraint.activate([
@@ -91,7 +92,8 @@ final class ScriptContentView: UIView, UIContentView {
 
     @objc
     private func timestampTapped() {
-        guard let config = configuration as? ScriptContentConfiguration else { return }
+        guard let config = configuration as? ScriptContentConfiguration,
+              !config.isEditing else { return } // 편집 모드일 때는 탭 동작 무시
         config.onTimestampTapped?(config.timestampSeconds)
     }
 
@@ -101,10 +103,7 @@ final class ScriptContentView: UIView, UIContentView {
     /// playingParagraphInfo가 변경될 때마다 UIKit이 재호출합니다.
     override func updateProperties() {
         super.updateProperties()
-        guard let config = configuration as? ScriptContentConfiguration else { return }
-        let info = config.highlight?.playingParagraphInfo
-        let index = info?.sectionIndex == config.sectionIndex ? info?.paragraphIndex : nil
-        applyHighlight(paragraphIndex: index)
+        updateHighlight()
     }
 
     // MARK: - Apply
@@ -112,9 +111,11 @@ final class ScriptContentView: UIView, UIContentView {
     private func apply(configuration: UIContentConfiguration) {
         guard let config = configuration as? ScriptContentConfiguration else { return }
         timeLabel.setTypography(text: config.timestamp, style: .caption)
+        tapGesture.isEnabled = !config.isEditing // 편집 모드일 때는 탭 제스처 비활성화
 
-        // 문단 내용이 바뀔 때만 뷰 재구성
-        let needsRebuild = paragraphRows.count != config.paragraphs.count
+        // 문단 내용이 바뀌거나 편집 모드가 전환될 때만 뷰 재구성
+        let currentIsEditing = paragraphRows.first?.view is UITextView
+        let needsRebuild = paragraphRows.isEmpty || paragraphRows.count != config.paragraphs.count || currentIsEditing != config.isEditing
 
         if needsRebuild {
             paragraphsStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
@@ -125,9 +126,11 @@ final class ScriptContentView: UIView, UIContentView {
                     textView.text = para
                     textView.font = Typography.body1.font
                     textView.textColor = UIColor.gray950
-                    textView.backgroundColor = .clear
+                    textView.backgroundColor = UIColor.gray100 // 편집 중임을 알기 쉽게 배경색 살짝 추가
+                    textView.layer.cornerRadius = 4
+                    textView.isEditable = true
                     textView.isScrollEnabled = false
-                    textView.textContainerInset = .zero
+                    textView.textContainerInset = UIEdgeInsets(top: 2, left: 0, bottom: 2, right: 0)
                     textView.textContainer.lineFragmentPadding = 0
                     textView.delegate = self
                     textView.tag = pIdx
@@ -161,9 +164,19 @@ final class ScriptContentView: UIView, UIContentView {
                 }
             }
         }
+        
+        // 뷰 구성 직후 현재 하이라이트 상태 즉시 적용
+        updateHighlight()
     }
 
     // MARK: - Highlight
+
+    private func updateHighlight() {
+        guard let config = configuration as? ScriptContentConfiguration else { return }
+        let info = config.highlight?.playingParagraphInfo
+        let index = info?.sectionIndex == config.sectionIndex ? info?.paragraphIndex : nil
+        applyHighlight(paragraphIndex: index)
+    }
 
     private func applyHighlight(paragraphIndex: Int?) {
         for (index, row) in paragraphRows.enumerated() {

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -257,6 +257,7 @@ private extension VoiceNoteViewController {
             guard let self else { return }
             Task { @MainActor in
                 self.viewModel.isEditing ? self.enterEditMode() : self.exitEditMode()
+                self.applySnapshot()
                 self.observeEditingState()
             }
         }
@@ -356,6 +357,10 @@ private extension VoiceNoteViewController {
                 timestampSeconds: section.timestamp,
                 paragraphs: section.paragraphs,
                 highlight: viewModel.playbackHighlight,
+                isEditing: viewModel.isEditing,
+                onParagraphEdited: { [weak self] sIdx, pIdx, text in
+                    self?.viewModel.updateScriptParagraph(sectionIndex: sIdx, paragraphIndex: pIdx, text: text)
+                },
                 onTimestampTapped: { [weak self] time in
                     self?.viewModel.scriptTimestampTapped(time)
                 }

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -29,8 +29,16 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
         label.textColor = UIColor.gray950
         label.lineBreakMode = .byTruncatingTail
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        label.isUserInteractionEnabled = true
+        let tap = UITapGestureRecognizer(target: self, action: #selector(titleLabelTapped))
+        label.addGestureRecognizer(tap)
         return label
     }()
+
+    @objc
+    private func titleLabelTapped() {
+        viewModel.enterTitleEditing()
+    }
 
     private lazy var titleTextField: UITextField = {
         let field = UITextField()
@@ -45,8 +53,14 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
     private lazy var doneButton: UIBarButtonItem = {
         let item = UIBarButtonItem(title: "완료", primaryAction: UIAction { [weak self] _ in
             guard let self else { return }
-            let title = titleTextField.text ?? ""
-            viewModel.doneEditing(title: title)
+            switch viewModel.editingMode {
+            case .title:
+                viewModel.doneTitleEditing(title: titleTextField.text ?? "")
+            case .script:
+                viewModel.doneScriptEditing()
+            case nil:
+                break
+            }
         })
         item.tintColor = UIColor.point800
         let paragraphStyle = NSMutableParagraphStyle()
@@ -146,7 +160,7 @@ private extension VoiceNoteViewController {
                 self?.viewModel.moveVoiceNote()
             }),
             UIAction(title: "편집하기", handler: { [weak self] _ in
-                self?.viewModel.enterEditing()
+                self?.viewModel.enterScriptEditing()
             }),
             UIAction(title: "삭제하기", attributes: .destructive, handler: { [weak self] _ in
                 self?.viewModel.deleteVoiceNote()
@@ -267,12 +281,11 @@ private extension VoiceNoteViewController {
 private extension VoiceNoteViewController {
     func observeEditingState() {
         withObservationTracking {
-            _ = viewModel.isEditing
+            _ = viewModel.editingMode
         } onChange: { [weak self] in
             guard let self else { return }
             Task { @MainActor in
-                self.viewModel.isEditing ? self.enterEditMode() : self.exitEditMode()
-                self.applySnapshot()
+                self.applyEditingMode(self.viewModel.editingMode)
                 self.observeEditingState()
             }
         }
@@ -280,7 +293,18 @@ private extension VoiceNoteViewController {
 }
 
 private extension VoiceNoteViewController {
-    func enterEditMode() {
+    func applyEditingMode(_ mode: VoiceNoteViewModel.EditingMode?) {
+        switch mode {
+        case .title:
+            enterTitleEditMode()
+        case .script:
+            enterScriptEditMode()
+        case nil:
+            exitEditMode()
+        }
+    }
+
+    func enterTitleEditMode() {
         titleTextField.text = viewModel.title
         titleTextField.frame.size.width = view.bounds.width
         navigationItem.titleView = titleTextField
@@ -290,6 +314,10 @@ private extension VoiceNoteViewController {
         titleTextField.selectAll(nil)
     }
 
+    func enterScriptEditMode() {
+        reconfigureScriptsOnly()
+    }
+
     func exitEditMode() {
         titleTextField.resignFirstResponder()
         titleLabel.text = viewModel.title
@@ -297,6 +325,15 @@ private extension VoiceNoteViewController {
         navigationItem.titleView = titleLabel
         navigationItem.rightBarButtonItems = normalRightBarButtonItems
         navigationItem.rightBarButtonItems?.forEach { $0.tintColor = .white }
+        reconfigureScriptsOnly()
+    }
+
+    func reconfigureScriptsOnly() {
+        var snapshot = dataSource.snapshot()
+        let scriptItems = snapshot.itemIdentifiers(inSection: .scripts)
+        guard !scriptItems.isEmpty else { return }
+        snapshot.reconfigureItems(scriptItems)
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
 }
 
@@ -374,7 +411,7 @@ private extension VoiceNoteViewController {
                 timestampSeconds: section.timestamp,
                 paragraphs: section.paragraphs,
                 highlightedParagraphIndex: highlightedParagraphIndex,
-                isEditing: viewModel.isEditing,
+                isEditing: viewModel.editingMode == .script,
                 onParagraphEdited: { [weak self] sIdx, pIdx, text in
                     self?.viewModel.updateScriptParagraph(sectionIndex: sIdx, paragraphIndex: pIdx, text: text)
                 },
@@ -426,17 +463,17 @@ private extension VoiceNoteViewController {
     func applySnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections(Section.allCases)
-        
+
         let metadataItems: [Item] = [.metadata]
         let keyPointItems = viewModel.keyPoints.map { Item.keyPoint(number: $0.number, text: $0.text) }
         let keywordItems: [Item] = [.keywords]
         let scriptItems = viewModel.scriptSections.indices.map { Item.script(index: $0) }
-        
+
         snapshot.appendItems(metadataItems, toSection: .metadata)
         snapshot.appendItems(keyPointItems, toSection: .keyPoints)
         snapshot.appendItems(keywordItems, toSection: .keywords)
         snapshot.appendItems(scriptItems, toSection: .scripts)
-        
+
         // 셀 내용이나 모드(isEditing)가 바뀌었을 수 있으므로 필요한 항목들을 재구성합니다.
         snapshot.reconfigureItems(metadataItems + keywordItems + scriptItems)
         dataSource.apply(snapshot, animatingDifferences: true)
@@ -447,16 +484,20 @@ private extension VoiceNoteViewController {
 
 extension VoiceNoteViewController: UITextFieldDelegate {
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        let title = textField.text ?? ""
-        viewModel.doneEditing(title: title)
+        viewModel.doneTitleEditing(title: textField.text ?? "")
         return true
+    }
+
+    public func textFieldDidEndEditing(_ textField: UITextField) {
+        guard viewModel.editingMode == .title else { return }
+        viewModel.doneTitleEditing(title: textField.text ?? "")
     }
 }
 
 // MARK: - Section / Item
 
 extension VoiceNoteViewController {
-    enum Section: Int, CaseIterable, Sendable {
+    enum Section: Int, CaseIterable {
         case metadata
         case keyPoints
         case keywords
@@ -481,7 +522,7 @@ extension VoiceNoteViewController {
         }
     }
 
-    enum Item: Hashable, Sendable {
+    enum Item: Hashable {
         case metadata
         case keyPoint(number: Int, text: String)
         case keywords

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -280,8 +280,8 @@ private extension VoiceNoteViewController {
     func enterEditMode() {
         titleTextField.text = viewModel.title
         titleTextField.frame.size.width = view.bounds.width
-        titleLabel.isHidden = true
         navigationItem.titleView = titleTextField
+        titleLabel.isHidden = true
         navigationItem.rightBarButtonItems = [doneButton]
         titleTextField.becomeFirstResponder()
         titleTextField.selectAll(nil)
@@ -289,8 +289,8 @@ private extension VoiceNoteViewController {
 
     func exitEditMode() {
         titleTextField.resignFirstResponder()
-        navigationItem.titleView = titleLabel
         titleLabel.isHidden = false
+        navigationItem.titleView = titleLabel
         navigationItem.rightBarButtonItems = normalRightBarButtonItems
         navigationItem.rightBarButtonItems?.forEach { $0.tintColor = .white }
     }

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -6,7 +6,6 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
     typealias Item = VoiceNoteViewModel.Item
 
     private let viewModel: VoiceNoteViewModel
-    private var hasAppliedCompletedSnapshot = false
     private lazy var dataSource = makeDataSource()
 
     // MARK: - UI Components
@@ -182,10 +181,7 @@ private extension VoiceNoteViewController {
                     snapshot.reconfigureItems([.metadata])
                     self.dataSource.apply(snapshot, animatingDifferences: false)
                 case .completed:
-                    if !self.hasAppliedCompletedSnapshot {
-                        self.hasAppliedCompletedSnapshot = true
-                        self.applySnapshot()
-                    }
+                    self.applySnapshot()
                 case .failed, .pending:
                     break
                 }

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -195,7 +195,6 @@ private extension VoiceNoteViewController {
         observeAnalysisState()
         observeErrorMessage()
         observeEditingState()
-        observeTitle()
     }
 
     private func observePlaybackState() {
@@ -243,18 +242,6 @@ private extension VoiceNoteViewController {
                     }
                 }
                 self.observeErrorMessage()
-            }
-        }
-    }
-
-    private func observeTitle() {
-        withObservationTracking {
-            _ = viewModel.title
-        } onChange: { [weak self] in
-            guard let self else { return }
-            Task { @MainActor in
-                self.titleLabel.text = self.viewModel.title
-                self.observeTitle()
             }
         }
     }

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -14,14 +14,31 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
     private let topBlurView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
     private lazy var segmentedControl = UnderlineSegmentedControl(items: [Section.keyPoints, .keywords, .scripts]
         .compactMap(\.title))
-    private lazy var backButton: UIButton = {
+    private lazy var backChevronButton: UIButton = {
         let btn = UIButton(type: .system)
         let backImage = UIImage(systemName: "chevron.left")?
             .withConfiguration(UIImage.SymbolConfiguration(weight: .bold))
         btn.setImage(backImage, for: .normal)
-        btn.titleLabel?.setTypography(style: .title1)
         btn.tintColor = UIColor.gray950
+        btn.addAction(UIAction { [weak self] _ in
+            self?.viewModel.send(.view(.pop))
+        }, for: .touchUpInside)
         return btn
+    }()
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = Typography.title1.font
+        label.textColor = UIColor.gray950
+        return label
+    }()
+
+    private lazy var navLeftView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [backChevronButton, titleLabel])
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = 4
+        return stack
     }()
 
     private lazy var collectionView: UICollectionView = {
@@ -106,15 +123,10 @@ private extension VoiceNoteViewController {
     }
 
     func setupNavigationBar() {
-        backButton.setTitle(" \(viewModel.state.title)", for: .normal)
-        backButton.addAction(
-            UIAction { [weak self] _ in
-                self?.viewModel.send(.view(.pop))
-            }, for: .touchUpInside
-        )
+        titleLabel.text = viewModel.state.title
         let menu = UIMenu(children: [
-            UIAction(title: "기록 이동하기", handler: { _ in
-                self.viewModel.send(.view(.moveVoiceNoteButtonTapped))
+            UIAction(title: "기록 이동하기", handler: { [weak self] _ in
+                self?.viewModel.send(.view(.moveVoiceNoteButtonTapped))
             }),
             UIAction(title: "편집하기", handler: { _ in }),
             UIAction(title: "삭제하기", attributes: .destructive, handler: { [weak self] _ in
@@ -128,14 +140,11 @@ private extension VoiceNoteViewController {
             target: nil,
             action: nil
         )
-        let leftItem = UIBarButtonItem(customView: backButton)
-        navigationItem.leftBarButtonItem = leftItem
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: navLeftView)
         navigationItem.rightBarButtonItems = [moreItem, searchItem]
         navigationItem.rightBarButtonItems?.forEach { $0.tintColor = .white }
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
-        navigationItem.rightBarButtonItems?.forEach {
-            $0.hidesSharedBackground = true
-        }
+        navigationItem.rightBarButtonItems?.forEach { $0.hidesSharedBackground = true }
     }
 
     func setupTabBar() {
@@ -205,6 +214,7 @@ private extension VoiceNoteViewController {
             }
         }
     }
+
 }
 
 // MARK: - Tab Actions

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -101,7 +101,7 @@ private extension VoiceNoteViewController {
 
             playerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             playerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            playerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            playerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
     }
 
@@ -119,7 +119,7 @@ private extension VoiceNoteViewController {
             UIAction(title: "편집하기", handler: { _ in }),
             UIAction(title: "삭제하기", attributes: .destructive, handler: { [weak self] _ in
                 self?.viewModel.send(.view(.deleteVoiceNoteButtonTapped))
-            })
+            }),
         ])
         let moreItem = UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: menu)
         let searchItem = UIBarButtonItem(
@@ -180,7 +180,7 @@ private extension VoiceNoteViewController {
                     var snapshot = self.dataSource.snapshot()
                     snapshot.reconfigureItems([.metadata])
                     self.dataSource.apply(snapshot, animatingDifferences: false)
-                case .completed:
+                case .completed, .transcribed:
                     self.applySnapshot()
                 case .failed, .pending:
                     break
@@ -259,7 +259,7 @@ private extension VoiceNoteViewController {
         }
 
         let keyPointCellReg = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, _, item in
-            guard case .keyPoint(let number, let text) = item else { return }
+            guard case let .keyPoint(number, text) = item else { return }
             cell.contentConfiguration = KeyPointContentConfiguration(number: number, text: text)
         }
 
@@ -270,7 +270,7 @@ private extension VoiceNoteViewController {
         }
 
         let scriptCellReg = UICollectionView.CellRegistration<UICollectionViewCell, Item> { [weak self] cell, _, item in
-            guard let self, case .script(let index) = item else { return }
+            guard let self, case let .script(index) = item else { return }
             let section = viewModel.state.scriptSections[index]
 
             cell.contentConfiguration = ScriptContentConfiguration(

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -30,16 +30,35 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
         let label = UILabel()
         label.font = Typography.title1.font
         label.textColor = UIColor.gray950
+        label.lineBreakMode = .byTruncatingTail
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return label
     }()
 
-    private lazy var navLeftView: UIStackView = {
-        let stack = UIStackView(arrangedSubviews: [backChevronButton, titleLabel])
-        stack.axis = .horizontal
-        stack.alignment = .center
-        stack.spacing = 4
-        return stack
+    private lazy var titleTextField: UITextField = {
+        let field = UITextField()
+        field.font = Typography.title1.font
+        field.textColor = UIColor.gray950
+        field.tintColor = UIColor.gray950
+        field.returnKeyType = .done
+        return field
     }()
+
+    private lazy var doneButton: UIBarButtonItem = {
+        let item = UIBarButtonItem(title: "완료", primaryAction: UIAction { [weak self] _ in
+            self?.exitEditMode()
+        })
+        item.tintColor = UIColor.point800
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = 1.08
+        let attrs: [NSAttributedString.Key: Any] = [.paragraphStyle: paragraphStyle]
+        item.setTitleTextAttributes(attrs, for: .normal)
+        item.setTitleTextAttributes(attrs, for: .highlighted)
+        return item
+    }()
+
+    private var normalRightBarButtonItems: [UIBarButtonItem] = []
+
 
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeLayout())
@@ -124,11 +143,14 @@ private extension VoiceNoteViewController {
 
     func setupNavigationBar() {
         titleLabel.text = viewModel.state.title
+        titleLabel.frame.size.width = view.bounds.width
         let menu = UIMenu(children: [
             UIAction(title: "기록 이동하기", handler: { [weak self] _ in
                 self?.viewModel.send(.view(.moveVoiceNoteButtonTapped))
             }),
-            UIAction(title: "편집하기", handler: { _ in }),
+            UIAction(title: "편집하기", handler: { [weak self] _ in
+                self?.enterEditMode()
+            }),
             UIAction(title: "삭제하기", attributes: .destructive, handler: { [weak self] _ in
                 self?.viewModel.send(.view(.deleteVoiceNoteButtonTapped))
             }),
@@ -140,8 +162,10 @@ private extension VoiceNoteViewController {
             target: nil,
             action: nil
         )
-        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: navLeftView)
-        navigationItem.rightBarButtonItems = [moreItem, searchItem]
+        normalRightBarButtonItems = [moreItem, searchItem]
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backChevronButton)
+        navigationItem.titleView = titleLabel
+        navigationItem.rightBarButtonItems = normalRightBarButtonItems
         navigationItem.rightBarButtonItems?.forEach { $0.tintColor = .white }
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
         navigationItem.rightBarButtonItems?.forEach { $0.hidesSharedBackground = true }
@@ -215,6 +239,28 @@ private extension VoiceNoteViewController {
         }
     }
 
+}
+
+// MARK: - Edit Mode
+
+private extension VoiceNoteViewController {
+    func enterEditMode() {
+        titleTextField.text = viewModel.state.title
+        titleTextField.frame.size.width = view.bounds.width
+        titleLabel.isHidden = true
+        navigationItem.titleView = titleTextField
+        navigationItem.rightBarButtonItems = [doneButton]
+        titleTextField.becomeFirstResponder()
+        titleTextField.selectAll(nil)
+    }
+
+    func exitEditMode() {
+        titleTextField.resignFirstResponder()
+        navigationItem.titleView = nil
+        titleLabel.isHidden = false
+        navigationItem.rightBarButtonItems = normalRightBarButtonItems
+        navigationItem.rightBarButtonItems?.forEach { $0.tintColor = .white }
+    }
 }
 
 // MARK: - Tab Actions

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -2,9 +2,6 @@ import Domain
 import UIKit
 
 public final class VoiceNoteViewController: UIViewController, Alertable {
-    typealias Section = VoiceNoteViewModel.Section
-    typealias Item = VoiceNoteViewModel.Item
-
     private let viewModel: VoiceNoteViewModel
     private lazy var dataSource = makeDataSource()
 
@@ -453,5 +450,41 @@ extension VoiceNoteViewController: UITextFieldDelegate {
         let title = textField.text ?? ""
         viewModel.doneEditing(title: title)
         return true
+    }
+}
+
+// MARK: - Section / Item
+
+extension VoiceNoteViewController {
+    enum Section: Int, CaseIterable, Sendable {
+        case metadata
+        case keyPoints
+        case keywords
+        case scripts
+
+        var title: String? {
+            switch self {
+            case .keyPoints: return "AI 요약"
+            case .keywords: return "키워드"
+            case .scripts: return "스크립트"
+            default: return nil
+            }
+        }
+
+        var headerTitle: String? {
+            switch self {
+            case .keyPoints: return "핵심 포인트"
+            case .keywords: return "키워드"
+            case .scripts: return "스크립트"
+            default: return nil
+            }
+        }
+    }
+
+    enum Item: Hashable, Sendable {
+        case metadata
+        case keyPoint(number: Int, text: String)
+        case keywords
+        case script(index: Int)
     }
 }

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -409,14 +409,19 @@ private extension VoiceNoteViewController {
     func applySnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections(Section.allCases)
-        snapshot.appendItems([.metadata], toSection: .metadata)
-        snapshot.appendItems(
-            viewModel.keyPoints.map { .keyPoint(number: $0.number, text: $0.text) },
-            toSection: .keyPoints
-        )
-        snapshot.appendItems([.keywords], toSection: .keywords)
-        snapshot.appendItems(viewModel.scriptSections.indices.map { .script(index: $0) }, toSection: .scripts)
-        snapshot.reconfigureItems([.metadata, .keywords])
+        
+        let metadataItems: [Item] = [.metadata]
+        let keyPointItems = viewModel.keyPoints.map { Item.keyPoint(number: $0.number, text: $0.text) }
+        let keywordItems: [Item] = [.keywords]
+        let scriptItems = viewModel.scriptSections.indices.map { Item.script(index: $0) }
+        
+        snapshot.appendItems(metadataItems, toSection: .metadata)
+        snapshot.appendItems(keyPointItems, toSection: .keyPoints)
+        snapshot.appendItems(keywordItems, toSection: .keywords)
+        snapshot.appendItems(scriptItems, toSection: .scripts)
+        
+        // 셀 내용이나 모드(isEditing)가 바뀌었을 수 있으므로 필요한 항목들을 재구성합니다.
+        snapshot.reconfigureItems(metadataItems + keywordItems + scriptItems)
         dataSource.apply(snapshot, animatingDifferences: true)
     }
 }

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -289,6 +289,7 @@ private extension VoiceNoteViewController {
 
     func exitEditMode() {
         titleTextField.resignFirstResponder()
+        titleLabel.text = viewModel.title
         titleLabel.isHidden = false
         navigationItem.titleView = titleLabel
         navigationItem.rightBarButtonItems = normalRightBarButtonItems

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -195,6 +195,24 @@ private extension VoiceNoteViewController {
         observeAnalysisState()
         observeErrorMessage()
         observeEditingState()
+        observePlayingParagraph()
+    }
+
+    private func observePlayingParagraph() {
+        withObservationTracking {
+            _ = viewModel.playingParagraphInfo
+        } onChange: { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                let scriptItems = self.dataSource.snapshot().itemIdentifiers(inSection: .scripts)
+                if !scriptItems.isEmpty {
+                    var snapshot = self.dataSource.snapshot()
+                    snapshot.reconfigureItems(scriptItems)
+                    self.dataSource.apply(snapshot, animatingDifferences: false)
+                }
+                self.observePlayingParagraph()
+            }
+        }
     }
 
     private func observePlaybackState() {
@@ -350,13 +368,15 @@ private extension VoiceNoteViewController {
         let scriptCellReg = UICollectionView.CellRegistration<UICollectionViewCell, Item> { [weak self] cell, _, item in
             guard let self, case .script(let index) = item else { return }
             let section = viewModel.scriptSections[index]
+            let info = viewModel.playingParagraphInfo
+            let highlightedParagraphIndex = info?.sectionIndex == index ? info?.paragraphIndex : nil
 
             cell.contentConfiguration = ScriptContentConfiguration(
                 sectionIndex: index,
                 timestamp: section.formattedTimestamp,
                 timestampSeconds: section.timestamp,
                 paragraphs: section.paragraphs,
-                highlight: viewModel.playbackHighlight,
+                highlightedParagraphIndex: highlightedParagraphIndex,
                 isEditing: viewModel.isEditing,
                 onParagraphEdited: { [weak self] sIdx, pIdx, text in
                     self?.viewModel.updateScriptParagraph(sectionIndex: sIdx, paragraphIndex: pIdx, text: text)

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -21,7 +21,7 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
         btn.setImage(backImage, for: .normal)
         btn.tintColor = UIColor.gray950
         btn.addAction(UIAction { [weak self] _ in
-            self?.viewModel.send(.view(.pop))
+            self?.viewModel.pop()
         }, for: .touchUpInside)
         return btn
     }()
@@ -41,12 +41,15 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
         field.textColor = UIColor.gray950
         field.tintColor = UIColor.gray950
         field.returnKeyType = .done
+        field.delegate = self
         return field
     }()
 
     private lazy var doneButton: UIBarButtonItem = {
         let item = UIBarButtonItem(title: "완료", primaryAction: UIAction { [weak self] _ in
-            self?.exitEditMode()
+            guard let self else { return }
+            let title = titleTextField.text ?? ""
+            viewModel.doneEditing(title: title)
         })
         item.tintColor = UIColor.point800
         let paragraphStyle = NSMutableParagraphStyle()
@@ -58,7 +61,6 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
     }()
 
     private var normalRightBarButtonItems: [UIBarButtonItem] = []
-
 
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeLayout())
@@ -85,12 +87,12 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
         super.viewDidLoad()
         setupUI()
         applySnapshot()
-        viewModel.send(.view(.onAppear))
+        viewModel.onAppear()
     }
 
     override public func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        viewModel.send(.view(.onDisappear))
+        viewModel.onDisappear()
     }
 }
 
@@ -109,9 +111,7 @@ private extension VoiceNoteViewController {
         setupNavigationBar()
         setupTabBar()
         setupPlayerView()
-        observePlaybackState()
-        observeAnalysisState()
-        observeErrorMessage()
+        setupBindings()
     }
 
     func setupConstraints() {
@@ -137,23 +137,23 @@ private extension VoiceNoteViewController {
 
             playerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             playerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            playerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            playerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }
 
     func setupNavigationBar() {
-        titleLabel.text = viewModel.state.title
+        titleLabel.text = viewModel.title
         titleLabel.frame.size.width = view.bounds.width
         let menu = UIMenu(children: [
             UIAction(title: "기록 이동하기", handler: { [weak self] _ in
-                self?.viewModel.send(.view(.moveVoiceNoteButtonTapped))
+                self?.viewModel.moveVoiceNote()
             }),
             UIAction(title: "편집하기", handler: { [weak self] _ in
-                self?.enterEditMode()
+                self?.viewModel.enterEditing()
             }),
             UIAction(title: "삭제하기", attributes: .destructive, handler: { [weak self] _ in
-                self?.viewModel.send(.view(.deleteVoiceNoteButtonTapped))
-            }),
+                self?.viewModel.deleteVoiceNote()
+            })
         ])
         let moreItem = UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: menu)
         let searchItem = UIBarButtonItem(
@@ -183,20 +183,28 @@ private extension VoiceNoteViewController {
     }
 
     func setupPlayerView() {
-        playerView.onPlayPause = { [weak self] in self?.viewModel.send(.view(.playPauseButtonTapped)) }
-        playerView.onRewind = { [weak self] in self?.viewModel.send(.view(.rewindButtonTapped)) }
-        playerView.onForward = { [weak self] in self?.viewModel.send(.view(.forwardButtonTapped)) }
-        playerView.onSeekBegan = { [weak self] in self?.viewModel.send(.view(.seekBegan)) }
-        playerView.onSeekEnded = { [weak self] time in self?.viewModel.send(.view(.seekEnded(time))) }
+        playerView.onPlayPause = { [weak self] in self?.viewModel.playPause() }
+        playerView.onRewind = { [weak self] in self?.viewModel.rewind() }
+        playerView.onForward = { [weak self] in self?.viewModel.forward() }
+        playerView.onSeekBegan = { [weak self] in self?.viewModel.seekBegan() }
+        playerView.onSeekEnded = { [weak self] time in self?.viewModel.seekEnded(time) }
+    }
+
+    func setupBindings() {
+        observePlaybackState()
+        observeAnalysisState()
+        observeErrorMessage()
+        observeEditingState()
+        observeTitle()
     }
 
     private func observePlaybackState() {
         withObservationTracking {
-            _ = viewModel.state.currentPlaybackState
+            _ = viewModel.currentPlaybackState
         } onChange: { [weak self] in
             guard let self else { return }
             Task { @MainActor in
-                self.playerView.apply(self.viewModel.state.currentPlaybackState)
+                self.playerView.apply(self.viewModel.currentPlaybackState)
                 self.observePlaybackState()
             }
         }
@@ -204,11 +212,11 @@ private extension VoiceNoteViewController {
 
     private func observeAnalysisState() {
         withObservationTracking {
-            _ = viewModel.state.voiceNote.analysisState
+            _ = viewModel.voiceNote.analysisState
         } onChange: { [weak self] in
             guard let self else { return }
             Task { @MainActor in
-                switch self.viewModel.state.voiceNote.analysisState {
+                switch self.viewModel.voiceNote.analysisState {
                 case .analyzing:
                     var snapshot = self.dataSource.snapshot()
                     snapshot.reconfigureItems([.metadata])
@@ -225,13 +233,13 @@ private extension VoiceNoteViewController {
 
     private func observeErrorMessage() {
         withObservationTracking {
-            _ = viewModel.state.errorMessage
+            _ = viewModel.errorMessage
         } onChange: { [weak self] in
             guard let self else { return }
             Task { @MainActor in
-                if let message = self.viewModel.state.errorMessage {
+                if let message = self.viewModel.errorMessage {
                     self.showAlert(title: "오류", message: message) { [weak self] in
-                        self?.viewModel.send(.internal(.errorDismissed))
+                        self?.viewModel.dismissError()
                     }
                 }
                 self.observeErrorMessage()
@@ -239,13 +247,38 @@ private extension VoiceNoteViewController {
         }
     }
 
+    private func observeTitle() {
+        withObservationTracking {
+            _ = viewModel.title
+        } onChange: { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                self.titleLabel.text = self.viewModel.title
+                self.observeTitle()
+            }
+        }
+    }
 }
 
 // MARK: - Edit Mode
 
 private extension VoiceNoteViewController {
+    func observeEditingState() {
+        withObservationTracking {
+            _ = viewModel.isEditing
+        } onChange: { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                self.viewModel.isEditing ? self.enterEditMode() : self.exitEditMode()
+                self.observeEditingState()
+            }
+        }
+    }
+}
+
+private extension VoiceNoteViewController {
     func enterEditMode() {
-        titleTextField.text = viewModel.state.title
+        titleTextField.text = viewModel.title
         titleTextField.frame.size.width = view.bounds.width
         titleLabel.isHidden = true
         navigationItem.titleView = titleTextField
@@ -256,7 +289,7 @@ private extension VoiceNoteViewController {
 
     func exitEditMode() {
         titleTextField.resignFirstResponder()
-        navigationItem.titleView = nil
+        navigationItem.titleView = titleLabel
         titleLabel.isHidden = false
         navigationItem.rightBarButtonItems = normalRightBarButtonItems
         navigationItem.rightBarButtonItems?.forEach { $0.tintColor = .white }
@@ -308,35 +341,35 @@ private extension VoiceNoteViewController {
     func makeDataSource() -> UICollectionViewDiffableDataSource<Section, Item> {
         let metadataCellReg = UICollectionView.CellRegistration<UICollectionViewCell, Item> { [weak self] cell, _, _ in
             cell.contentConfiguration = MetadataContentConfiguration(
-                folderName: self?.viewModel.state.folderName ?? "",
-                date: self?.viewModel.state.metadataText1 ?? "",
-                duration: self?.viewModel.state.metadataText2 ?? ""
+                folderName: self?.viewModel.folderName ?? "",
+                date: self?.viewModel.metadataText1 ?? "",
+                duration: self?.viewModel.metadataText2 ?? ""
             )
         }
 
         let keyPointCellReg = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, _, item in
-            guard case let .keyPoint(number, text) = item else { return }
+            guard case .keyPoint(let number, let text) = item else { return }
             cell.contentConfiguration = KeyPointContentConfiguration(number: number, text: text)
         }
 
         let keywordsCellReg = UICollectionView.CellRegistration<KeywordsCell, Item> { [weak self] cell, _, _ in
             cell.contentConfiguration = KeywordsContentConfiguration(
-                keywords: self?.viewModel.state.keywords ?? []
+                keywords: self?.viewModel.keywords ?? []
             )
         }
 
         let scriptCellReg = UICollectionView.CellRegistration<UICollectionViewCell, Item> { [weak self] cell, _, item in
-            guard let self, case let .script(index) = item else { return }
-            let section = viewModel.state.scriptSections[index]
+            guard let self, case .script(let index) = item else { return }
+            let section = viewModel.scriptSections[index]
 
             cell.contentConfiguration = ScriptContentConfiguration(
                 sectionIndex: index,
                 timestamp: section.formattedTimestamp,
                 timestampSeconds: section.timestamp,
                 paragraphs: section.paragraphs,
-                highlight: viewModel.state.playbackHighlight,
+                highlight: viewModel.playbackHighlight,
                 onTimestampTapped: { [weak self] time in
-                    self?.viewModel.send(.view(.scriptTimestampTapped(time)))
+                    self?.viewModel.scriptTimestampTapped(time)
                 }
             )
         }
@@ -385,12 +418,22 @@ private extension VoiceNoteViewController {
         snapshot.appendSections(Section.allCases)
         snapshot.appendItems([.metadata], toSection: .metadata)
         snapshot.appendItems(
-            viewModel.state.keyPoints.map { .keyPoint(number: $0.number, text: $0.text) },
+            viewModel.keyPoints.map { .keyPoint(number: $0.number, text: $0.text) },
             toSection: .keyPoints
         )
         snapshot.appendItems([.keywords], toSection: .keywords)
-        snapshot.appendItems(viewModel.state.scriptSections.indices.map { .script(index: $0) }, toSection: .scripts)
+        snapshot.appendItems(viewModel.scriptSections.indices.map { .script(index: $0) }, toSection: .scripts)
         snapshot.reconfigureItems([.metadata, .keywords])
         dataSource.apply(snapshot, animatingDifferences: true)
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension VoiceNoteViewController: UITextFieldDelegate {
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        let title = textField.text ?? ""
+        viewModel.doneEditing(title: title)
+        return true
     }
 }

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -282,15 +282,25 @@ extension FolderDetailViewModel {
                 voiceNote
             }
 
+            func transcribe(audioFilePath: String) async throws(VoiceNoteUseCaseError) -> Transcript {
+                Transcript(text: "")
+            }
+
             func summarize(
-                audioFilePath: String,
+                transcript: Transcript,
                 language: Language
-            ) async throws(VoiceNoteUseCaseError) -> AudioToSummaryResult {
-                AudioToSummaryResult(
-                    transcript: Transcript(text: ""),
-                    keywords: [],
-                    summary: Summary(text: "")
-                )
+            ) async throws(VoiceNoteUseCaseError) -> (keywords: [Keyword], summary: Summary) {
+                (keywords: [], summary: Summary(text: ""))
+            }
+
+            func observe(id: UUID) throws(VoiceNoteUseCaseError) -> AsyncStream<VoiceNote> {
+                guard let item = items.first(where: { $0.id == id }) else {
+                    throw .recordNotFound(id)
+                }
+                return AsyncStream { continuation in
+                    continuation.yield(item)
+                    continuation.finish()
+                }
             }
         }
 

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -410,6 +410,13 @@ extension MainViewModel {
             ) async throws(VoiceNoteUseCaseError) -> AudioToSummaryResult {
                 AudioToSummaryResult(transcript: Transcript(text: ""), keywords: [], summary: Summary(text: ""))
             }
+
+            func observe(id: UUID) throws(VoiceNoteUseCaseError) -> AsyncStream<VoiceNote> {
+                guard let item = defaultItems.first(where: { $0.id == id }) else {
+                    throw .recordNotFound(id)
+                }
+                return AsyncStream { $0.yield(item) }
+            }
         }
 
         struct PreviewFolderUseCase: FolderUseCase {

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -404,11 +404,15 @@ extension MainViewModel {
                 voiceNote
             }
 
+            func transcribe(audioFilePath: String) async throws(VoiceNoteUseCaseError) -> Transcript {
+                Transcript(text: "")
+            }
+
             func summarize(
-                audioFilePath: String,
+                transcript: Transcript,
                 language: Language
-            ) async throws(VoiceNoteUseCaseError) -> AudioToSummaryResult {
-                AudioToSummaryResult(transcript: Transcript(text: ""), keywords: [], summary: Summary(text: ""))
+            ) async throws(VoiceNoteUseCaseError) -> (keywords: [Keyword], summary: Summary) {
+                (keywords: [], summary: Summary(text: ""))
             }
 
             func observe(id: UUID) throws(VoiceNoteUseCaseError) -> AsyncStream<VoiceNote> {

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingStep.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingStep.swift
@@ -52,7 +52,7 @@ enum Step: Int, CaseIterable, Equatable {
         case .micPermission:
             OnBoardingItem(
                 headline: "필요한 권한만\n요청할게요.",
-                body: "녹음을 시작하려면\n마이크 권한이 필요해요.",
+                body: "녹음과 음성 변환을 위해\n마이크와 음성 인식 권한이 필요해요.",
                 image: "onboarding03"
             )
         case .finish:

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
@@ -20,6 +20,7 @@ public final class OnBoardingViewModel {
 
     let languageRepository: any LanguageRepository
     let voiceRecordRepository: any VoiceRecordRepository
+    let sttRepository: any STTRepository
     let checkFirstLaunchRepository: any CheckFirstLaunchRepository
     let folderUseCase: any FolderUseCase
 
@@ -28,11 +29,13 @@ public final class OnBoardingViewModel {
     public init(
         languageRepository: any LanguageRepository,
         voiceRecordRepository: any VoiceRecordRepository,
+        sttRepository: any STTRepository,
         checkFirstLaunchRepository: any CheckFirstLaunchRepository,
         folderUseCase: any FolderUseCase
     ) {
         self.languageRepository = languageRepository
         self.voiceRecordRepository = voiceRecordRepository
+        self.sttRepository = sttRepository
         self.checkFirstLaunchRepository = checkFirstLaunchRepository
         self.folderUseCase = folderUseCase
     }
@@ -137,12 +140,24 @@ extension OnBoardingViewModel {
 extension OnBoardingViewModel {
     private func requestPermission() {
         Task {
-            let status = voiceRecordRepository.checkMicrophonePermission()
-            if status == .notDetermined {
+            // 마이크 권한 요청
+            let micStatus = voiceRecordRepository.checkMicrophonePermission()
+            if micStatus == .notDetermined {
                 do {
                     _ = try await voiceRecordRepository.requestMicrophonePermission()
                 } catch {
                     errorMessage = error.localizedDescription
+                    AppLogger.error(error)
+                }
+            }
+
+            // STT 권한 요청
+            let sttStatus = sttRepository.checkSTTPermission()
+            if sttStatus == .notDetermined {
+                do {
+                    _ = try await sttRepository.requestSTTPermission()
+                } catch {
+                    // STT 권한 에러는 마이크 권한 에러를 덮어쓰지 않도록 함 (필요시 추가 처리 가능)
                     AppLogger.error(error)
                 }
             }

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
@@ -168,7 +168,7 @@ extension OnBoardingViewModel {
         Task {
             do {
                 languageRepository.saveLanguage(language)
-                _ = try  folderUseCase.createDefault()
+                _ = try folderUseCase.createDefault()
                 _ = checkFirstLaunchRepository.checkAndMarkFirstLaunch()
                 onBoardingCoordinator?.finishOnBoarding()
             } catch {

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
@@ -168,7 +168,7 @@ extension OnBoardingViewModel {
         Task {
             do {
                 languageRepository.saveLanguage(language)
-                _ = try await folderUseCase.createDefault()
+                _ = try  folderUseCase.createDefault()
                 _ = checkFirstLaunchRepository.checkAndMarkFirstLaunch()
                 onBoardingCoordinator?.finishOnBoarding()
             } catch {

--- a/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
@@ -110,7 +110,7 @@ public final class RecordingViewModel {
             state.showAlert = false
         case .openAlertButtonTapped:
             state.showAlert = true
-        case let .errorOccurred(error):
+        case .errorOccurred(let error):
             state.errorMessage = error.localizedDescription
         }
     }

--- a/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
@@ -110,7 +110,7 @@ public final class RecordingViewModel {
             state.showAlert = false
         case .openAlertButtonTapped:
             state.showAlert = true
-        case .errorOccurred(let error):
+        case let .errorOccurred(error):
             state.errorMessage = error.localizedDescription
         }
     }
@@ -177,84 +177,3 @@ public final class RecordingViewModel {
         timerTask = nil
     }
 }
-
-// MARK: - Preview Data
-
-#if DEBUG
-    extension RecordingViewModel {
-        public static func preview() -> RecordingViewModel {
-            RecordingViewModel(
-                repository: PreviewVoiceRecordRepository(),
-                voiceNoteUseCase: PreviewVoiceNoteUseCase()
-            )
-        }
-
-        private struct PreviewVoiceRecordRepository: VoiceRecordRepository {
-            func checkMicrophonePermission() -> PermissionStatus {
-                .authorized
-            }
-
-            func requestMicrophonePermission() async throws(VoiceRecordRepositoryError)
-                -> PermissionStatus
-            {
-                .authorized
-            }
-
-            func startRecording() async throws(VoiceRecordRepositoryError) -> AsyncStream<Waveform> {
-                AsyncStream { continuation in
-                    continuation.finish()
-                }
-            }
-
-            func pauseRecording() async throws(VoiceRecordRepositoryError) {}
-            func resumeRecording() async throws(VoiceRecordRepositoryError) {}
-            func finishRecording() async throws(VoiceRecordRepositoryError) -> VoiceRecord {
-                VoiceRecord(audioFilePath: "", duration: 0)
-            }
-
-            func cancelRecording() async throws(VoiceRecordRepositoryError) {}
-        }
-
-        private struct PreviewVoiceNoteUseCase: VoiceNoteUseCase {
-            func create(_ voiceRecord: VoiceRecord) throws(VoiceNoteUseCaseError) -> VoiceNote {
-                VoiceNote(
-                    title: "미리보기 기록",
-                    createdAt: .now,
-                    updatedAt: .now,
-                    folderID: UUID(),
-                    voiceRecord: voiceRecord,
-                    keywords: [],
-                    transcript: nil,
-                    summary: nil
-                )
-            }
-
-            func fetchAllFromDefaultFolder() throws(VoiceNoteUseCaseError) -> [VoiceNote] {
-                []
-            }
-
-            func fetchAll(folderID: UUID) throws(VoiceNoteUseCaseError) -> [VoiceNote] {
-                []
-            }
-
-            func fetch(byId id: UUID) throws(VoiceNoteUseCaseError) -> VoiceNote {
-                throw .recordNotFound(id)
-            }
-
-            func fetchRecent(limit: Int) throws(VoiceNoteUseCaseError) -> [VoiceNote] {
-                []
-            }
-
-            func update(_ voiceNote: VoiceNote) throws(VoiceNoteUseCaseError) -> VoiceNote {
-                voiceNote
-            }
-
-            func summarize(
-                audioFilePath: String,
-                language: Language
-            ) async throws(VoiceNoteUseCaseError) -> AudioToSummaryResult {
-                AudioToSummaryResult(transcript: Transcript(text: ""), keywords: [], summary: Summary(text: ""))
-            }
-        }
-    }
-#endif

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -111,39 +111,33 @@ extension TrashViewModel {
 
 extension TrashViewModel {
     func deleteAll() {
-        Task {
-            do {
-                try await repository.allClear()
-                items.removeAll()
-            } catch {
-                AppLogger.error(error)
-                errorMessage = error.localizedDescription
-            }
+        do {
+            try repository.allClear()
+            items.removeAll()
+        } catch {
+            AppLogger.error(error)
+            errorMessage = error.localizedDescription
         }
     }
 
     func delete(item: WasteBasketItem) {
-        Task {
-            do {
-                try await repository.delete(item: item)
-                items.removeAll { $0.id == item.id }
-            } catch {
-                AppLogger.error(error)
-                errorMessage = error.localizedDescription
-            }
+        do {
+            try repository.delete(item: item)
+            items.removeAll { $0.id == item.id }
+        } catch {
+            AppLogger.error(error)
+            errorMessage = error.localizedDescription
         }
     }
 
     private func delete(items deleteItems: [WasteBasketItem]) {
-        Task {
-            do {
-                try await repository.deleteAll(items: deleteItems)
-                let deleteIDs = Set(deleteItems.map(\.id))
-                items.removeAll { deleteIDs.contains($0.id) }
-            } catch {
-                AppLogger.error(error)
-                errorMessage = error.localizedDescription
-            }
+        do {
+            try repository.deleteAll(items: deleteItems)
+            let deleteIDs = Set(deleteItems.map(\.id))
+            items.removeAll { deleteIDs.contains($0.id) }
+        } catch {
+            AppLogger.error(error)
+            errorMessage = error.localizedDescription
         }
     }
 }
@@ -152,27 +146,23 @@ extension TrashViewModel {
 
 extension TrashViewModel {
     func restore(item: WasteBasketItem) {
-        Task {
-            do {
-                try await repository.restore(item: item)
-                items.removeAll { $0.id == item.id }
-            } catch {
-                AppLogger.error(error)
-                errorMessage = error.localizedDescription
-            }
+        do {
+            try repository.restore(item: item)
+            items.removeAll { $0.id == item.id }
+        } catch {
+            AppLogger.error(error)
+            errorMessage = error.localizedDescription
         }
     }
 
     func restore(items restoreItems: [WasteBasketItem]) {
-        Task {
-            do {
-                try await repository.restoreAll(items: restoreItems)
-                let restoreIDs = Set(restoreItems.map(\.id))
-                items.removeAll { restoreIDs.contains($0.id) }
-            } catch {
-                AppLogger.error(error)
-                errorMessage = error.localizedDescription
-            }
+        do {
+            try repository.restoreAll(items: restoreItems)
+            let restoreIDs = Set(restoreItems.map(\.id))
+            items.removeAll { restoreIDs.contains($0.id) }
+        } catch {
+            AppLogger.error(error)
+            errorMessage = error.localizedDescription
         }
     }
 }

--- a/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
@@ -55,7 +55,7 @@ public final class MoveFolderListViewModel {
 
     private func fetchFolders() {
         do {
-            var voiceNote: VoiceNote = switch receive {
+           let voiceNote: VoiceNote = switch receive {
             case .single(let item):
                 item
             case .multiple(let items):

--- a/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
@@ -39,7 +39,7 @@ public final class MoveFolderListViewModel {
             case let .folderSelected(folder):
                 state.selectedFolder = folder
             case .moveButtonTapped:
-                Task { await moveVoiceNote() }
+                moveVoiceNote()
             case .closeButtonTapped:
                 coordinator?.dismiss()
             case .addFolderButtonTapped:

--- a/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
@@ -32,11 +32,11 @@ public final class MoveFolderListViewModel {
 
     func send(_ action: Action) {
         switch action {
-        case let .view(viewAction):
+        case .view(let viewAction):
             switch viewAction {
             case .onAppear:
                 fetchFolders()
-            case let .folderSelected(folder):
+            case .folderSelected(let folder):
                 state.selectedFolder = folder
             case .moveButtonTapped:
                 moveVoiceNote()
@@ -45,9 +45,9 @@ public final class MoveFolderListViewModel {
             case .addFolderButtonTapped:
                 coordinator?.pushNewFolder()
             }
-        case let .internal(internalAction):
+        case .internal(let internalAction):
             switch internalAction {
-            case let .foldersLoaded(folders):
+            case .foldersLoaded(let folders):
                 state.folders = folders
             }
         }
@@ -55,7 +55,7 @@ public final class MoveFolderListViewModel {
 
     private func fetchFolders() {
         do {
-           let voiceNote: VoiceNote = switch receive {
+            let voiceNote: VoiceNote = switch receive {
             case .single(let item):
                 item
             case .multiple(let items):

--- a/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
@@ -32,11 +32,11 @@ public final class MoveFolderListViewModel {
 
     func send(_ action: Action) {
         switch action {
-        case .view(let viewAction):
+        case let .view(viewAction):
             switch viewAction {
             case .onAppear:
-                Task { await fetchFolders() }
-            case .folderSelected(let folder):
+                fetchFolders()
+            case let .folderSelected(folder):
                 state.selectedFolder = folder
             case .moveButtonTapped:
                 Task { await moveVoiceNote() }
@@ -45,15 +45,15 @@ public final class MoveFolderListViewModel {
             case .addFolderButtonTapped:
                 coordinator?.pushNewFolder()
             }
-        case .internal(let internalAction):
+        case let .internal(internalAction):
             switch internalAction {
-            case .foldersLoaded(let folders):
+            case let .foldersLoaded(folders):
                 state.folders = folders
             }
         }
     }
 
-    private func fetchFolders() async {
+    private func fetchFolders() {
         do {
             var voiceNote: VoiceNote = switch receive {
             case .single(let item):
@@ -69,7 +69,7 @@ public final class MoveFolderListViewModel {
         }
     }
 
-    private func moveVoiceNote() async {
+    private func moveVoiceNote() {
         guard let selectedFolder = state.selectedFolder else { return }
         do {
             switch receive {

--- a/Presentation/Sources/ViewModel/VoiceNote/NewFolderViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/NewFolderViewModel.swift
@@ -26,7 +26,7 @@ public final class NewFolderViewModel {
             case .cancelButtonTapped:
                 coordinator?.cancel()
             case .createButtonTapped(let name):
-               createFolder(name: name) 
+                createFolder(name: name)
             }
         }
     }
@@ -35,9 +35,9 @@ public final class NewFolderViewModel {
         state.errorMessage = nil
     }
 
-    private func createFolder(name: String)  {
+    private func createFolder(name: String) {
         do {
-            _ = try  folderUseCase.create(name: name)
+            _ = try folderUseCase.create(name: name)
             coordinator?.folderCreated()
         } catch {
             AppLogger.error(error)

--- a/Presentation/Sources/ViewModel/VoiceNote/NewFolderViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/NewFolderViewModel.swift
@@ -26,7 +26,7 @@ public final class NewFolderViewModel {
             case .cancelButtonTapped:
                 coordinator?.cancel()
             case .createButtonTapped(let name):
-                Task { await createFolder(name: name) }
+               createFolder(name: name) 
             }
         }
     }
@@ -35,9 +35,9 @@ public final class NewFolderViewModel {
         state.errorMessage = nil
     }
 
-    private func createFolder(name: String) async {
+    private func createFolder(name: String)  {
         do {
-            _ = try await folderUseCase.create(name: name)
+            _ = try  folderUseCase.create(name: name)
             coordinator?.folderCreated()
         } catch {
             AppLogger.error(error)

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -425,36 +425,4 @@ public extension VoiceNoteViewModel {
         public let sectionIndex: Int
         public let paragraphIndex: Int
     }
-
-    enum Section: Int, CaseIterable, Sendable {
-        case metadata
-        case keyPoints
-        case keywords
-        case scripts
-
-        public var title: String? {
-            switch self {
-            case .keyPoints: return "AI 요약"
-            case .keywords: return "키워드"
-            case .scripts: return "스크립트"
-            default: return nil
-            }
-        }
-
-        public var headerTitle: String? {
-            switch self {
-            case .keyPoints: return "핵심 포인트"
-            case .keywords: return "키워드"
-            case .scripts: return "스크립트"
-            default: return nil
-            }
-        }
-    }
-
-    enum Item: Hashable, Sendable {
-        case metadata
-        case keyPoint(number: Int, text: String)
-        case keywords
-        case script(index: Int)
-    }
 }

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -10,7 +10,7 @@ public final class VoiceNoteViewModel {
     public private(set) var voiceNote: VoiceNote
     public private(set) var folderName: String = ""
     public private(set) var errorMessage: String?
-    public private(set) var isEditing: Bool = false
+    public private(set) var editingMode: EditingMode?
     public private(set) var currentPlaybackState = AudioPlaybackState(status: .idle, currentTime: 0, duration: 0)
     public private(set) var playingParagraphInfo: PlayingParagraphInfo?
     public private(set) var editableScriptSections: [ScriptSection] = []
@@ -118,9 +118,17 @@ public final class VoiceNoteViewModel {
         coordinator?.presentFolderList(with: .single(voiceNote))
     }
 
-    public func enterEditing() {
+    public func enterTitleEditing() {
+        editingMode = .title
+    }
+
+    public func enterScriptEditing() {
         editableScriptSections = scriptSections
-        isEditing = true
+        editingMode = .script
+    }
+
+    public func cancelEditing() {
+        editingMode = nil
     }
 
     public func updateScriptParagraph(sectionIndex: Int, paragraphIndex: Int, text: String) {
@@ -133,11 +141,11 @@ public final class VoiceNoteViewModel {
         editableScriptSections = sections
     }
 
-    public func doneEditing(title: String) {
+    public func doneTitleEditing(title: String) {
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !trimmedTitle.isEmpty, trimmedTitle != voiceNote.title else {
-            isEditing = false
+            editingMode = nil
             return
         }
 
@@ -149,29 +157,57 @@ public final class VoiceNoteViewModel {
             folderID: voiceNote.folderID,
             voiceRecord: voiceNote.voiceRecord,
             keywords: voiceNote.keywords,
-            transcript: makeUpdatedTranscript(),
+            transcript: voiceNote.transcript,
             summary: voiceNote.summary,
             analysisState: voiceNote.analysisState
         )
 
         do {
             _ = try voiceNoteUseCase.update(updatedNote)
-            self.voiceNote = updatedNote
-            isEditing = false
+            voiceNote = updatedNote
+            editingMode = nil
         } catch {
             errorMessage = "제목 수정에 실패했습니다: \(error.localizedDescription)"
         }
     }
 
+    public func doneScriptEditing() {
+        guard let updatedTranscript = makeUpdatedTranscript() else {
+            editingMode = nil
+            return
+        }
+
+        let updatedNote = VoiceNote(
+            id: voiceNote.id,
+            title: voiceNote.title,
+            createdAt: voiceNote.createdAt,
+            updatedAt: .now,
+            folderID: voiceNote.folderID,
+            voiceRecord: voiceNote.voiceRecord,
+            keywords: voiceNote.keywords,
+            transcript: updatedTranscript,
+            summary: voiceNote.summary,
+            analysisState: voiceNote.analysisState
+        )
+
+        do {
+            _ = try voiceNoteUseCase.update(updatedNote)
+            voiceNote = updatedNote
+            editingMode = nil
+        } catch {
+            errorMessage = "스크립트 수정에 실패했습니다: \(error.localizedDescription)"
+        }
+    }
+
     private func makeUpdatedTranscript() -> Transcript? {
         guard let original = voiceNote.transcript else { return nil }
-        
+
         let segments = editableScriptSections.flatMap { section in
             section.paragraphs.map { pText in
                 TranscriptSegment(substring: pText, timestamp: section.timestamp, duration: 0)
             }
         }
-        
+
         return Transcript(
             id: original.id,
             createdAt: original.createdAt,
@@ -412,7 +448,7 @@ public extension VoiceNoteViewModel {
     }
 
     var scriptSections: [ScriptSection] {
-        if isEditing { return editableScriptSections }
+        if editingMode == .script { return editableScriptSections }
         guard let transcript = voiceNote.transcript, !transcript.segments.isEmpty else { return [] }
         return Self.groupSegmentsIntoSections(transcript.segments)
     }
@@ -424,5 +460,10 @@ public extension VoiceNoteViewModel {
     struct PlayingParagraphInfo: Equatable {
         public let sectionIndex: Int
         public let paragraphIndex: Int
+    }
+
+    enum EditingMode: Sendable {
+        case title
+        case script
     }
 }

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -218,6 +218,7 @@ public final class VoiceNoteViewModel {
 
         do {
             _ = try voiceNoteUseCase.update(updatedNote)
+            self.voiceNote = updatedNote
             isEditing = false
         } catch {
             errorMessage = "제목 수정에 실패했습니다: \(error.localizedDescription)"

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -12,6 +12,8 @@ public final class VoiceNoteViewModel {
     @ObservationIgnored
     private var playbackObservationTask: Task<Void, Never>?
     @ObservationIgnored
+    private var voiceNoteObservationTask: Task<Void, Never>?
+    @ObservationIgnored
     private var wasPlayingBeforeSeek = false
     public weak var coordinator: VoiceNoteCoordinatorDelegate?
 
@@ -43,6 +45,7 @@ public final class VoiceNoteViewModel {
 
     deinit {
         playbackObservationTask?.cancel()
+        voiceNoteObservationTask?.cancel()
     }
 
     // MARK: - Send
@@ -52,9 +55,9 @@ public final class VoiceNoteViewModel {
         case .view(let viewAction):
             switch viewAction {
             case .onAppear:
-                // 재생 스트림 구독 시작 및 폴더명·AI 분석 로드
-                startPlaybackObservation()
-                Task { await fetchFolderName() }
+                setupPalyback()
+                fetchFolderName()
+                observeVoiceNote()
                 if state.voiceNote.analysisState != .completed {
                     state.voiceNote.analysisState = .analyzing
                     Task { await performNewAnalysis() }
@@ -95,17 +98,17 @@ public final class VoiceNoteViewModel {
             case .moveVoiceNoteButtonTapped:
                 coordinator?.presentFolderList(with: .single(state.voiceNote))
             case .deleteVoiceNoteButtonTapped:
-                Task { await moveToWasteBasket() }
+                moveToWasteBasket()
             }
 
         case .internal(let internalAction):
             switch internalAction {
             case .metadataLoaded(let folderName):
-                // 폴더명 비동기 로드 완료
                 state.folderName = folderName
-            case .analysisCompleted(let note):
-                // AI 분석 완료 — keywords/transcript/summary가 채워진 노트로 교체
+            case .voiceNoteObserved(let note):
+                let folderChanged = state.voiceNote.folderID != note.folderID
                 state.voiceNote = note
+                if folderChanged { fetchFolderName() }
             case .analysisFailed(let message):
                 // AI 분석 실패 — 에러 메시지 표시
                 state.errorMessage = message
@@ -126,9 +129,9 @@ public final class VoiceNoteViewModel {
 
     // MARK: - Private Methods
 
-    private func fetchFolderName() async {
+    private func fetchFolderName() {
         do {
-            let folderName = try await folderUseCase.fetch(by: state.voiceNote.folderID).name
+            let folderName = try folderUseCase.fetch(by: state.voiceNote.folderID).name
             send(.internal(.metadataLoaded(folderName: folderName)))
         } catch {
             AppLogger.error(error)
@@ -155,15 +158,13 @@ public final class VoiceNoteViewModel {
                 analysisState: .completed
             )
 
-            // 분석 결과 반영 (폴더명은 metadataLoaded 액션이 별도로 담당)
-            let finalNote = try await voiceNoteUseCase.update(updated)
-            send(.internal(.analysisCompleted(note: finalNote)))
+            _ = try voiceNoteUseCase.update(updated)
         } catch {
             send(.internal(.analysisFailed(error.localizedDescription)))
         }
     }
 
-    private func startPlaybackObservation() {
+    private func setupPalyback() {
         playbackObservationTask?.cancel()
         playbackObservationTask = nil
         do {
@@ -180,9 +181,25 @@ public final class VoiceNoteViewModel {
         }
     }
 
+    private func observeVoiceNote() {
+        voiceNoteObservationTask?.cancel()
+        voiceNoteObservationTask = Task {
+            do {
+                let stream = try voiceNoteUseCase.observe(id: state.voiceNote.id)
+                for await note in stream.dropFirst() {
+                    send(.internal(.voiceNoteObserved(note)))
+                }
+            } catch {
+                send(.internal(.errorOccurred(error.localizedDescription)))
+            }
+        }
+    }
+
     private func stop() {
         playbackObservationTask?.cancel()
         playbackObservationTask = nil
+        voiceNoteObservationTask?.cancel()
+        voiceNoteObservationTask = nil
         do {
             try playbackRepository.stop()
         } catch {
@@ -214,11 +231,10 @@ public final class VoiceNoteViewModel {
         }
     }
 
-    private func moveToWasteBasket() async {
-        if Task.isCancelled { return }
+    private func moveToWasteBasket() {
         do {
             stop()
-            try await wasteBasketRepository.moveToWasteBasket(item: .voiceNote(obj: state.voiceNote))
+            try wasteBasketRepository.moveToWasteBasket(item: .voiceNote(obj: state.voiceNote))
             coordinator?.pop()
         } catch {
             send(.internal(.errorOccurred(error.localizedDescription)))
@@ -284,7 +300,7 @@ public extension VoiceNoteViewModel {
 
         public enum Internal {
             case metadataLoaded(folderName: String)
-            case analysisCompleted(note: VoiceNote)
+            case voiceNoteObserved(VoiceNote)
             case analysisFailed(String)
             case playbackStateChanged(AudioPlaybackState)
             case errorOccurred(String)

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -58,9 +58,15 @@ public final class VoiceNoteViewModel {
                 setupPalyback()
                 fetchFolderName()
                 observeVoiceNote()
-                if state.voiceNote.analysisState != .completed {
+                switch state.voiceNote.analysisState {
+                case .pending, .failed:
                     state.voiceNote.analysisState = .analyzing
-                    Task { await performNewAnalysis() }
+                    Task { await performTranscription() }
+                case .transcribed:
+                    state.voiceNote.analysisState = .analyzing
+                    Task { await performSummarization() }
+                case .analyzing, .completed:
+                    break
                 }
             case .onDisappear:
                 // 재생 중단 및 리소스 해제
@@ -138,29 +144,54 @@ public final class VoiceNoteViewModel {
         }
     }
 
-    private func performNewAnalysis() async {
+    private func performTranscription() async {
         do {
-            let language = languageRepository.fetchLanguage()
-            let result = try await voiceNoteUseCase.summarize(
-                audioFilePath: state.voiceNote.voiceRecord.audioFilePath,
-                language: language
+            let transcript = try await voiceNoteUseCase.transcribe(
+                audioFilePath: state.voiceNote.voiceRecord.audioFilePath
             )
-            let updated = VoiceNote(
+            let withTranscript = VoiceNote(
                 id: state.voiceNote.id,
                 title: state.voiceNote.title,
                 createdAt: state.voiceNote.createdAt,
                 updatedAt: .now,
                 folderID: state.voiceNote.folderID,
                 voiceRecord: state.voiceNote.voiceRecord,
-                keywords: result.keywords,
-                transcript: result.transcript,
-                summary: result.summary,
-                analysisState: .completed
+                transcript: transcript,
+                analysisState: .transcribed
             )
-
-            _ = try voiceNoteUseCase.update(updated)
+            _ = try voiceNoteUseCase.update(withTranscript)
+            // stream이 .transcribed 상태를 emit하면 UI 업데이트됨
+            // 이어서 AI 요약 시도
+            await performSummarization()
         } catch {
             send(.internal(.analysisFailed(error.localizedDescription)))
+        }
+    }
+
+    private func performSummarization() async {
+        guard let transcript = state.voiceNote.transcript else { return }
+        do {
+            let language = languageRepository.fetchLanguage()
+            let (keywords, summary) = try await voiceNoteUseCase.summarize(
+                transcript: transcript,
+                language: language
+            )
+            let completed = VoiceNote(
+                id: state.voiceNote.id,
+                title: state.voiceNote.title,
+                createdAt: state.voiceNote.createdAt,
+                updatedAt: .now,
+                folderID: state.voiceNote.folderID,
+                voiceRecord: state.voiceNote.voiceRecord,
+                keywords: keywords,
+                transcript: transcript,
+                summary: summary,
+                analysisState: .completed
+            )
+            _ = try voiceNoteUseCase.update(completed)
+        } catch {
+            // STT는 성공했으므로 .failed로 덮어쓰지 않음 — 스크립트는 유지
+            send(.internal(.errorOccurred(error.localizedDescription)))
         }
     }
 

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -58,91 +58,19 @@ public final class VoiceNoteViewModel {
 
     // MARK: - View Actions
 
-    public func send(_ action: Action) {
-        switch action {
-        case .view(let viewAction):
-            switch viewAction {
-            case .onAppear:
-                setupPalyback()
-                fetchFolderName()
-                observeVoiceNote()
-                switch state.voiceNote.analysisState {
-                case .pending, .failed:
-                    state.voiceNote.analysisState = .analyzing
-                    Task { await performTranscription() }
-                case .transcribed:
-                    state.voiceNote.analysisState = .analyzing
-                    Task { await performSummarization() }
-                case .analyzing, .completed:
-                    break
-                }
-            case .onDisappear:
-                // 재생 중단 및 리소스 해제
-                stop()
-            case .playPauseButtonTapped:
-                // 현재 재생 중이면 일시정지, 아니면 재생
-                if state.currentPlaybackState.status == .playing {
-                    pause()
-                } else {
-                    play()
-                }
-            case .rewindButtonTapped:
-                // 현재 위치에서 skipInterval만큼 뒤로 이동
-                seek(to: state.currentPlaybackState.currentTime - Policy.playbackSkipInterval)
-            case .forwardButtonTapped:
-                // 현재 위치에서 skipInterval만큼 앞으로 이동
-                seek(to: state.currentPlaybackState.currentTime + Policy.playbackSkipInterval)
-            case .seekBegan:
-                // 슬라이더 드래그 시작 — 재생 중이었으면 일시정지하고 상태 보존
-                wasPlayingBeforeSeek = state.currentPlaybackState.status == .playing
-                if wasPlayingBeforeSeek { pause() }
-            case .seekEnded(let time):
-                // 슬라이더 드래그 종료 — 목표 위치로 이동 후 드래그 전 재생 상태 복원
-                seek(to: time)
-                if wasPlayingBeforeSeek {
-                    wasPlayingBeforeSeek = false
-                    play()
-                }
-            case .scriptTimestampTapped(let time):
-                // 스크립트 타임스탬프 탭 — 해당 시간으로 이동 후 재생
-                seek(to: time)
-                play()
-            case .pop:
-                coordinator?.pop()
-            case .moveVoiceNoteButtonTapped:
-                coordinator?.presentFolderList(with: .single(state.voiceNote))
-            case .editButtonTapped:
-                state.isEditing = true
-            case .doneButtonTapped:
-                state.isEditing = false
-            // TODO: 제목 저장 구현 필요
-            case .deleteVoiceNoteButtonTapped:
-                moveToWasteBasket()
-            }
-
-        case .internal(let internalAction):
-            switch internalAction {
-            case .metadataLoaded(let folderName):
-                state.folderName = folderName
-            case .voiceNoteObserved(let note):
-                let folderChanged = state.voiceNote.folderID != note.folderID
-                state.voiceNote = note
-                if folderChanged { fetchFolderName() }
-            case .analysisFailed(let message):
-                // AI 분석 실패 — 에러 메시지 표시
-                state.errorMessage = message
-                state.voiceNote.analysisState = .failed
-            case .playbackStateChanged(let playbackState):
-                // 재생 진행 스트림에서 수신한 최신 상태 반영
-                state.currentPlaybackState = playbackState
-                state.updatePlayingParagraph()
-            case .errorOccurred(let message):
-                // 재생 제어 중 에러 발생 — 알럿 표시
-                state.errorMessage = message
-            case .errorDismissed:
-                // 에러 알럿 닫기
-                state.errorMessage = nil
-            }
+    public func onAppear() {
+        setupPlayback()
+        fetchFolderName()
+        observeVoiceNote()
+        switch voiceNote.analysisState {
+        case .pending, .failed:
+            voiceNote.analysisState = .analyzing
+            Task { await performTranscription() }
+        case .transcribed:
+            voiceNote.analysisState = .analyzing
+            Task { await performSummarization() }
+        case .analyzing, .completed:
+            break
         }
     }
 
@@ -189,7 +117,7 @@ public final class VoiceNoteViewModel {
     }
 
     public func moveVoiceNote() {
-        coordinator?.presentFolderList(with: voiceNote)
+        coordinator?.presentFolderList(with: .single(voiceNote))
     }
 
     public func enterEditing() {

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -13,8 +13,6 @@ public final class VoiceNoteViewModel {
     public private(set) var isEditing: Bool = false
     public private(set) var currentPlaybackState = AudioPlaybackState(status: .idle, currentTime: 0, duration: 0)
     public private(set) var playingParagraphInfo: PlayingParagraphInfo?
-    /// State가 struct이 아니므로 let으로 선언해 참조 안정성을 보장합니다.
-    public let playbackHighlight = PlaybackHighlight()
     public private(set) var editableScriptSections: [ScriptSection] = []
 
     @ObservationIgnored
@@ -336,7 +334,6 @@ public final class VoiceNoteViewModel {
         guard !sections.isEmpty else {
             guard playingParagraphInfo != nil else { return }
             playingParagraphInfo = nil
-            playbackHighlight.playingParagraphInfo = nil
             return
         }
 
@@ -349,7 +346,6 @@ public final class VoiceNoteViewModel {
         }
         guard playingParagraphInfo != newInfo else { return }
         playingParagraphInfo = newInfo
-        playbackHighlight.playingParagraphInfo = newInfo
     }
 
     private static func groupSegmentsIntoSections(_ segments: [TranscriptSegment]) -> [ScriptSection] {
@@ -425,11 +421,6 @@ public extension VoiceNoteViewModel {
 // MARK: - Nested Types
 
 public extension VoiceNoteViewModel {
-    @Observable
-    final class PlaybackHighlight {
-        public var playingParagraphInfo: PlayingParagraphInfo?
-    }
-
     struct PlayingParagraphInfo: Equatable {
         public let sectionIndex: Int
         public let paragraphIndex: Int

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -7,7 +7,14 @@ public protocol VoiceNoteCoordinatorDelegate: BaseCoordinatorDelegate {}
 @MainActor
 @Observable
 public final class VoiceNoteViewModel {
-    public private(set) var state: State
+    public private(set) var voiceNote: VoiceNote
+    public private(set) var folderName: String = ""
+    public private(set) var errorMessage: String?
+    public private(set) var isEditing: Bool = false
+    public private(set) var currentPlaybackState = AudioPlaybackState(status: .idle, currentTime: 0, duration: 0)
+    public private(set) var playingParagraphInfo: PlayingParagraphInfo?
+    /// State가 struct이 아니므로 let으로 선언해 참조 안정성을 보장합니다.
+    public let playbackHighlight = PlaybackHighlight()
 
     @ObservationIgnored
     private var playbackObservationTask: Task<Void, Never>?
@@ -35,7 +42,7 @@ public final class VoiceNoteViewModel {
         playbackRepository: any VoiceRecordPlaybackRepository,
         wasteBasketRepository: any WasteBasketRepository
     ) {
-        state = State(voiceNote: voiceNote)
+        self.voiceNote = voiceNote
         self.voiceNoteUseCase = voiceNoteUseCase
         self.folderUseCase = folderUseCase
         self.languageRepository = languageRepository
@@ -48,7 +55,7 @@ public final class VoiceNoteViewModel {
         voiceNoteObservationTask?.cancel()
     }
 
-    // MARK: - Send
+    // MARK: - View Actions
 
     public func send(_ action: Action) {
         switch action {
@@ -138,12 +145,98 @@ public final class VoiceNoteViewModel {
         }
     }
 
+    public func onDisappear() {
+        stop()
+    }
+
+    public func playPause() {
+        if currentPlaybackState.status == .playing {
+            pause()
+        } else {
+            play()
+        }
+    }
+
+    public func rewind() {
+        seek(to: currentPlaybackState.currentTime - Policy.playbackSkipInterval)
+    }
+
+    public func forward() {
+        seek(to: currentPlaybackState.currentTime + Policy.playbackSkipInterval)
+    }
+
+    public func seekBegan() {
+        wasPlayingBeforeSeek = currentPlaybackState.status == .playing
+        if wasPlayingBeforeSeek { pause() }
+    }
+
+    public func seekEnded(_ time: TimeInterval) {
+        seek(to: time)
+        if wasPlayingBeforeSeek {
+            wasPlayingBeforeSeek = false
+            play()
+        }
+    }
+
+    public func scriptTimestampTapped(_ time: TimeInterval) {
+        seek(to: time)
+        play()
+    }
+
+    public func pop() {
+        coordinator?.pop()
+    }
+
+    public func moveVoiceNote() {
+        coordinator?.presentFolderList(with: voiceNote)
+    }
+
+    public func enterEditing() {
+        isEditing = true
+    }
+
+    public func doneEditing(title: String) {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedTitle.isEmpty, trimmedTitle != voiceNote.title else {
+            isEditing = false
+            return
+        }
+
+        let updatedNote = VoiceNote(
+            id: voiceNote.id,
+            title: trimmedTitle,
+            createdAt: voiceNote.createdAt,
+            updatedAt: .now,
+            folderID: voiceNote.folderID,
+            voiceRecord: voiceNote.voiceRecord,
+            keywords: voiceNote.keywords,
+            transcript: voiceNote.transcript,
+            summary: voiceNote.summary,
+            analysisState: voiceNote.analysisState
+        )
+
+        do {
+            _ = try voiceNoteUseCase.update(updatedNote)
+            isEditing = false
+        } catch {
+            errorMessage = "제목 수정에 실패했습니다: \(error.localizedDescription)"
+        }
+    }
+
+    public func deleteVoiceNote() {
+        moveToWasteBasket()
+    }
+
+    public func dismissError() {
+        errorMessage = nil
+    }
+
     // MARK: - Private Methods
 
     private func fetchFolderName() {
         do {
-            let folderName = try folderUseCase.fetch(by: state.voiceNote.folderID).name
-            send(.internal(.metadataLoaded(folderName: folderName)))
+            folderName = try folderUseCase.fetch(by: voiceNote.folderID).name
         } catch {
             AppLogger.error(error)
         }
@@ -152,29 +245,28 @@ public final class VoiceNoteViewModel {
     private func performTranscription() async {
         do {
             let transcript = try await voiceNoteUseCase.transcribe(
-                audioFilePath: state.voiceNote.voiceRecord.audioFilePath
+                audioFilePath: voiceNote.voiceRecord.audioFilePath
             )
             let withTranscript = VoiceNote(
-                id: state.voiceNote.id,
-                title: state.voiceNote.title,
-                createdAt: state.voiceNote.createdAt,
+                id: voiceNote.id,
+                title: voiceNote.title,
+                createdAt: voiceNote.createdAt,
                 updatedAt: .now,
-                folderID: state.voiceNote.folderID,
-                voiceRecord: state.voiceNote.voiceRecord,
+                folderID: voiceNote.folderID,
+                voiceRecord: voiceNote.voiceRecord,
                 transcript: transcript,
                 analysisState: .transcribed
             )
             _ = try voiceNoteUseCase.update(withTranscript)
-            // stream이 .transcribed 상태를 emit하면 UI 업데이트됨
-            // 이어서 AI 요약 시도
             await performSummarization()
         } catch {
-            send(.internal(.analysisFailed(error.localizedDescription)))
+            errorMessage = error.localizedDescription
+            voiceNote.analysisState = .failed
         }
     }
 
     private func performSummarization() async {
-        guard let transcript = state.voiceNote.transcript else { return }
+        guard let transcript = voiceNote.transcript else { return }
         do {
             let language = languageRepository.fetchLanguage()
             let (keywords, summary) = try await voiceNoteUseCase.summarize(
@@ -182,12 +274,12 @@ public final class VoiceNoteViewModel {
                 language: language
             )
             let completed = VoiceNote(
-                id: state.voiceNote.id,
-                title: state.voiceNote.title,
-                createdAt: state.voiceNote.createdAt,
+                id: voiceNote.id,
+                title: voiceNote.title,
+                createdAt: voiceNote.createdAt,
                 updatedAt: .now,
-                folderID: state.voiceNote.folderID,
-                voiceRecord: state.voiceNote.voiceRecord,
+                folderID: voiceNote.folderID,
+                voiceRecord: voiceNote.voiceRecord,
                 keywords: keywords,
                 transcript: transcript,
                 summary: summary,
@@ -196,24 +288,25 @@ public final class VoiceNoteViewModel {
             _ = try voiceNoteUseCase.update(completed)
         } catch {
             // STT는 성공했으므로 .failed로 덮어쓰지 않음 — 스크립트는 유지
-            send(.internal(.errorOccurred(error.localizedDescription)))
+            errorMessage = error.localizedDescription
         }
     }
 
-    private func setupPalyback() {
+    private func setupPlayback() {
         playbackObservationTask?.cancel()
         playbackObservationTask = nil
         do {
             let stream = try playbackRepository.prepare(
-                audioFilePath: state.voiceNote.voiceRecord.audioFilePath
+                audioFilePath: voiceNote.voiceRecord.audioFilePath
             )
             playbackObservationTask = Task {
                 for await playbackState in stream {
-                    send(.internal(.playbackStateChanged(playbackState)))
+                    currentPlaybackState = playbackState
+                    updatePlayingParagraph()
                 }
             }
         } catch {
-            send(.internal(.errorOccurred(error.localizedDescription)))
+            errorMessage = error.localizedDescription
         }
     }
 
@@ -221,12 +314,14 @@ public final class VoiceNoteViewModel {
         voiceNoteObservationTask?.cancel()
         voiceNoteObservationTask = Task {
             do {
-                let stream = try voiceNoteUseCase.observe(id: state.voiceNote.id)
+                let stream = try voiceNoteUseCase.observe(id: voiceNote.id)
                 for await note in stream.dropFirst() {
-                    send(.internal(.voiceNoteObserved(note)))
+                    let folderChanged = voiceNote.folderID != note.folderID
+                    voiceNote = note
+                    if folderChanged { fetchFolderName() }
                 }
             } catch {
-                send(.internal(.errorOccurred(error.localizedDescription)))
+                errorMessage = error.localizedDescription
             }
         }
     }
@@ -239,7 +334,7 @@ public final class VoiceNoteViewModel {
         do {
             try playbackRepository.stop()
         } catch {
-            send(.internal(.errorOccurred(error.localizedDescription)))
+            errorMessage = error.localizedDescription
         }
     }
 
@@ -247,7 +342,7 @@ public final class VoiceNoteViewModel {
         do {
             try playbackRepository.play()
         } catch {
-            send(.internal(.errorOccurred(error.localizedDescription)))
+            errorMessage = error.localizedDescription
         }
     }
 
@@ -255,7 +350,7 @@ public final class VoiceNoteViewModel {
         do {
             try playbackRepository.pause()
         } catch {
-            send(.internal(.errorOccurred(error.localizedDescription)))
+            errorMessage = error.localizedDescription
         }
     }
 
@@ -263,28 +358,122 @@ public final class VoiceNoteViewModel {
         do {
             try playbackRepository.seek(to: time)
         } catch {
-            send(.internal(.errorOccurred(error.localizedDescription)))
+            errorMessage = error.localizedDescription
         }
     }
 
     private func moveToWasteBasket() {
         do {
             stop()
-            try wasteBasketRepository.moveToWasteBasket(item: .voiceNote(obj: state.voiceNote))
+            try wasteBasketRepository.moveToWasteBasket(item: .voiceNote(obj: voiceNote))
             coordinator?.pop()
         } catch {
-            send(.internal(.errorOccurred(error.localizedDescription)))
+            errorMessage = error.localizedDescription
         }
+    }
+
+    private func updatePlayingParagraph() {
+        let currentTime = currentPlaybackState.currentTime
+        let sections = scriptSections
+        guard !sections.isEmpty else {
+            guard playingParagraphInfo != nil else { return }
+            playingParagraphInfo = nil
+            playbackHighlight.playingParagraphInfo = nil
+            return
+        }
+
+        var newInfo: PlayingParagraphInfo?
+        for (index, section) in sections.enumerated().reversed() {
+            if section.timestamp <= currentTime {
+                newInfo = PlayingParagraphInfo(sectionIndex: index, paragraphIndex: 0)
+                break
+            }
+        }
+        guard playingParagraphInfo != newInfo else { return }
+        playingParagraphInfo = newInfo
+        playbackHighlight.playingParagraphInfo = newInfo
+    }
+
+    private static func groupSegmentsIntoSections(_ segments: [TranscriptSegment]) -> [ScriptSection] {
+        guard let first = segments.first else { return [] }
+
+        var sections: [ScriptSection] = []
+        var currentTimestamp = first.timestamp
+        var currentWords: [String] = [first.substring]
+
+        for i in 1 ..< segments.count {
+            let prev = segments[i - 1]
+            let curr = segments[i]
+            let gap = curr.timestamp - (prev.timestamp + prev.duration)
+
+            if gap > Policy.scriptGroupingPauseThreshold {
+                let paragraph = currentWords.joined(separator: " ")
+                sections.append(ScriptSection(timestamp: currentTimestamp, paragraphs: [paragraph]))
+                currentTimestamp = curr.timestamp
+                currentWords = [curr.substring]
+            } else {
+                currentWords.append(curr.substring)
+            }
+        }
+
+        if !currentWords.isEmpty {
+            let paragraph = currentWords.joined(separator: " ")
+            sections.append(ScriptSection(timestamp: currentTimestamp, paragraphs: [paragraph]))
+        }
+
+        return sections
+    }
+}
+
+// MARK: - Computed Properties
+
+public extension VoiceNoteViewModel {
+    var title: String {
+        voiceNote.title
+    }
+
+    var metadataText1: String {
+        let created = voiceNote.createdAt.toString(format: "yyyy.MM.dd · a HH:mm")
+        guard voiceNote.createdAt != voiceNote.updatedAt else { return created }
+        let updated = voiceNote.updatedAt.toString(format: "yyyy.MM.dd")
+        return "\(created) (\(updated) 수정됨)"
+    }
+
+    var metadataText2: String {
+        voiceNote.voiceRecord.duration.koreanDurationString
+    }
+
+    var keywords: [String] {
+        voiceNote.keywords.map(\.word)
+    }
+
+    var keyPoints: [KeyPoint] {
+        guard let summary = voiceNote.summary else { return [] }
+        return summary.text
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .enumerated()
+            .map { KeyPoint(number: $0.offset + 1, text: $0.element) }
+    }
+
+    var scriptSections: [ScriptSection] {
+        guard let transcript = voiceNote.transcript, !transcript.segments.isEmpty else { return [] }
+        return Self.groupSegmentsIntoSections(transcript.segments)
     }
 }
 
 // MARK: - Nested Types
 
 public extension VoiceNoteViewModel {
-    /// 재생 위치에 따른 하이라이트 상태. 셀이 직접 관찰합니다.
     @Observable
     final class PlaybackHighlight {
-        public var playingParagraphInfo: State.PlayingParagraphInfo?
+        public var playingParagraphInfo: PlayingParagraphInfo?
+    }
+
+    struct PlayingParagraphInfo: Equatable {
+        public let sectionIndex: Int
+        public let paragraphIndex: Int
     }
 
     enum Section: Int, CaseIterable, Sendable {
@@ -317,159 +506,5 @@ public extension VoiceNoteViewModel {
         case keyPoint(number: Int, text: String)
         case keywords
         case script(index: Int)
-    }
-
-    enum Action {
-        public enum View {
-            case onAppear
-            case onDisappear
-            case playPauseButtonTapped
-            case rewindButtonTapped
-            case forwardButtonTapped
-            case seekBegan
-            case seekEnded(TimeInterval)
-            case scriptTimestampTapped(TimeInterval)
-            case pop
-            case moveVoiceNoteButtonTapped
-            case editButtonTapped
-            case doneButtonTapped(String)
-            case deleteVoiceNoteButtonTapped
-        }
-
-        public enum Internal {
-            case metadataLoaded(folderName: String)
-            case voiceNoteObserved(VoiceNote)
-            case analysisFailed(String)
-            case playbackStateChanged(AudioPlaybackState)
-            case errorOccurred(String)
-            case errorDismissed
-        }
-
-        case view(View)
-        case `internal`(Internal)
-    }
-
-    struct State {
-        var voiceNote: VoiceNote
-        var isEditing: Bool = false
-        var errorMessage: String?
-        var folderName: String = ""
-        /// State가 struct이므로 let으로 선언해 참조 안정성을 보장합니다.
-        let playbackHighlight = PlaybackHighlight()
-        var currentPlaybackState = AudioPlaybackState(status: .idle, currentTime: 0, duration: 0)
-
-        init(voiceNote: VoiceNote) {
-            self.voiceNote = voiceNote
-        }
-
-        // MARK: - Highlight Logic
-
-        /// 현재 재생 중인 문단의 정보를 담는 구조체
-        public struct PlayingParagraphInfo: Equatable {
-            public let sectionIndex: Int
-            public let paragraphIndex: Int
-        }
-
-        /// 현재 하이라이트된 문단 정보
-        public private(set) var playingParagraphInfo: PlayingParagraphInfo?
-
-        /// 재생 시간에 따라 하이라이트 정보를 업데이트합니다.
-        /// - Note: `@Observable`은 값이 같아도 setter 호출 시 observation을 fire하므로,
-        ///   동일 값이면 early return하여 visible cell의 불필요한 `updateProperties()` 호출을 방지합니다.
-        mutating func updatePlayingParagraph() {
-            let currentTime = currentPlaybackState.currentTime
-            let sections = scriptSections
-            guard !sections.isEmpty else {
-                guard playingParagraphInfo != nil else { return }
-                playingParagraphInfo = nil
-                playbackHighlight.playingParagraphInfo = nil
-                return
-            }
-
-            var newInfo: PlayingParagraphInfo?
-            for (index, section) in sections.enumerated().reversed() {
-                if section.timestamp <= currentTime {
-                    newInfo = PlayingParagraphInfo(sectionIndex: index, paragraphIndex: 0)
-                    break
-                }
-            }
-            guard playingParagraphInfo != newInfo else {
-                return
-            }
-            playingParagraphInfo = newInfo
-            playbackHighlight.playingParagraphInfo = newInfo
-        }
-
-        // MARK: - Mapped Properties
-
-        public var title: String {
-            voiceNote.title
-        }
-
-        public var metadataText1: String {
-            let created = voiceNote.createdAt.toString(format: "yyyy.MM.dd · a HH:mm")
-            guard voiceNote.createdAt != voiceNote.updatedAt else { return created }
-            let updated = voiceNote.updatedAt.toString(format: "yyyy.MM.dd")
-            return "\(created) (\(updated) 수정됨)"
-        }
-
-        public var metadataText2: String {
-            voiceNote.voiceRecord.duration.koreanDurationString
-        }
-
-        public var keywords: [String] {
-            voiceNote.keywords.map(\.word)
-        }
-
-        public var keyPoints: [KeyPoint] {
-            guard let summary = voiceNote.summary else { return [] }
-            return summary.text
-                .components(separatedBy: "\n")
-                .map { $0.trimmingCharacters(in: .whitespaces) }
-                .filter { !$0.isEmpty }
-                .enumerated()
-                .map { KeyPoint(number: $0.offset + 1, text: $0.element) }
-        }
-
-        public var scriptSections: [ScriptSection] {
-            guard let transcript = voiceNote.transcript, !transcript.segments.isEmpty else { return [] }
-            return Self.groupSegmentsIntoSections(transcript.segments)
-        }
-
-        // MARK: - Segment Grouping
-
-        /// 세그먼트를 공백 임계값 기준으로 섹션들로 그룹화
-        private static func groupSegmentsIntoSections(_ segments: [TranscriptSegment]) -> [ScriptSection] {
-            guard let first = segments.first else { return [] }
-
-            var sections: [ScriptSection] = []
-            var currentTimestamp = first.timestamp
-            var currentWords: [String] = [first.substring]
-
-            for i in 1 ..< segments.count {
-                let prev = segments[i - 1]
-                let curr = segments[i]
-                let gap = curr.timestamp - (prev.timestamp + prev.duration)
-
-                if gap > Policy.scriptGroupingPauseThreshold {
-                    // 현재까지 모은 단어들을 하나의 문단으로 완성
-                    let paragraph = currentWords.joined(separator: " ")
-                    sections.append(ScriptSection(timestamp: currentTimestamp, paragraphs: [paragraph]))
-                    // 새 섹션 시작
-                    currentTimestamp = curr.timestamp
-                    currentWords = [curr.substring]
-                } else {
-                    currentWords.append(curr.substring)
-                }
-            }
-
-            // 마지막 섹션 추가
-            if !currentWords.isEmpty {
-                let paragraph = currentWords.joined(separator: " ")
-                sections.append(ScriptSection(timestamp: currentTimestamp, paragraphs: [paragraph]))
-            }
-
-            return sections
-        }
     }
 }

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -15,6 +15,7 @@ public final class VoiceNoteViewModel {
     public private(set) var playingParagraphInfo: PlayingParagraphInfo?
     /// State가 struct이 아니므로 let으로 선언해 참조 안정성을 보장합니다.
     public let playbackHighlight = PlaybackHighlight()
+    public private(set) var editableScriptSections: [ScriptSection] = []
 
     @ObservationIgnored
     private var playbackObservationTask: Task<Void, Never>?
@@ -192,7 +193,18 @@ public final class VoiceNoteViewModel {
     }
 
     public func enterEditing() {
+        editableScriptSections = scriptSections
         isEditing = true
+    }
+
+    public func updateScriptParagraph(sectionIndex: Int, paragraphIndex: Int, text: String) {
+        guard sectionIndex < editableScriptSections.count,
+              paragraphIndex < editableScriptSections[sectionIndex].paragraphs.count else { return }
+        var sections = editableScriptSections
+        var paragraphs = sections[sectionIndex].paragraphs
+        paragraphs[paragraphIndex] = text
+        sections[sectionIndex] = ScriptSection(timestamp: sections[sectionIndex].timestamp, paragraphs: paragraphs)
+        editableScriptSections = sections
     }
 
     public func doneEditing(title: String) {
@@ -211,7 +223,7 @@ public final class VoiceNoteViewModel {
             folderID: voiceNote.folderID,
             voiceRecord: voiceNote.voiceRecord,
             keywords: voiceNote.keywords,
-            transcript: voiceNote.transcript,
+            transcript: makeUpdatedTranscript(),
             summary: voiceNote.summary,
             analysisState: voiceNote.analysisState
         )
@@ -223,6 +235,23 @@ public final class VoiceNoteViewModel {
         } catch {
             errorMessage = "제목 수정에 실패했습니다: \(error.localizedDescription)"
         }
+    }
+
+    private func makeUpdatedTranscript() -> Transcript? {
+        guard let original = voiceNote.transcript else { return nil }
+        
+        let segments = editableScriptSections.flatMap { section in
+            section.paragraphs.map { pText in
+                TranscriptSegment(substring: pText, timestamp: section.timestamp, duration: 0)
+            }
+        }
+        
+        return Transcript(
+            id: original.id,
+            createdAt: original.createdAt,
+            text: segments.map(\.substring).joined(separator: "\n"),
+            segments: segments
+        )
     }
 
     public func deleteVoiceNote() {
@@ -459,6 +488,7 @@ public extension VoiceNoteViewModel {
     }
 
     var scriptSections: [ScriptSection] {
+        if isEditing { return editableScriptSections }
         guard let transcript = voiceNote.transcript, !transcript.segments.isEmpty else { return [] }
         return Self.groupSegmentsIntoSections(transcript.segments)
     }

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -103,6 +103,11 @@ public final class VoiceNoteViewModel {
                 coordinator?.pop()
             case .moveVoiceNoteButtonTapped:
                 coordinator?.presentFolderList(with: .single(state.voiceNote))
+            case .editButtonTapped:
+                state.isEditing = true
+            case .doneButtonTapped:
+                state.isEditing = false
+            // TODO: 제목 저장 구현 필요
             case .deleteVoiceNoteButtonTapped:
                 moveToWasteBasket()
             }
@@ -326,6 +331,8 @@ public extension VoiceNoteViewModel {
             case scriptTimestampTapped(TimeInterval)
             case pop
             case moveVoiceNoteButtonTapped
+            case editButtonTapped
+            case doneButtonTapped(String)
             case deleteVoiceNoteButtonTapped
         }
 
@@ -344,6 +351,7 @@ public extension VoiceNoteViewModel {
 
     struct State {
         var voiceNote: VoiceNote
+        var isEditing: Bool = false
         var errorMessage: String?
         var folderName: String = ""
         /// State가 struct이므로 let으로 선언해 참조 안정성을 보장합니다.

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -1,6 +1,6 @@
-@testable import Presentation
 import Domain
 import DomainTesting
+@testable import Presentation
 import XCTest
 
 @MainActor
@@ -201,7 +201,7 @@ final class MainViewModelTests: XCTestCase {
         // Then
         sut.mockVoiceNoteRepo.verify()
         XCTAssertEqual(sut.viewModel.categoryData[1].items.count, 2)
-        if case .voiceNote(let note) = sut.viewModel.categoryData[1].items[0] {
+        if case let .voiceNote(note) = sut.viewModel.categoryData[1].items[0] {
             XCTAssertEqual(note.title, "노트1")
         } else {
             XCTFail("VoiceNote 타입이 아닙니다.")
@@ -222,7 +222,7 @@ final class MainViewModelTests: XCTestCase {
         // Then
         sut.mockVoiceNoteRepo.verify()
         XCTAssertEqual(sut.viewModel.categoryData[0].items.count, 2)
-        if case .voiceNote(let note) = sut.viewModel.categoryData[0].items[0] {
+        if case let .voiceNote(note) = sut.viewModel.categoryData[0].items[0] {
             XCTAssertEqual(note.title, "최신1")
         } else {
             XCTFail("VoiceNote 타입이 아닙니다.")
@@ -233,7 +233,7 @@ final class MainViewModelTests: XCTestCase {
         let sut = makeSUT()
         let expectedFolders = [
             Folder(name: "테스트 폴더 1"),
-            Folder(name: "테스트 폴더 2")
+            Folder(name: "테스트 폴더 2"),
         ]
 
         sut.mockFolderRepo.setFetchAllResult(.success(expectedFolders))
@@ -247,7 +247,7 @@ final class MainViewModelTests: XCTestCase {
         sut.mockFolderRepo.verify()
         XCTAssertEqual(sut.viewModel.categoryData[2].items.count, 2)
 
-        if case .folder(let folder) = sut.viewModel.categoryData[2].items[0] {
+        if case let .folder(folder) = sut.viewModel.categoryData[2].items[0] {
             XCTAssertEqual(folder.name, "테스트 폴더 1")
         } else {
             XCTFail("Folder 타입이 아닙니다.")

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -1,6 +1,6 @@
+@testable import Presentation
 import Domain
 import DomainTesting
-@testable import Presentation
 import XCTest
 
 @MainActor
@@ -201,7 +201,7 @@ final class MainViewModelTests: XCTestCase {
         // Then
         sut.mockVoiceNoteRepo.verify()
         XCTAssertEqual(sut.viewModel.categoryData[1].items.count, 2)
-        if case let .voiceNote(note) = sut.viewModel.categoryData[1].items[0] {
+        if case .voiceNote(let note) = sut.viewModel.categoryData[1].items[0] {
             XCTAssertEqual(note.title, "노트1")
         } else {
             XCTFail("VoiceNote 타입이 아닙니다.")
@@ -222,7 +222,7 @@ final class MainViewModelTests: XCTestCase {
         // Then
         sut.mockVoiceNoteRepo.verify()
         XCTAssertEqual(sut.viewModel.categoryData[0].items.count, 2)
-        if case let .voiceNote(note) = sut.viewModel.categoryData[0].items[0] {
+        if case .voiceNote(let note) = sut.viewModel.categoryData[0].items[0] {
             XCTAssertEqual(note.title, "최신1")
         } else {
             XCTFail("VoiceNote 타입이 아닙니다.")
@@ -233,7 +233,7 @@ final class MainViewModelTests: XCTestCase {
         let sut = makeSUT()
         let expectedFolders = [
             Folder(name: "테스트 폴더 1"),
-            Folder(name: "테스트 폴더 2"),
+            Folder(name: "테스트 폴더 2")
         ]
 
         sut.mockFolderRepo.setFetchAllResult(.success(expectedFolders))
@@ -247,7 +247,7 @@ final class MainViewModelTests: XCTestCase {
         sut.mockFolderRepo.verify()
         XCTAssertEqual(sut.viewModel.categoryData[2].items.count, 2)
 
-        if case let .folder(folder) = sut.viewModel.categoryData[2].items[0] {
+        if case .folder(let folder) = sut.viewModel.categoryData[2].items[0] {
             XCTAssertEqual(folder.name, "테스트 폴더 1")
         } else {
             XCTFail("Folder 타입이 아닙니다.")

--- a/Presentation/Tests/OnBoarding/OnBoardingViewModelTests.swift
+++ b/Presentation/Tests/OnBoarding/OnBoardingViewModelTests.swift
@@ -22,6 +22,7 @@ final class OnBoardingViewModelTests: XCTestCase {
         let viewModel: OnBoardingViewModel
         let mockLanguageRepo: MockLanguageRepository
         let mockVoiceRecordRepo: MockVoiceRecordRepository
+        let mockSTTRepo: MockSTTRepository
         let mockCheckFirstLaunchRepo: MockCheckFirstLaunchRepository
         let mockFolderRepo: MockFolderRepository
         let mockNavDelegate: MockNavigationDelegate
@@ -30,6 +31,7 @@ final class OnBoardingViewModelTests: XCTestCase {
     private func makeSUT() -> SUT {
         let mockLanguageRepo = MockLanguageRepository()
         let mockVoiceRecordRepo = MockVoiceRecordRepository()
+        let mockSTTRepo = MockSTTRepository()
         let mockCheckFirstLaunchRepo = MockCheckFirstLaunchRepository()
         let mockFolderRepo = MockFolderRepository()
         let mockNavDelegate = MockNavigationDelegate()
@@ -37,6 +39,7 @@ final class OnBoardingViewModelTests: XCTestCase {
         let viewModel = OnBoardingViewModel(
             languageRepository: mockLanguageRepo,
             voiceRecordRepository: mockVoiceRecordRepo,
+            sttRepository: mockSTTRepo,
             checkFirstLaunchRepository: mockCheckFirstLaunchRepo,
             folderUseCase: DefaultFolderUseCase(repository: mockFolderRepo)
         )
@@ -46,6 +49,7 @@ final class OnBoardingViewModelTests: XCTestCase {
             viewModel: viewModel,
             mockLanguageRepo: mockLanguageRepo,
             mockVoiceRecordRepo: mockVoiceRecordRepo,
+            mockSTTRepo: mockSTTRepo,
             mockCheckFirstLaunchRepo: mockCheckFirstLaunchRepo,
             mockFolderRepo: mockFolderRepo,
             mockNavDelegate: mockNavDelegate
@@ -91,17 +95,27 @@ final class OnBoardingViewModelTests: XCTestCase {
     func test_syncPageState호출시_마이크권한스텝이면_권한을_요청한다() async {
         let sut = makeSUT()
 
+        // Mic
         await sut.mockVoiceRecordRepo.setCheckPermissionResult(.notDetermined)
         await sut.mockVoiceRecordRepo.setRequestPermissionResult(.success(.authorized))
+        // STT
+        await sut.mockSTTRepo.setCheckResult(.notDetermined)
+        await sut.mockSTTRepo.setRequestResult(.success(.authorized))
 
         sut.viewModel.syncPageState(nextStep: Step.micPermission.rawValue)
 
         // Task 내부 비동기 호출 대기 (안전하게 0.3초 대기)
         try? await Task.sleep(nanoseconds: 300_000_000)
 
+        // Mic 검증
         await sut.mockVoiceRecordRepo.expectCheckPermission(callCount: 1)
         await sut.mockVoiceRecordRepo.expectRequestPermission(callCount: 1)
         await sut.mockVoiceRecordRepo.verify()
+
+        // STT 검증
+        await sut.mockSTTRepo.expectCheckSTTPermission(callCount: 1)
+        await sut.mockSTTRepo.expectRequestSTTPermission(callCount: 1)
+        await sut.mockSTTRepo.verify()
     }
 
     func test_primaryButtonAction_첫스텝에서_다음스텝으로_이동한다() {
@@ -160,8 +174,12 @@ final class OnBoardingViewModelTests: XCTestCase {
         let sut = makeSUT()
 
         // Background Task가 실행되므로 미리 모의 객체(Mock) 응답을 세팅해 두어야 에러(미설정)가 나지 않습니다.
+        // Mic
         await sut.mockVoiceRecordRepo.setCheckPermissionResult(.notDetermined)
         await sut.mockVoiceRecordRepo.setRequestPermissionResult(.success(.authorized))
+        // STT
+        await sut.mockSTTRepo.setCheckResult(.notDetermined)
+        await sut.mockSTTRepo.setRequestResult(.success(.authorized))
 
         sut.viewModel.syncPageState(nextStep: Step.micPermission.rawValue)
 

--- a/Presentation/Tests/Trash/TrashViewModelTests.swift
+++ b/Presentation/Tests/Trash/TrashViewModelTests.swift
@@ -53,6 +53,7 @@ final class TrashViewModelTests: XCTestCase {
         let dummyItem = WasteBasketItem.folder(
             obj: Folder(name: "테스트 폴더", createdAt: Date().addingTimeInterval(-86400 * 5))
         )
+        sut.mockRepo.setDeleteResult(.success(()))
         sut.viewModel.toggleSelectionMode() // isSelectionMode = true
         XCTAssertTrue(sut.viewModel.isSelectionMode, "토글 후 true가 되어야 합니다.")
 


### PR DESCRIPTION
## ✨ 작업 요약
> 보이스노트 제목 편집기능과 분석 상태 스트리밍을 구현합니다.

- 보이스노트 **제목 편집**: 타이틀 레이블 탭 → 편집 모드 → 완료 시 저장
- 보이스노트 **스크립트 편집**: 더보기 메뉴 "편집하기" → 문단 단위 편집 → 저장
- 편집 상태를 `EditingMode(.title / .script)`로 통합, 제목/스크립트 편집 경로를 명확히 분리
- VoiceNote `observe(id:)` 스트림 도입으로 외부 변경(폴더 이동 등)을 실시간 반영
- 분석 파이프라인을 `.pending → .analyzing → .transcribed → .completed` 단계로 분리, 중간 실패 시 스크립트는 유지

---

## 📋 구체적인 내용

**추가/변경된 동작**

- 제목 편집: `titleLabel` 탭 → TextField 포커스 + 전체 선택 → Return/완료/탭아웃 시 커밋, 공백/미변경은 원복
- 스크립트 편집: 메뉴 "편집하기" → 문단을 `UITextView`로 전환 → `editableScriptSections`에 반영 → 완료 시 Transcript 갱신
- 하이라이트: 재생 중 현재 문단을 `reconfigureItems` 기반으로 갱신 (VC·VM이 `PlayingParagraphInfo`로 상태 공유)
- 분석 상태: `VoiceNote.analysisState`에 `.transcribed` 추가, 전사/요약을 분리해 각 단계별 실패 대응
- Repository: `observe(id:)` (AsyncStream)으로 VoiceNote 변경 스트리밍
- 네비게이션: 좌측 영역을 `backChevronButton` + `titleLabel`로 분리

**영향 받는 화면/모듈**

- Presentation: `VoiceNoteViewController`, `VoiceNoteViewModel`, `ScriptCell`, `MoveFolderListViewModel`, `NewFolderViewModel`, `OnBoardingViewModel`, `FolderDetailViewModel`
- Domain: `VoiceNote`, `VoiceNoteUseCase`, `VoiceNoteRepository`
- Data: `DefaultVoiceNoteRepository`, `DefaultSTTRepository`, `CoreDataLocalDataBase`
- App: `AppDIContainer`

---

## 🔗 연관 이슈

- closed #206

---

## 🧩 설계·구현 노트

### 편집 상태 모델 — `EditingMode`

- **선택한 방식**: `editingMode: EditingMode?` (`.title` / `.script` / `nil`) 단일 상태
  - 제목/스크립트 편집 경로가 상호 배타적이라 하나의 옵셔널로 충분
  - 뷰는 `applyEditingMode(_:)` 한 분기점으로 UI 변환
- **고려했다가 제외한 방식**
  - `isEditingTitle`, `isEditingScript` 두 Bool — 동시 true 금지를 코드 레벨에서 강제하기 어려움
  - 타이틀 바 공통 "완료" 버튼 + 통합 `doneEditing` — 제목만/스크립트만 수정한 경우를 구분하기 힘들어 저장 누락 버그(미변경 시 다른 필드 저장 스킵) 발생. 분리로 해결

### 스크립트 하이라이트 — `reconfigureItems`

- **선택한 방식**: VM이 `playingParagraphInfo` 값 스냅샷 공개, VC는 변경 시 scripts 섹션만 `reconfigureItems`
- **고려했다가 제외한 방식**
  - 셀이 VM을 직접 `@Observable`로 구독: 셀이 VM을 알게 되어 결합도 상승
  - VC가 "이전 하이라이트 인덱스"를 보유: VC에 파생 상태가 생겨 일관성 유지 부담
  - 전체 섹션 reconfigure는 diff 비용이 크지 않다고 판단

### 분석 파이프라인

- `.transcribed` 단계를 추가해 "전사는 성공, 요약은 실패" 시 스크립트를 유지하고 `.failed`로 덮어쓰지 않도록 함
- `observe(id:)` 스트림을 구독해 앱 내 다른 화면에서의 변경(폴더 이동 등)을 실시간 반영

---

## ✅ 확인 사항

- [ ] 정상 플로우 동작 확인 — 제목 편집 저장 / 스크립트 편집 저장 / 재생 중 하이라이트
- [ ] 엣지 케이스 — 공백만 입력 시 원복 / 편집 중 백그라운드 전환 / 편집 중 타 화면 이동
- [ ] UI 변경 스크린샷 또는 GIF 첨부
- [ ] 테스트 추가 — UseCase / Repository observe(id:) 테스트 반영

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [x] 로직·엣지 케이스
- [x] 예외/에러 핸들링
- [x] UI/UX
- [ ] 성능·의존성

**특히 봐줬으면 하는 부분**

- `EditingMode` 단일 옵셔널로 합친 결정이 적절한지 (향후 "제목+스크립트 동시 편집" 요구가 생기면 분리해야 함)
- `doneScriptEditing`에서 `TranscriptSegment(duration: 0)`으로 재생성되는 부분 — 원본 duration 손실이 섹션 그룹핑에 영향을 줄 수 있음. 별도 이슈로 분리 여부 논의 필요
- `updatePlayingParagraph`에서 `paragraphIndex: 0` 하드코딩 — 현재 섹션당 단일 문단 구조라 실질 영향 없지만 의미상 부정확

---

## 📚 참고

- iOS 18 Observation (`withObservationTracking`, `reconfigureItems`)
- UIKit `@Observable` 모델 바인딩 패턴

---

## 🗺 편집 상태 흐름

```mermaid
stateDiagram-v2
    [*] --> Idle: editingMode = nil
    Idle --> TitleEditing: titleLabel 탭
    Idle --> ScriptEditing: 메뉴 "편집하기"
    TitleEditing --> Idle: 완료 · Return · 탭아웃
    ScriptEditing --> Idle: 완료 버튼
    TitleEditing --> Idle: 공백/미변경 → 원복
```

## 🗺 분석 파이프라인

```mermaid
flowchart LR
    P[.pending] --> A[.analyzing]
    A -->|전사 성공| T[.transcribed]
    A -->|전사 실패| F[.failed]
    T --> A2[.analyzing]
    A2 -->|요약 성공| C[.completed]
    A2 -->|요약 실패| T2[스크립트 유지]
```
