### PR TITLE
상세폴더 UX, TextField 리펙토링합니다.

### DIFF
--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -107,7 +107,7 @@ public final class AppDIContainer {
         )
     }
 
-    public func makeMoveFolderListViewModel(receive: Receive, dismiss: (() -> Void)? = nil) -> MoveFolderListViewModel {
+    public func makeMoveFolderListViewModel(receive: Receive, dismiss: ((String) -> Void)? = nil) -> MoveFolderListViewModel {
         return MoveFolderListViewModel(
             receive: receive,
             folderUseCase: folderUseCase,

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -107,7 +107,10 @@ public final class AppDIContainer {
         )
     }
 
-    public func makeMoveFolderListViewModel(receive: Receive, dismiss: ((String) -> Void)? = nil) -> MoveFolderListViewModel {
+    public func makeMoveFolderListViewModel(
+        receive: Receive,
+        dismiss: ((String) -> Void)? = nil
+    ) -> MoveFolderListViewModel {
         return MoveFolderListViewModel(
             receive: receive,
             folderUseCase: folderUseCase,

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -162,7 +162,7 @@ extension MainCoordinator: BaseCoordinatorDelegate {
     }
 
     // TODO: Present 폴더 이동 시트 ( 사용 화면 - 음성 노트, 개인 폴더 )
-    func presentFolderList(with receive: Receive, dismiss: (() -> Void)?) {
+    func presentFolderList(with receive: Receive, dismiss: ((String) -> Void)?) {
         let viewModel = dependencyContainer.makeMoveFolderListViewModel(receive: receive, dismiss: dismiss)
         viewModel.coordinator = self
         let viewController = MoveFolderListViewController(viewModel: viewModel)

--- a/Presentation/Sources/Component/Common/TextFieldView.swift
+++ b/Presentation/Sources/Component/Common/TextFieldView.swift
@@ -4,11 +4,7 @@ final class TextFieldView: UIView {
     // MARK: - Properties
 
     var field: Field
-
-    // 키보드 상태 변화를 알리기 위한 콜백
-    var onEditingDidBegin: (() -> Void)?
-    var onEditingDidEnd: (() -> Void)?
-
+    
     // MARK: - Componenet
 
     private let container: UIStackView = {
@@ -43,9 +39,6 @@ final class TextFieldView: UIView {
         tf.layer.cornerRadius = 8
         tf.textColor = .gray950
         tf.font = Typography.body1.font
-        // UITextField는 한 줄 입력 요소이므로 줄간격(paragraphStyle)이나
-        // baselineOffset이 들어가면 자체 수직 정렬(Center Y) 계산과 충돌해 텍스트가 살짝 아래로 처집니다.
-        // 따라서 폰트, 글자색상, 자간(kern)만 명시적으로 넣어줍니다.
         tf.defaultTextAttributes = [
             .font: Typography.body1.font,
             .foregroundColor: UIColor.gray950,
@@ -67,6 +60,16 @@ final class TextFieldView: UIView {
         label.textColor = .gray600
         label.numberOfLines = 0
         return label
+    }()
+    
+    private lazy var textCount: UILabel = {
+        let text = UILabel()
+        text.translatesAutoresizingMaskIntoConstraints = false
+        text.setTypography(text: field.textCountLabel, style: .label)
+        text.textColor = UIColor.gray750
+        text.numberOfLines = 0
+        text.setContentCompressionResistancePriority(.required, for: .vertical)
+        return text
     }()
 
     private let bottomContainer: UIStackView = {
@@ -132,6 +135,8 @@ final class TextFieldView: UIView {
         }
         primaryButton.isEnabled = field.isSubmitEnabled
         updatePlaceholderVisibility()
+        // error Message
+        updateErrorMessageLabel()
     }
 
     // MARK: - Setup
@@ -152,7 +157,9 @@ final class TextFieldView: UIView {
         container.addArrangedSubview(titleLabel)
         container.addArrangedSubview(subTitleLabel)
         container.addArrangedSubview(textField)
-        container.setCustomSpacing(24, after: textField)
+        container.setCustomSpacing(8, after: textField)
+        container.addArrangedSubview(textCount)
+        container.setCustomSpacing(24, after: textCount)
         container.addArrangedSubview(bottomContainer)
         addSubview(container)
         textField.addSubview(placeholderLabel)
@@ -178,15 +185,31 @@ final class TextFieldView: UIView {
         primaryButton.setCapsuleCornerRadius()
         updatePlaceholderVisibility()
     }
-
-    private func updatePlaceholderVisibility() {
-        placeholderLabel.isHidden = !field.text.isEmpty
-    }
-
+    
     @objc
     private func textFieldDidChange() {
         field.text = textField.text ?? ""
+        field.errorMessage = nil
+        textCount.setTypography(text: field.textCountLabel, style: .label)
+        textCount.textColor = field.text.count >= 50 ? .danger : .gray750
         updatePlaceholderVisibility()
+    }
+}
+
+// MARK: - Update Method
+extension TextFieldView {
+    private func updatePlaceholderVisibility() {
+        placeholderLabel.isHidden = !field.text.isEmpty
+    }
+    
+    private func updateErrorMessageLabel() {
+        if let errorMessage = field.errorMessage {
+            textCount.setTypography(text: errorMessage, style: .label)
+            textCount.textColor = .danger
+        } else {
+            textCount.setTypography(text: field.textCountLabel, style: .label)
+            textCount.textColor = field.text.count >= 50 ? .danger : .gray750
+        }
     }
 }
 
@@ -200,21 +223,27 @@ extension TextFieldView {
         var subTitle: String
         var placeHolder: String
         var text: String
-
-        var trimmedText: String {
-            text.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
+        var errorMessage: String?
 
         var isSubmitEnabled: Bool {
-            !trimmedText.isEmpty
+            !text.isEmpty
+        }
+        
+        var textCountLabel: String {
+            "\(text.count)/\(50)"
+        }
+        
+        var textCountOverCheck: Bool {
+            text.count > 50
         }
 
-        init(mode: Mode, title: String, subTitle: String, placeHolder: String, text: String = "") {
+        init(mode: Mode, title: String, subTitle: String, placeHolder: String, text: String = "", errorMessage: String?) {
             self.mode = mode
             self.title = title
             self.subTitle = subTitle
             self.placeHolder = placeHolder
             self.text = text
+            self.errorMessage = errorMessage
         }
     }
 
@@ -232,11 +261,9 @@ extension TextFieldView: UITextFieldDelegate {
         return true
     }
 
-    func textFieldDidBeginEditing(_ textField: UITextField) {
-        onEditingDidBegin?()
-    }
-
-    func textFieldDidEndEditing(_ textField: UITextField) {
-        onEditingDidEnd?()
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let currentText = textField.text as NSString? else { return true }
+        let updatedText = currentText.replacingCharacters(in: range, with: string)
+        return updatedText.count <= 50
     }
 }

--- a/Presentation/Sources/Component/Common/TextFieldView.swift
+++ b/Presentation/Sources/Component/Common/TextFieldView.swift
@@ -4,7 +4,7 @@ final class TextFieldView: UIView {
     // MARK: - Properties
 
     var field: Field
-    
+
     // MARK: - Componenet
 
     private let container: UIStackView = {
@@ -61,7 +61,7 @@ final class TextFieldView: UIView {
         label.numberOfLines = 0
         return label
     }()
-    
+
     private lazy var textCount: UILabel = {
         let text = UILabel()
         text.translatesAutoresizingMaskIntoConstraints = false
@@ -185,7 +185,7 @@ final class TextFieldView: UIView {
         primaryButton.setCapsuleCornerRadius()
         updatePlaceholderVisibility()
     }
-    
+
     @objc
     private func textFieldDidChange() {
         field.text = textField.text ?? ""
@@ -197,11 +197,12 @@ final class TextFieldView: UIView {
 }
 
 // MARK: - Update Method
+
 extension TextFieldView {
     private func updatePlaceholderVisibility() {
         placeholderLabel.isHidden = !field.text.isEmpty
     }
-    
+
     private func updateErrorMessageLabel() {
         if let errorMessage = field.errorMessage {
             textCount.setTypography(text: errorMessage, style: .label)
@@ -228,16 +229,23 @@ extension TextFieldView {
         var isSubmitEnabled: Bool {
             !text.isEmpty
         }
-        
+
         var textCountLabel: String {
             "\(text.count)/\(50)"
         }
-        
+
         var textCountOverCheck: Bool {
             text.count > 50
         }
 
-        init(mode: Mode, title: String, subTitle: String, placeHolder: String, text: String = "", errorMessage: String?) {
+        init(
+            mode: Mode,
+            title: String,
+            subTitle: String,
+            placeHolder: String,
+            text: String = "",
+            errorMessage: String?
+        ) {
             self.mode = mode
             self.title = title
             self.subTitle = subTitle
@@ -261,7 +269,11 @@ extension TextFieldView: UITextFieldDelegate {
         return true
     }
 
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
         guard let currentText = textField.text as NSString? else { return true }
         let updatedText = currentText.replacingCharacters(in: range, with: string)
         return updatedText.count <= 50

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -383,7 +383,6 @@ private extension FolderDetailViewController {
                 print("더 보기 버튼 탭됨")
             case .single, .all:
                 // TODO: 삭제 로직 실행
-                print("삭제 버튼 탭됨")
                 vm.openAlertView()
             }
         }
@@ -398,7 +397,13 @@ private extension FolderDetailViewController {
                 print("검색 버튼 탭됨")
             case .all, .single:
                 // TODO: 이동 로직 실행
-                vm.presentMoveFolder()
+                vm.presentMoveFolder() { [weak self] name in
+                    self?.vm.fetchItems()
+                    self?.chagokBackgroundView.makeToast(
+                        type: .normal,
+                        "`\(name)` 폴더로 이동됐어요."
+                    )
+                }
                 vm.setSelectionMode(.none)
             }
         }

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -397,7 +397,7 @@ private extension FolderDetailViewController {
                 print("검색 버튼 탭됨")
             case .all, .single:
                 // TODO: 이동 로직 실행
-                vm.presentMoveFolder() { [weak self] name in
+                vm.presentMoveFolder { [weak self] name in
                     self?.vm.fetchItems()
                     self?.chagokBackgroundView.makeToast(
                         type: .normal,

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -192,16 +192,15 @@ public final class FolderViewController: CollectionViewController {
             for: .touchUpInside
         )
     }
-
-    
 }
 
 // MARK: - Update Method
+
 extension FolderViewController {
     private func updateErrorMessage() {
         textField.field.errorMessage = vm.errorMessage
     }
-    
+
     private func syncTextFieldField() {
         textField.field.mode = vm.mode
 

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -44,7 +44,8 @@ public final class FolderViewController: CollectionViewController {
             mode: .create,
             title: "새 폴더",
             subTitle: "새로 만들 폴더의 이름을\n입력해주세요.",
-            placeHolder: "폴더 이름을 적어주세요"
+            placeHolder: "폴더 이름을 적어주세요",
+            errorMessage: vm.errorMessage
         ),
         cancelButton: cancelButton,
         primaryButton: primaryButton
@@ -88,8 +89,15 @@ public final class FolderViewController: CollectionViewController {
 
     override public func updateProperties() {
         super.updateProperties()
-        syncTextFieldField()
+        // textField
         textField.isHidden = !vm.showTextField
+        if vm.showTextField {
+            view.bringSubviewToFront(textField)
+        }
+        syncTextFieldField()
+        // error Message
+        updateErrorMessage()
+        // DataSource
         updateDataSource()
     }
 
@@ -107,9 +115,10 @@ public final class FolderViewController: CollectionViewController {
             containerGuide.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             containerGuide.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
             textField.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8),
-            textField.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.35),
+            textField.centerYAnchor.constraint(equalTo: containerGuide.centerYAnchor),
             textField.centerXAnchor.constraint(equalTo: containerGuide.centerXAnchor),
-            textField.centerYAnchor.constraint(equalTo: containerGuide.centerYAnchor)
+            textField.topAnchor.constraint(greaterThanOrEqualTo: containerGuide.topAnchor, constant: 20),
+            textField.bottomAnchor.constraint(lessThanOrEqualTo: containerGuide.bottomAnchor, constant: -20)
         ])
     }
 
@@ -169,8 +178,7 @@ public final class FolderViewController: CollectionViewController {
         primaryButton.addAction(
             UIAction { [weak self] _ in
                 guard let self else { return }
-                let name = textField.field.trimmedText
-                guard !name.isEmpty else { return }
+                let name = textField.field.text
 
                 switch vm.mode {
                 case .create:
@@ -185,6 +193,15 @@ public final class FolderViewController: CollectionViewController {
         )
     }
 
+    
+}
+
+// MARK: - Update Method
+extension FolderViewController {
+    private func updateErrorMessage() {
+        textField.field.errorMessage = vm.errorMessage
+    }
+    
     private func syncTextFieldField() {
         textField.field.mode = vm.mode
 
@@ -193,6 +210,7 @@ public final class FolderViewController: CollectionViewController {
             textField.field.title = "새 폴더"
             textField.field.subTitle = "새로 만들 폴더의 이름을\n입력해주세요."
             textField.field.placeHolder = "폴더 이름을 적어주세요"
+            textField.field.errorMessage = vm.errorMessage
             if !vm.showTextField {
                 textField.field.text = ""
             }
@@ -200,6 +218,7 @@ public final class FolderViewController: CollectionViewController {
             textField.field.title = "폴더 이름 수정"
             textField.field.subTitle = "수정할 폴더의 이름을\n입력해주세요."
             textField.field.placeHolder = "폴더 이름을 적어주세요"
+            textField.field.errorMessage = vm.errorMessage
             textField.field.text = vm.editFolder?.name ?? ""
         }
     }

--- a/Presentation/Sources/ViewModel/CoordinatorDelegate/BaseCoordinatorDelegate.swift
+++ b/Presentation/Sources/ViewModel/CoordinatorDelegate/BaseCoordinatorDelegate.swift
@@ -6,7 +6,7 @@ public protocol BaseCoordinatorDelegate: AnyObject {
     /// 뒤로가기
     func pop()
     /// 폴더 Sheet 열기
-    func presentFolderList(with: Receive, dismiss: (() -> Void)?)
+    func presentFolderList(with: Receive, dismiss: ((String) -> Void)?)
 }
 
 public enum Receive: Hashable {

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -95,11 +95,9 @@ extension FolderDetailViewModel {
     }
 
     /// 폴더 이동 Present
-    func presentMoveFolder() {
+    func presentMoveFolder(dismiss: @escaping (String) -> Void) {
         guard !selectedItems.isEmpty else { return }
-        coordinator?.presentFolderList(with: .multiple(selectedItems), dismiss: { [weak self] in
-            self?.fetchItems()
-        })
+        coordinator?.presentFolderList(with: .multiple(selectedItems), dismiss: dismiss)
     }
 
     /// 전체 선택

--- a/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
@@ -17,6 +17,7 @@ public final class FolderViewModel {
     private(set) var showTextField: Bool = false
     private(set) var editFolder: Folder?
     private(set) var mode: TextFieldView.Mode = .create
+    private(set) var errorMessage: String? = nil
     public weak var coordinator: FolderCoordinatorDelegate?
 
     // MARK: - Dependencies
@@ -45,12 +46,14 @@ extension FolderViewModel {
     }
 
     func openTextField(for folder: Folder? = nil) {
+        errorMessage = nil
         editFolder = folder
         setMode(folder == nil ? .create : .edit)
         showTextField = true
     }
 
     func closeTextField() {
+        errorMessage = nil
         editFolder = nil
         setMode(.create)
         showTextField = false
@@ -80,6 +83,7 @@ extension FolderViewModel {
             closeTextField()
         } catch {
             AppLogger.error(error)
+            errorMessage = error.errorDescription
         }
     }
 
@@ -118,6 +122,7 @@ extension FolderViewModel {
             closeTextField()
         } catch {
             AppLogger.error(error)
+            errorMessage = error.errorDescription
         }
     }
 

--- a/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
@@ -17,7 +17,7 @@ public final class FolderViewModel {
     private(set) var showTextField: Bool = false
     private(set) var editFolder: Folder?
     private(set) var mode: TextFieldView.Mode = .create
-    private(set) var errorMessage: String? = nil
+    private(set) var errorMessage: String?
     public weak var coordinator: FolderCoordinatorDelegate?
 
     // MARK: - Dependencies

--- a/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/MoveFolderListViewModel.swift
@@ -16,13 +16,13 @@ public final class MoveFolderListViewModel {
     private let receive: Receive
     private let folderUseCase: any FolderUseCase
     private let voiceNoteUseCase: any VoiceNoteUseCase
-    private let onDismiss: (() -> Void)?
+    private let onDismiss: ((String) -> Void)?
 
     public init(
         receive: Receive,
         folderUseCase: any FolderUseCase,
         voiceNoteUseCase: any VoiceNoteUseCase,
-        onDismiss: (() -> Void)? = nil
+        onDismiss: ((String) -> Void)? = nil
     ) {
         self.receive = receive
         self.folderUseCase = folderUseCase
@@ -83,7 +83,7 @@ public final class MoveFolderListViewModel {
                     _ = try voiceNoteUseCase.update(voiceNote)
                 }
             }
-            onDismiss?()
+            onDismiss?(selectedFolder.name)
             coordinator?.dismiss()
         } catch {
             AppLogger.error(error)

--- a/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
@@ -18,7 +18,7 @@ final class MockFolderDetailCoordinatorDelegate: FolderDetailCoordinatorDelegate
         pushedVoiceNote = voiceNote
     }
 
-    func presentFolderList(with receive: Receive, dismiss: (() -> Void)?) {
+    func presentFolderList(with receive: Receive, dismiss: ((String) -> Void)?) {
         presentFolderListCalled = true
     }
 }
@@ -97,7 +97,7 @@ final class FolderDetailViewModelTests: XCTestCase {
         let note = VoiceNote.stub(title: "테스트 노트")
 
         sut.viewModel.selectItem(note)
-        sut.viewModel.presentMoveFolder()
+        sut.viewModel.presentMoveFolder { _ in }
 
         XCTAssertTrue(sut.mockCoordinator.presentFolderListCalled)
     }
@@ -105,7 +105,7 @@ final class FolderDetailViewModelTests: XCTestCase {
     func test_presentMoveFolder_버튼탭시_선택항목없으면_무시() {
         let sut = makeSUT()
 
-        sut.viewModel.presentMoveFolder()
+        sut.viewModel.presentMoveFolder { _ in }
 
         XCTAssertFalse(sut.mockCoordinator.presentFolderListCalled)
     }

--- a/Presentation/Tests/Folder/FolderViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderViewModelTests.swift
@@ -16,7 +16,7 @@ final class MockFolderCoordinatorDelegate: FolderCoordinatorDelegate {
         pushedFolder = folder
     }
 
-    func presentFolderList(with receive: Receive, dismiss: (() -> Void)?) {}
+    func presentFolderList(with receive: Receive, dismiss: ((String) -> Void)?) {}
 }
 
 @MainActor

--- a/Presentation/Tests/Mocks/MockBaseCoordinatorDelegate.swift
+++ b/Presentation/Tests/Mocks/MockBaseCoordinatorDelegate.swift
@@ -6,7 +6,7 @@ final class MockBaseCoordinatorDelegate: BaseCoordinatorDelegate {
     var popCalled = false
     var presentFolderListCalled = false
 
-    func presentFolderList(with: Presentation.Receive, dismiss: (() -> Void)?) {
+    func presentFolderList(with: Presentation.Receive, dismiss: ((String) -> Void)?) {
         presentFolderListCalled = true
     }
 


### PR DESCRIPTION
---
## ✨ 작업 요약
- `TextFieldView` 공통 컴포넌트의 기능을 강화하고, 상세 폴더 화면 내 UX를 개선하기 위한 리팩토링을 진행했습니다.

## 📋 구체적인 내용
- **추가/변경된 동작**:
  - **TextFieldView 글자수 제한**: 최대 50자까지 입력 가능하도록 제한하고, 한도 도달 시 빨간색 강조 피드백을 추가했습니다.
  - **에러 메시지 처리 개선**: 에러 메시지가 길어질 경우 글자가 잘리지 않도록 멀티라인(numberOfLines=0)을 지원하고, 우선순위(Compression Resistance)를 조정했습니다.
  - **상태 초기화 로직**: 취소 버튼을 누르거나 재진입 시 이전 입력값과 에러 메시지가 남아있지 않도록 상태 초기화 로직을 구현했습니다.
  - **레이아웃 유연화**: `FolderViewController`에서 고정 높이 대신 컨텐츠 양에 따라 높이가 조절되도록 제약 조건을 개선했습니다.
  - **테스트 코드 안정화**: `BaseCoordinatorDelegate` 프로토콜 변경에 맞춰 관련 Mock 객체와 유닛 테스트 코드를 업데이트했습니다.
- **영향 받는 화면/모듈**:
  - `Presentation` 모듈 내 `TextFieldView`, `FolderViewController`, `FolderViewModel` 및 관련 테스트 클래스

---

## 🧩 설계·구현 노트
- **선택한 방식**
  - `UITextFieldDelegate`를 활용하여 원천적으로 글자수 초과를 방지함으로써 데이터 정합성을 높였습니다.
  - `Field` 모델과 `UpdateProperties` 패턴을 사용하여 단방향 데이터 흐름에 가깝게 UI가 갱신되도록 리팩토링했습니다.
  - `UIStackView` 내부 레이아웃 우선순위 조정을 통해 유연한 에러 피드백 화면을 구성했습니다.

---

## ✅ 확인 사항
- [x] 50자 제한 및 색상 변경 피드백 확인
- [x] 에러 메시지 멀티라인 노출 확인
- [x] 취소/재진입 시 데이터 초기화 확인
- [x] 프로토콜 변경에 따른 테스트 코드 컴파일 오류 해결

---

## 👀 리뷰 포인트
- `TextFieldView`의 `updateErrorMessageLabel` 로직이 에러 여부에 따라 올바르게 라벨을 전환하는지 확인 부탁드립니다.
- `FolderViewController`에서 `TextFieldView` 노출 시 `bringSubviewToFront`를 통한 인터랙션 처리가 적절한지 봐주시면 감사하겠습니다.

---

## 📚 참고