### PR TITLE
폴더 상세 버그 수정, 언어 선택 Menu 기능 구현

### DIFF
--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -80,7 +80,8 @@ public final class AppDIContainer {
             microphoneRepository: voiceRecordRepository,
             voiceNoteUseCase: voiceNoteUseCase,
             folderUseCase: folderUseCase,
-            wasteBasketRepository: wasteBasketRepository
+            wasteBasketRepository: wasteBasketRepository,
+            languageRepository: languageRepository
         )
     }
 

--- a/Presentation/Sources/Component/Common/LanguagePicker.swift
+++ b/Presentation/Sources/Component/Common/LanguagePicker.swift
@@ -78,6 +78,11 @@ final class LanguagePicker: UIStackView {
 
     // MARK: - Update Properties
 
+    func setLanguage(_ language: Language) {
+        selectedLanguage = language
+        updateSelectionState()
+    }
+
     private func updateSelectionState() {
         itemViews.forEach { $0.setSelected($0.language == selectedLanguage, showAlert: showAlert) }
     }

--- a/Presentation/Sources/Component/Common/LanguagePicker.swift
+++ b/Presentation/Sources/Component/Common/LanguagePicker.swift
@@ -50,7 +50,11 @@ final class LanguagePicker: UIStackView {
         }
 
         for language in Language.allCases {
-            let itemView = LanguageItemView(language: language, isSelected: language == selectedLanguage, showAlert: showAlert)
+            let itemView = LanguageItemView(
+                language: language,
+                isSelected: language == selectedLanguage,
+                showAlert: showAlert
+            )
             itemView.addGestureRecognizer(
                 UITapGestureRecognizer(target: self, action: #selector(itemTapped(_:)))
             )

--- a/Presentation/Sources/Component/Common/LanguagePicker.swift
+++ b/Presentation/Sources/Component/Common/LanguagePicker.swift
@@ -8,15 +8,17 @@ final class LanguagePicker: UIStackView {
 
     private(set) var selectedLanguage: Language
     var onLanguageChanged: ((Language) -> Void)?
+    var showAlert: Bool
 
     private var itemViews: [LanguageItemView] = []
 
     // MARK: - LifeCycle
 
-    init(selected: Language) {
+    init(selected: Language, axis: NSLayoutConstraint.Axis = .vertical, showAlert: Bool = false) {
         selectedLanguage = selected
+        self.showAlert = showAlert
         super.init(frame: .zero)
-        setup()
+        setup(axis: axis)
         createItems()
     }
 
@@ -27,9 +29,9 @@ final class LanguagePicker: UIStackView {
 
     // MARK: - Set up
 
-    private func setup() {
-        axis = .vertical
-        spacing = Constant.languagePickerSpacing
+    private func setup(axis: NSLayoutConstraint.Axis) {
+        self.axis = axis
+        spacing = axis == .horizontal ? 12 : Constant.languagePickerSpacing
         alignment = .fill
         distribution = .fill
         translatesAutoresizingMaskIntoConstraints = false
@@ -38,13 +40,27 @@ final class LanguagePicker: UIStackView {
     // MARK: - Helper
 
     private func createItems() {
+        let leftSpacer = UIView()
+        let rightSpacer = UIView()
+
+        if axis == .horizontal {
+            leftSpacer.translatesAutoresizingMaskIntoConstraints = false
+            rightSpacer.translatesAutoresizingMaskIntoConstraints = false
+            addArrangedSubview(leftSpacer)
+        }
+
         for language in Language.allCases {
-            let itemView = LanguageItemView(language: language, isSelected: language == selectedLanguage)
+            let itemView = LanguageItemView(language: language, isSelected: language == selectedLanguage, showAlert: showAlert)
             itemView.addGestureRecognizer(
                 UITapGestureRecognizer(target: self, action: #selector(itemTapped(_:)))
             )
             addArrangedSubview(itemView)
             itemViews.append(itemView)
+        }
+
+        if axis == .horizontal {
+            addArrangedSubview(rightSpacer)
+            leftSpacer.widthAnchor.constraint(equalTo: rightSpacer.widthAnchor).isActive = true
         }
     }
 
@@ -63,7 +79,7 @@ final class LanguagePicker: UIStackView {
     // MARK: - Update Properties
 
     private func updateSelectionState() {
-        itemViews.forEach { $0.setSelected($0.language == selectedLanguage) }
+        itemViews.forEach { $0.setSelected($0.language == selectedLanguage, showAlert: showAlert) }
     }
 }
 
@@ -102,18 +118,18 @@ private final class LanguageItemView: UIView {
 
     // MARK: - LifeCycle
 
-    init(language: Language, isSelected: Bool) {
+    init(language: Language, isSelected: Bool, showAlert: Bool) {
         self.language = language
         self.isSelected = isSelected
         super.init(frame: .zero)
         setUp()
         setupConstraints()
-        setSelected(isSelected)
+        setSelected(isSelected, showAlert: showAlert)
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        nil
     }
 
     // MARK: - Constraints
@@ -148,19 +164,19 @@ private final class LanguageItemView: UIView {
 
     // MARK: - Update Properties
 
-    private func languageText() -> String {
+    private func languageText(showAlert: Bool = false) -> String {
         switch language {
         case .ko:
-            return "한국어 (기본설정)"
+            return "한국어\(showAlert ? "" : " (기본설정)")"
         case .en:
             return "영어"
         }
     }
 
-    func setSelected(_ selected: Bool) {
+    func setSelected(_ selected: Bool, showAlert: Bool) {
         isSelected = selected
         innerIndicatorView.backgroundColor = selected ? .point600 : .gray900
         titleLabel.textColor = selected ? .gray900 : .gray750
-        titleLabel.setTypography(text: languageText(), style: .subtitle1)
+        titleLabel.setTypography(text: languageText(showAlert: showAlert), style: .subtitle1)
     }
 }

--- a/Presentation/Sources/Component/Common/LanguagePickertAlert.swift
+++ b/Presentation/Sources/Component/Common/LanguagePickertAlert.swift
@@ -1,0 +1,154 @@
+import UIKit
+
+final class LanguagePickertAlert: UIView {
+    let closeButton: GlassButton
+    let primaryButton: GlassButton
+    private let title: String
+    private var widthConstraint: NSLayoutConstraint?
+
+    private let topContent: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.spacing = 24
+        view.distribution = .fill
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let bottomContent: UIStackView = {
+        let view = UIStackView()
+        view.axis = .horizontal
+        view.distribution = .fill
+        view.spacing = Constant.alertSpacing
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private lazy var header: UILabel = {
+        let t = UILabel()
+        t.translatesAutoresizingMaskIntoConstraints = false
+        t.setTypography(text: title, style: .title2)
+        t.textAlignment = .center
+        t.textColor = UIColor.gray950
+        t.numberOfLines = 0
+        return t
+    }()
+    
+    private let languagePicker: LanguagePicker
+
+    init(
+        title: String,
+        languagePicker: LanguagePicker,
+        closeButton: GlassButton,
+        primaryButton: GlassButton,
+        frame: CGRect = .zero
+    ) {
+        self.title = title
+        self.closeButton = closeButton
+        self.languagePicker = languagePicker
+        self.primaryButton = primaryButton
+        super.init(frame: frame)
+        setup()
+        setupButton()
+        childSetup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+}
+
+// MARK: - LifeCycle
+
+extension LanguagePickertAlert {
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        guard let superview else {
+            widthConstraint?.isActive = false
+            widthConstraint = nil
+            return
+        }
+        guard widthConstraint == nil else { return }
+        let width = widthAnchor.constraint(equalTo: superview.widthAnchor, multiplier: Constant.alertMultiplierWidth)
+        width.isActive = true
+        widthConstraint = width
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.cornerRadius = Constant.cornerRadius
+
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = Constant.shadowOpacity
+        layer.shadowOffset = CGSize(width: Constant.shadowOffsetWidth, height: Constant.shadowOffsetHeight)
+        layer.shadowRadius = Constant.cornerRadius
+        layer.shadowPath =
+            UIBezierPath(
+                roundedRect: bounds,
+                cornerRadius: Constant.cornerRadius
+            ).cgPath
+    }
+}
+
+// MARK: - setUp
+
+extension LanguagePickertAlert {
+    /// LanguagePickertAlert의 전체 배경색, 테두리(border), 모서리 등 가장 기초적인 View 스타일을 설정합니다.
+    private func setup() {
+        translatesAutoresizingMaskIntoConstraints = false
+        backgroundColor = .point200.withAlphaComponent(Constant.backgroundOpacity)
+        layer.borderWidth = Constant.borderWidth
+        layer.borderColor = UIColor.gray600.cgColor
+    }
+
+    /// LanguagePickertAlert에 맞게 외부 설정 값 상관 없이 내부에서 일관된 디자인을  처리합니다.
+    private func setupButton() {
+        // close
+        closeButton.setShadow(false)
+        closeButton.setCapsuleCornerRadius()
+        // primary
+        primaryButton.setShadow(false)
+        primaryButton.setCapsuleCornerRadius()
+    }
+
+    /// LanguagePickertAlert 내부의 컴포넌트들(제목, 언어 설정, 버튼 등)을 StackView에 배치하고
+    /// 오토레이아웃 제약 조건을 설정합니다.
+    private func childSetup() {
+        topContent.addArrangedSubview(header)
+        topContent.addArrangedSubview(languagePicker)
+        bottomContent.addArrangedSubview(closeButton)
+        bottomContent.addArrangedSubview(primaryButton)
+        addSubview(topContent)
+        addSubview(bottomContent)
+
+        NSLayoutConstraint.activate([
+            topContent.topAnchor.constraint(equalTo: topAnchor, constant: Constant.alertTopAndBottomValueForTopContent),
+            topContent.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: Constant.alertLeftAndRightValueForTopContent
+            ),
+            topContent.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -Constant.alertLeftAndRightValueForTopContent
+            ),
+            topContent.bottomAnchor.constraint(
+                equalTo: bottomContent.topAnchor,
+                constant: -Constant.alertTopAndBottomContentSpacing
+            ),
+            bottomContent.heightAnchor.constraint(equalToConstant: Constant.alertBottomContentHeight),
+            bottomContent.bottomAnchor.constraint(
+                equalTo: bottomAnchor,
+                constant: -Constant.alertTopAndBottomValueForTopContent
+            ),
+            bottomContent.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: Constant.alertLeftAndRightValueForBottomContent
+            ),
+            bottomContent.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -Constant.alertLeftAndRightValueForBottomContent
+            )
+        ])
+    }
+}

--- a/Presentation/Sources/Component/Common/LanguagePickertAlert.swift
+++ b/Presentation/Sources/Component/Common/LanguagePickertAlert.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class LanguagePickertAlert: UIView {
+final class LanguagePickerAlert: UIView {
     let closeButton: GlassButton
     let primaryButton: GlassButton
     private let title: String
@@ -61,7 +61,7 @@ final class LanguagePickertAlert: UIView {
 
 // MARK: - LifeCycle
 
-extension LanguagePickertAlert {
+extension LanguagePickerAlert {
     override func didMoveToSuperview() {
         super.didMoveToSuperview()
         guard let superview else {
@@ -93,7 +93,7 @@ extension LanguagePickertAlert {
 
 // MARK: - setUp
 
-extension LanguagePickertAlert {
+extension LanguagePickerAlert {
     /// LanguagePickertAlert의 전체 배경색, 테두리(border), 모서리 등 가장 기초적인 View 스타일을 설정합니다.
     private func setup() {
         translatesAutoresizingMaskIntoConstraints = false

--- a/Presentation/Sources/Component/Common/LanguagePickertAlert.swift
+++ b/Presentation/Sources/Component/Common/LanguagePickertAlert.swift
@@ -33,7 +33,7 @@ final class LanguagePickertAlert: UIView {
         t.numberOfLines = 0
         return t
     }()
-    
+
     private let languagePicker: LanguagePicker
 
     init(

--- a/Presentation/Sources/Component/Common/NavigationItemButton.swift
+++ b/Presentation/Sources/Component/Common/NavigationItemButton.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 final class NavigationItemButton: UIButton {
-
     typealias Attribute = [NSAttributedString.Key: Any]
 
     // MARK: - State
@@ -40,14 +39,15 @@ final class NavigationItemButton: UIButton {
         var config = UIButton.Configuration.plain()
         config.contentInsets = .zero
         config.automaticallyUpdateForSelection = false
-        self.configuration = config
+        configuration = config
 
-        self.configurationUpdateHandler = { [weak self] button in
+        configurationUpdateHandler = { [weak self] button in
             guard let self, var config = button.configuration else { return }
             let symbolConfig = UIImage.SymbolConfiguration(weight: .bold)
 
             if button.isSelected {
-                config.image = selectedItem.imageName.flatMap { UIImage(systemName: $0)?.withConfiguration(symbolConfig) }
+                config.image = selectedItem.imageName
+                    .flatMap { UIImage(systemName: $0)?.withConfiguration(symbolConfig) }
                 config.title = selectedItem.title
                 config.baseForegroundColor = selectedForegroundColor
             } else {

--- a/Presentation/Sources/Component/Common/NavigationItemButton.swift
+++ b/Presentation/Sources/Component/Common/NavigationItemButton.swift
@@ -1,0 +1,85 @@
+import UIKit
+
+final class NavigationItemButton: UIButton {
+
+    typealias Attribute = [NSAttributedString.Key: Any]
+
+    // MARK: - State
+
+    private let normalItem: Item
+    private let selectedItem: Item
+    private let attributedString: Attribute
+    private let normalForegroundColor: UIColor
+    private let selectedForegroundColor: UIColor
+
+    // MARK: - Initialize
+
+    init(
+        normalItem: Item,
+        selectedItem: Item,
+        attributedString: Attribute,
+        normalForegroundColor: UIColor = .gray950,
+        selectedForegroundColor: UIColor = .gray950,
+        frame: CGRect = .zero
+    ) {
+        self.normalItem = normalItem
+        self.selectedItem = selectedItem
+        self.attributedString = attributedString
+        self.normalForegroundColor = normalForegroundColor
+        self.selectedForegroundColor = selectedForegroundColor
+        super.init(frame: .zero)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    private func setup() {
+        var config = UIButton.Configuration.plain()
+        config.contentInsets = .zero
+        config.automaticallyUpdateForSelection = false
+        self.configuration = config
+
+        self.configurationUpdateHandler = { [weak self] button in
+            guard let self, var config = button.configuration else { return }
+            let symbolConfig = UIImage.SymbolConfiguration(weight: .bold)
+
+            if button.isSelected {
+                config.image = selectedItem.imageName.flatMap { UIImage(systemName: $0)?.withConfiguration(symbolConfig) }
+                config.title = selectedItem.title
+                config.baseForegroundColor = selectedForegroundColor
+            } else {
+                config.image = normalItem.imageName.flatMap { UIImage(systemName: $0)?.withConfiguration(symbolConfig) }
+                config.title = normalItem.title
+                config.baseForegroundColor = normalForegroundColor
+            }
+
+            if let title = config.title {
+                config.attributedTitle = AttributedString(
+                    title,
+                    attributes: AttributeContainer(attributedString)
+                )
+            } else {
+                config.attributedTitle = nil
+            }
+            config.background.backgroundColor = .clear
+            button.configuration = config
+        }
+    }
+}
+
+// MARK: - Data 구조
+
+extension NavigationItemButton {
+    struct Item {
+        let title: String?
+        let imageName: String?
+
+        init(title: String? = nil, imageName: String? = nil) {
+            self.title = title
+            self.imageName = imageName
+        }
+    }
+}

--- a/Presentation/Sources/DesignSystem/UIViewController+Extension.swift
+++ b/Presentation/Sources/DesignSystem/UIViewController+Extension.swift
@@ -10,6 +10,22 @@ public class ViewController: UIViewController {
     }
 }
 
+public extension UIViewController {
+    func updateNavigationBarAppearance(isTransparent: Bool) {
+        let appearance = UINavigationBarAppearance()
+        if isTransparent {
+            appearance.configureWithTransparentBackground()
+        } else {
+            appearance.configureWithDefaultBackground()
+            appearance.backgroundColor = UIColor.gray50
+        }
+
+        navigationItem.standardAppearance = appearance
+        navigationItem.compactAppearance = appearance
+        navigationItem.scrollEdgeAppearance = appearance
+    }
+}
+
 // MARK: UICollectionViewController
 
 public class CollectionViewController: UICollectionViewController {

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -111,12 +111,15 @@ public final class FolderDetailViewController: CollectionViewController {
             listConfiguration.headerMode = .none
             listConfiguration.showsSeparators = false
             listConfiguration.backgroundColor = .clear
-
-            return NSCollectionLayoutSection.list(
+            let section = NSCollectionLayoutSection.list(
                 using: listConfiguration,
                 layoutEnvironment: layoutEnvironment
             )
+            section.contentInsets = .init(top: 12, leading: 20, bottom: 20, trailing: 20)
+            section.interGroupSpacing = 8
+            return section
         }
+
         super.init(collectionViewLayout: layout)
     }
 
@@ -238,6 +241,7 @@ public final class FolderDetailViewController: CollectionViewController {
                         totalCount: folder.content.count
                     )
                 }
+                .margins(.all, 0)
             case .voiceNote(let voiceNote):
                 cell.contentConfiguration = UIHostingConfiguration {
                     VoiceNoteCardView(
@@ -254,6 +258,7 @@ public final class FolderDetailViewController: CollectionViewController {
                         self?.vm.pushVoiceNote(voiceNote: voiceNote)
                     }
                 }
+                .margins(.all, 0)
             }
         }
 

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -14,50 +14,24 @@ public final class FolderDetailViewController: CollectionViewController {
 
     // MARK: - Component
 
-    private lazy var backButton: UIButton = {
-        let btn = UIButton(type: .custom) // .system 대신 .custom을 사용하여 기본 배경 효과 제거
-        let symbolConfig = UIImage.SymbolConfiguration(weight: .bold)
-        let backImage = UIImage(systemName: "chevron.left")?
-            .withConfiguration(symbolConfig)
-        btn.setImage(backImage, for: .normal)
-        btn.setImage(
-            UIImage(systemName: "xmark")?.withConfiguration(symbolConfig),
-            for: .selected
-        )
-        btn.setTitle(vm.title, for: .normal)
-        btn.setTitle("", for: .selected) // nil 대신 ""을 사용하여 .normal 타이틀이 나오는 것을 방지
-        btn.titleLabel?.setTypography(style: .title1)
-        btn.tintColor = UIColor.gray950
-        return btn
-    }()
+    private lazy var backButton: NavigationItemButton = .init(
+        normalItem: .init(title: vm.title, imageName: "chevron.left"),
+        selectedItem: .init(title: "", imageName: "xmark"),
+        attributedString: Typography.title1.textAttributes
+    )
 
-    private lazy var moreAndActionButton: UIButton = {
-        let btn = UIButton(type: .custom)
-        let symbolConfig = UIImage.SymbolConfiguration(weight: .bold)
-        btn.setImage(UIImage(systemName: "ellipsis")?.withConfiguration(symbolConfig), for: .normal)
-        btn.setImage(UIImage(), for: .selected)
-        btn.setTitle(nil, for: .normal)
-        btn.setTitle("삭제", for: .selected)
-        btn.setTitleColor(UIColor.gray950, for: .normal)
-        btn.setTitleColor(UIColor.danger, for: .selected)
-        btn.titleLabel?.setTypography(style: .title1)
-        btn.tintColor = UIColor.gray950
-        return btn
-    }()
+    private lazy var moreAndActionButton: NavigationItemButton = .init(
+        normalItem: .init(imageName: "ellipsis"),
+        selectedItem: .init(title: "삭제"),
+        attributedString: Typography.title1.textAttributes,
+        selectedForegroundColor: .danger
+    )
 
-    private lazy var searchAndMoveButton: UIButton = {
-        let btn = UIButton(type: .custom)
-        let symbolConfig = UIImage.SymbolConfiguration(weight: .bold)
-        btn.setImage(UIImage(systemName: "magnifyingglass")?.withConfiguration(symbolConfig), for: .normal)
-        btn.setImage(UIImage(), for: .selected)
-        btn.setTitle(nil, for: .normal)
-        btn.setTitle("이동", for: .selected)
-        btn.setTitleColor(UIColor.gray950, for: .normal)
-        btn.setTitleColor(UIColor.gray950, for: .selected)
-        btn.titleLabel?.setTypography(style: .title1)
-        btn.tintColor = UIColor.gray950
-        return btn
-    }()
+    private lazy var searchAndMoveButton: NavigationItemButton = .init(
+        normalItem: .init(imageName: "magnifyingglass"),
+        selectedItem: .init(title: "이동"),
+        attributedString: Typography.title1.textAttributes
+    )
 
     private lazy var createdAtAction = UIAction(
         title: "생성일 순"
@@ -136,6 +110,7 @@ public final class FolderDetailViewController: CollectionViewController {
         setupRemoveAlert()
         setupDataSource()
         updateDataSource()
+        updateNavigationBarAppearance(isTransparent: vm.showAlert)
     }
 
     override public func viewWillAppear(_ animated: Bool) {
@@ -330,7 +305,6 @@ extension FolderDetailViewController {
         let isEditMode = (select != .none)
         for item in [backButton, moreAndActionButton, searchAndMoveButton] {
             item.isSelected = isEditMode
-            item.invalidateIntrinsicContentSize()
             item.sizeToFit()
         }
         moreAndActionButton.showsMenuAsPrimaryAction = !isEditMode
@@ -353,6 +327,7 @@ extension FolderDetailViewController {
         if shouldShowAlert {
             view.bringSubviewToFront(removeAlertOverlayView)
         }
+        updateNavigationBarAppearance(isTransparent: shouldShowAlert)
     }
 }
 

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -16,25 +16,17 @@ public final class FolderViewController: CollectionViewController {
 
     // MARK: - Component
 
-    private lazy var backButton: UIButton = {
-        let btn = UIButton(type: .system)
-        let backImage = UIImage(systemName: "chevron.left")?
-            .withConfiguration(UIImage.SymbolConfiguration(weight: .bold))
-        btn.setImage(backImage, for: .normal)
-        btn.setTitle(" \(vm.category.title)", for: .normal)
-        btn.titleLabel?.setTypography(style: .title1)
-        btn.tintColor = UIColor.gray950
-        return btn
-    }()
+    private lazy var backButton: NavigationItemButton = .init(
+        normalItem: .init(title: " \(vm.category.title)", imageName: "chevron.left"),
+        selectedItem: .init(title: " \(vm.category.title)", imageName: "chevron.left"),
+        attributedString: Typography.title1.textAttributes
+    )
 
-    private lazy var addButton: UIButton = {
-        let btn = UIButton(type: .system)
-        let addImage = UIImage(systemName: "folder.badge.plus")?
-            .withConfiguration(UIImage.SymbolConfiguration(weight: .bold))
-        btn.setImage(addImage, for: .normal)
-        btn.tintColor = UIColor.gray950
-        return btn
-    }()
+    private lazy var addButton: NavigationItemButton = .init(
+        normalItem: .init(imageName: "folder.badge.plus"),
+        selectedItem: .init(imageName: "folder.badge.plus"),
+        attributedString: Typography.title1.textAttributes
+    )
 
     private var cancelButton: GlassButton = .close("취소")
     private var primaryButton: GlassButton = .primary("만들기")
@@ -89,6 +81,8 @@ public final class FolderViewController: CollectionViewController {
 
     override public func updateProperties() {
         super.updateProperties()
+        // Navigation
+        updateNavigationBarAppearance(isTransparent: vm.showTextField)
         // textField
         textField.isHidden = !vm.showTextField
         if vm.showTextField {

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -47,7 +47,7 @@ public final class MainViewController: ViewController {
     }()
 
     private lazy var langAction: UIAction = UIAction(title: "녹음 언어 선택") { [weak self] _ in
-        
+        self?.vm.openLanguageAlert()
     }
     
     private lazy var termsofServiceAction: UIAction = UIAction(title: "약관 보기") { [weak self] _ in
@@ -64,8 +64,32 @@ public final class MainViewController: ViewController {
         menu: UIMenu(title: "", children: [langAction, termsofServiceAction])
     )
     
-    private let cancelAlertButton: GlassButton = .close("나중에")
-    private let primaryAlertButton: GlassButton = .primary("설정으로 이동")
+    // TODO: Language Picker Alert
+    private let cancelLanguageAlertButton: GlassButton = .close("취소")
+    private let primaryLanguageAlertButton: GlassButton = .primary("저장하기")
+    private let languageAlertOverlayView: UIView = {
+        let overlay = UIView()
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        overlay.isHidden = true
+        return overlay
+    }()
+    
+    private lazy var languagePicker: LanguagePicker = .init(
+        selected: vm.checkLanguage(),
+        axis: .horizontal,
+        showAlert: true
+    )
+    
+    private lazy var languageAlertView: LanguagePickertAlert = .init(
+        title: "언어 선택",
+        languagePicker: languagePicker,
+        closeButton: cancelLanguageAlertButton,
+        primaryButton: primaryLanguageAlertButton
+    )
+    // TODO: Permission Alert
+    private let cancelPermissionAlertButton: GlassButton = .close("나중에")
+    private let primaryPermissionAlertButton: GlassButton = .primary("설정으로 이동")
     private let permissionAlertOverlayView: UIView = {
         let overlay = UIView()
         overlay.translatesAutoresizingMaskIntoConstraints = false
@@ -77,8 +101,8 @@ public final class MainViewController: ViewController {
     private lazy var permissionAlertView: AlertView = .init(
         title: "마이크 권한이 필요해요",
         subTitle: "설정에서 마이크 권한을 \n허용해주세요.",
-        closeButton: cancelAlertButton,
-        primaryButton: primaryAlertButton
+        closeButton: cancelPermissionAlertButton,
+        primaryButton: primaryPermissionAlertButton
     )
 
     private let floatingButton: GlassButton = .floating(
@@ -95,6 +119,7 @@ public final class MainViewController: ViewController {
         setupCollectionView()
         setupfloatingButton()
         setupPermissionAlert()
+        setupLanguageAlert()
     }
 
     override public func viewWillAppear(_ animated: Bool) {
@@ -107,11 +132,16 @@ public final class MainViewController: ViewController {
 
     override public func updateProperties() {
         super.updateProperties()
+        let shouldshowLanguageAlert = vm.showLanguageAlert
         let shouldshowPermissionAlert = vm.showPermissionAlert
+        languageAlertOverlayView.isHidden = !shouldshowLanguageAlert
         permissionAlertOverlayView.isHidden = !shouldshowPermissionAlert
-        updateInteractionForAlert(isPresented: shouldshowPermissionAlert)
+        updateInteractionForAlert(isPresented: shouldshowPermissionAlert || shouldshowLanguageAlert)
         if shouldshowPermissionAlert {
             view.bringSubviewToFront(permissionAlertOverlayView)
+        }
+        if shouldshowLanguageAlert {
+            view.bringSubviewToFront(languageAlertOverlayView)
         }
         updateDataSource()
     }
@@ -120,19 +150,19 @@ public final class MainViewController: ViewController {
 
     private func setup() {
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: navTitle)
-        navigationItem.rightBarButtonItems = [searchItem, settingItem]
+        navigationItem.rightBarButtonItems = [settingItem, searchItem]
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
         navigationItem.rightBarButtonItem?.hidesSharedBackground = true
     }
 
     private func setupPermissionAlert() {
-        cancelAlertButton.addAction(UIAction { [weak self] _ in
-            self?.vm.closeAlertView()
+        cancelPermissionAlertButton.addAction(UIAction { [weak self] _ in
+            self?.vm.closePermissionAlert()
         }, for: .touchUpInside)
 
-        primaryAlertButton.addAction(UIAction { [weak self] _ in
+        primaryPermissionAlertButton.addAction(UIAction { [weak self] _ in
             guard let self else { return }
-            vm.closeAlertView()
+            vm.closePermissionAlert()
             openAppSettings()
         }, for: .touchUpInside)
 
@@ -145,6 +175,31 @@ public final class MainViewController: ViewController {
             permissionAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             permissionAlertView.centerXAnchor.constraint(equalTo: permissionAlertOverlayView.centerXAnchor),
             permissionAlertView.centerYAnchor.constraint(equalTo: permissionAlertOverlayView.centerYAnchor)
+        ])
+    }
+    
+    private func setupLanguageAlert() {
+        cancelLanguageAlertButton.addAction(UIAction { [weak self] _ in
+            self?.vm.closeLanguageAlert()
+        }, for: .touchUpInside)
+
+        primaryLanguageAlertButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            languagePicker.onLanguageChanged = { [weak self] lang in
+                self?.vm.saveLanguage(lang)
+            }
+            vm.closeLanguageAlert()
+        }, for: .touchUpInside)
+
+        view.addSubview(languageAlertOverlayView)
+        languageAlertOverlayView.addSubview(languageAlertView)
+        NSLayoutConstraint.activate([
+            languageAlertOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
+            languageAlertOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            languageAlertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            languageAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            languageAlertView.centerXAnchor.constraint(equalTo: languageAlertOverlayView.centerXAnchor),
+            languageAlertView.centerYAnchor.constraint(equalTo: languageAlertOverlayView.centerYAnchor)
         ])
     }
 

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -49,21 +49,20 @@ public final class MainViewController: ViewController {
     private lazy var langAction: UIAction = UIAction(title: "녹음 언어 선택") { [weak self] _ in
         self?.vm.openLanguageAlert()
     }
-    
+
     private lazy var termsofServiceAction: UIAction = UIAction(title: "약관 보기") { [weak self] _ in
-        
     }
-    
+
     private let searchItem: UIBarButtonItem = .init(
         image: UIImage(systemName: "magnifyingglass"),
         menu: nil
     )
-    
+
     private lazy var settingItem: UIBarButtonItem = .init(
         image: UIImage(systemName: "gearshape"),
         menu: UIMenu(title: "", children: [langAction, termsofServiceAction])
     )
-    
+
     // TODO: Language Picker Alert
     private let cancelLanguageAlertButton: GlassButton = .close("취소")
     private let primaryLanguageAlertButton: GlassButton = .primary("저장하기")
@@ -74,13 +73,13 @@ public final class MainViewController: ViewController {
         overlay.isHidden = true
         return overlay
     }()
-    
+
     private lazy var languagePicker: LanguagePicker = .init(
         selected: vm.checkLanguage(),
         axis: .horizontal,
         showAlert: true
     )
-    
+
     private lazy var languageAlertView: LanguagePickertAlert = .init(
         title: "언어 선택",
         languagePicker: languagePicker,
@@ -182,7 +181,7 @@ public final class MainViewController: ViewController {
             permissionAlertView.centerYAnchor.constraint(equalTo: permissionAlertOverlayView.centerYAnchor)
         ])
     }
-    
+
     private func setupLanguageAlert() {
         cancelLanguageAlertButton.addAction(UIAction { [weak self] _ in
             self?.vm.closeLanguageAlert()

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -80,7 +80,7 @@ public final class MainViewController: ViewController {
         showAlert: true
     )
 
-    private lazy var languageAlertView: LanguagePickertAlert = .init(
+    private lazy var languageAlertView: LanguagePickerAlert = .init(
         title: "언어 선택",
         languagePicker: languagePicker,
         closeButton: cancelLanguageAlertButton,

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -141,6 +141,7 @@ public final class MainViewController: ViewController {
             view.bringSubviewToFront(permissionAlertOverlayView)
         }
         if shouldshowLanguageAlert {
+            languagePicker.setLanguage(vm.checkLanguage())
             view.bringSubviewToFront(languageAlertOverlayView)
         }
         updateDataSource()
@@ -185,9 +186,7 @@ public final class MainViewController: ViewController {
 
         primaryLanguageAlertButton.addAction(UIAction { [weak self] _ in
             guard let self else { return }
-            languagePicker.onLanguageChanged = { [weak self] lang in
-                self?.vm.saveLanguage(lang)
-            }
+            vm.saveLanguage(languagePicker.selectedLanguage)
             vm.closeLanguageAlert()
         }, for: .touchUpInside)
 

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -144,6 +144,9 @@ public final class MainViewController: ViewController {
             languagePicker.setLanguage(vm.checkLanguage())
             view.bringSubviewToFront(languageAlertOverlayView)
         }
+        updateNavigationBarAppearance(
+            isTransparent: shouldshowLanguageAlert || shouldshowPermissionAlert
+        )
         updateDataSource()
     }
 
@@ -153,7 +156,8 @@ public final class MainViewController: ViewController {
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: navTitle)
         navigationItem.rightBarButtonItems = [settingItem, searchItem]
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
-        navigationItem.rightBarButtonItem?.hidesSharedBackground = true
+        navigationItem.rightBarButtonItems?.forEach { $0.hidesSharedBackground = true
+        }
     }
 
     private func setupPermissionAlert() {

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -46,6 +46,24 @@ public final class MainViewController: ViewController {
         return c
     }()
 
+    private lazy var langAction: UIAction = UIAction(title: "녹음 언어 선택") { [weak self] _ in
+        
+    }
+    
+    private lazy var termsofServiceAction: UIAction = UIAction(title: "약관 보기") { [weak self] _ in
+        
+    }
+    
+    private let searchItem: UIBarButtonItem = .init(
+        image: UIImage(systemName: "magnifyingglass"),
+        menu: nil
+    )
+    
+    private lazy var settingItem: UIBarButtonItem = .init(
+        image: UIImage(systemName: "gearshape"),
+        menu: UIMenu(title: "", children: [langAction, termsofServiceAction])
+    )
+    
     private let cancelAlertButton: GlassButton = .close("나중에")
     private let primaryAlertButton: GlassButton = .primary("설정으로 이동")
     private let permissionAlertOverlayView: UIView = {
@@ -89,10 +107,10 @@ public final class MainViewController: ViewController {
 
     override public func updateProperties() {
         super.updateProperties()
-        let shouldShowAlert = vm.showAlert
-        permissionAlertOverlayView.isHidden = !shouldShowAlert
-        updateInteractionForAlert(isPresented: shouldShowAlert)
-        if shouldShowAlert {
+        let shouldshowPermissionAlert = vm.showPermissionAlert
+        permissionAlertOverlayView.isHidden = !shouldshowPermissionAlert
+        updateInteractionForAlert(isPresented: shouldshowPermissionAlert)
+        if shouldshowPermissionAlert {
             view.bringSubviewToFront(permissionAlertOverlayView)
         }
         updateDataSource()
@@ -102,10 +120,7 @@ public final class MainViewController: ViewController {
 
     private func setup() {
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: navTitle)
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            image: UIImage(systemName: "magnifyingglass"),
-            menu: nil
-        )
+        navigationItem.rightBarButtonItems = [searchItem, settingItem]
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
         navigationItem.rightBarButtonItem?.hidesSharedBackground = true
     }

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -118,6 +118,10 @@ extension FolderDetailViewModel {
     }
 
     func openAlertView() {
+        guard !selectedItems.isEmpty else {
+            setSelectionMode(.none)
+            return
+        }
         showAlert = true
     }
 }

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -44,7 +44,7 @@ public final class MainViewModel {
         categoryData[selectedCategoryIndex].items.isEmpty
     }
 
-    private(set) var showAlert: Bool = false
+    private(set) var showPermissionAlert: Bool = false
 
     private(set) var errorMessage: String?
 
@@ -96,11 +96,11 @@ extension MainViewModel {
     }
 
     func closeAlertView() {
-        showAlert = false
+        showPermissionAlert = false
     }
 
     func openAlertView() {
-        showAlert = true
+        showPermissionAlert = true
     }
 }
 

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -106,11 +106,11 @@ extension MainViewModel {
     func openPermissionAlert() {
         showPermissionAlert = true
     }
-    
+
     func closeLanguageAlert() {
         showLanguageAlert = false
     }
-    
+
     func openLanguageAlert() {
         showLanguageAlert = true
     }
@@ -210,7 +210,7 @@ extension MainViewModel {
     func checkLanguage() -> Language {
         languageRepository.fetchLanguage()
     }
-    
+
     func saveLanguage(_ lang: Language) {
         languageRepository.saveLanguage(lang)
     }
@@ -494,12 +494,12 @@ extension MainViewModel {
             func restore(item: WasteBasketItem) throws(RestoreWasteBasketRepositoryError) {}
             func restoreAll(items: [WasteBasketItem]) throws(RestoreWasteBasketRepositoryError) {}
         }
-        
+
         struct PreviewLanguageRepository: LanguageRepository {
             func fetchLanguage() -> Language {
                 .ko
             }
-            
+
             func saveLanguage(_ language: Language) {
                 AppLogger.info("Language State : \(language)")
             }

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -45,6 +45,7 @@ public final class MainViewModel {
     }
 
     private(set) var showPermissionAlert: Bool = false
+    private(set) var showLanguageAlert: Bool = false
 
     private(set) var errorMessage: String?
 
@@ -54,6 +55,7 @@ public final class MainViewModel {
     let voiceNoteUseCase: any VoiceNoteUseCase
     let folderUseCase: any FolderUseCase
     let wasteBasketRepository: any WasteBasketRepository
+    let languageRepository: any LanguageRepository
 
     // TODO: 화면 전환
     public weak var mainCoordinator: MainCoordinatorDelegate?
@@ -62,12 +64,14 @@ public final class MainViewModel {
         microphoneRepository: any VoiceRecordRepository,
         voiceNoteUseCase: any VoiceNoteUseCase,
         folderUseCase: any FolderUseCase,
-        wasteBasketRepository: any WasteBasketRepository
+        wasteBasketRepository: any WasteBasketRepository,
+        languageRepository: any LanguageRepository
     ) {
         self.microphoneRepository = microphoneRepository
         self.voiceNoteUseCase = voiceNoteUseCase
         self.folderUseCase = folderUseCase
         self.wasteBasketRepository = wasteBasketRepository
+        self.languageRepository = languageRepository
     }
 }
 
@@ -95,12 +99,20 @@ extension MainViewModel {
         self.didScroll = didScroll
     }
 
-    func closeAlertView() {
+    func closePermissionAlert() {
         showPermissionAlert = false
     }
 
-    func openAlertView() {
+    func openPermissionAlert() {
         showPermissionAlert = true
+    }
+    
+    func closeLanguageAlert() {
+        showLanguageAlert = false
+    }
+    
+    func openLanguageAlert() {
+        showLanguageAlert = true
     }
 }
 
@@ -185,10 +197,22 @@ extension MainViewModel {
     func handleRecordButtonTap() {
         let status = microphoneRepository.checkMicrophonePermission()
         if status != .authorized {
-            openAlertView()
+            openPermissionAlert()
         } else {
             presentRecodingView()
         }
+    }
+}
+
+// MARK: - Language Method
+
+extension MainViewModel {
+    func checkLanguage() -> Language {
+        languageRepository.fetchLanguage()
+    }
+    
+    func saveLanguage(_ lang: Language) {
+        languageRepository.saveLanguage(lang)
     }
 }
 
@@ -203,7 +227,8 @@ extension MainViewModel {
                     defaultItems: previewData.defaultVoiceNotes
                 ),
                 folderUseCase: PreviewFolderUseCase(items: previewData.folders),
-                wasteBasketRepository: PreviewWasteBasketRepository(items: previewData.wasteBasketItems)
+                wasteBasketRepository: PreviewWasteBasketRepository(items: previewData.wasteBasketItems),
+                languageRepository: PreviewLanguageRepository()
             )
 
             viewModel.categoryData[0].items = previewData.recentVoiceNotes.map(LibraryItem.voiceNote)
@@ -468,6 +493,16 @@ extension MainViewModel {
             func moveAllToWasteBasket(items: [WasteBasketItem]) throws(MoveWasteBasketRepositoryError) {}
             func restore(item: WasteBasketItem) throws(RestoreWasteBasketRepositoryError) {}
             func restoreAll(items: [WasteBasketItem]) throws(RestoreWasteBasketRepositoryError) {}
+        }
+        
+        struct PreviewLanguageRepository: LanguageRepository {
+            func fetchLanguage() -> Language {
+                .ko
+            }
+            
+            func saveLanguage(_ language: Language) {
+                AppLogger.info("Language State : \(language)")
+            }
         }
     }
 #endif

--- a/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
@@ -112,12 +112,30 @@ final class FolderDetailViewModelTests: XCTestCase {
 
     func test_AlertView_상태변경() {
         let sut = makeSUT()
+        let note = VoiceNote.stub(title: "테스트 노트")
 
+        // 아이템이 선택된 상태여야 얼럿이 열림
+        sut.viewModel.selectItem(note)
         sut.viewModel.openAlertView()
         XCTAssertTrue(sut.viewModel.showAlert)
 
         sut.viewModel.closeAlertView()
         XCTAssertFalse(sut.viewModel.showAlert)
+    }
+
+    func test_openAlertView_아이템선택없을시_상태원복() {
+        let sut = makeSUT()
+
+        // 선택 모드이지만 아이템은 없는 상태
+        sut.viewModel.setSelectionMode(.single)
+        XCTAssertEqual(sut.viewModel.select, .single)
+
+        // 아이템 없이 얼럿 오픈 시도
+        sut.viewModel.openAlertView()
+
+        // 얼럿은 열리지 않고 선택 모드도 해제되어야 함
+        XCTAssertFalse(sut.viewModel.showAlert)
+        XCTAssertEqual(sut.viewModel.select, .none)
     }
 
     func test_fetchItems_호출시_보이스노트로드확인() async {
@@ -216,11 +234,11 @@ final class FolderDetailViewModelTests: XCTestCase {
         sut.mockWasteBasketRepo.expectMoveAllToWasteBasket(callCount: 1)
 
         sut.viewModel.move()
-        try? await Task.sleep(nanoseconds: 300_000_000)
 
         sut.mockWasteBasketRepo.verify()
         XCTAssertTrue(sut.viewModel.items.isEmpty)
         XCTAssertEqual(sut.viewModel.select, .none)
+        XCTAssertTrue(sut.viewModel.selectedItems.isEmpty)
     }
 
     func test_restore_호출시_복원후_fetch재호출() async {

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -48,6 +48,7 @@ final class MainViewModelTests: XCTestCase {
         let mockVoiceNoteRepo: MockVoiceNoteRepository
         let mockWasteBasketRepo: MockWasteBasketRepository
         let mockCoordinator: MockMainCoordinatorDelegate
+        let mockLanguageRepo: MockLanguageRepository
     }
 
     private func makeSUT() -> SUT {
@@ -56,6 +57,7 @@ final class MainViewModelTests: XCTestCase {
         let mockVoiceNoteRepo = MockVoiceNoteRepository()
         let mockWasteBasketRepo = MockWasteBasketRepository()
         let mockCoordinator = MockMainCoordinatorDelegate()
+        let mockLanguageRepo = MockLanguageRepository()
 
         let viewModel = MainViewModel(
             microphoneRepository: mockVoiceRecordRepo,
@@ -65,7 +67,8 @@ final class MainViewModelTests: XCTestCase {
                 summaryRepository: MockSummaryRepository()
             ),
             folderUseCase: DefaultFolderUseCase(repository: mockFolderRepo),
-            wasteBasketRepository: mockWasteBasketRepo
+            wasteBasketRepository: mockWasteBasketRepo,
+            languageRepository: mockLanguageRepo
         )
         viewModel.mainCoordinator = mockCoordinator
 
@@ -75,7 +78,8 @@ final class MainViewModelTests: XCTestCase {
             mockFolderRepo: mockFolderRepo,
             mockVoiceNoteRepo: mockVoiceNoteRepo,
             mockWasteBasketRepo: mockWasteBasketRepo,
-            mockCoordinator: mockCoordinator
+            mockCoordinator: mockCoordinator,
+            mockLanguageRepo: mockLanguageRepo
         )
     }
 
@@ -142,11 +146,17 @@ final class MainViewModelTests: XCTestCase {
     func test_AlertView_상태변경() {
         let sut = makeSUT()
 
-        sut.viewModel.openAlertView()
+        sut.viewModel.openPermissionAlert()
         XCTAssertTrue(sut.viewModel.showPermissionAlert)
 
-        sut.viewModel.closeAlertView()
+        sut.viewModel.closePermissionAlert()
         XCTAssertFalse(sut.viewModel.showPermissionAlert)
+        
+        sut.viewModel.openLanguageAlert()
+        XCTAssertTrue(sut.viewModel.showLanguageAlert)
+        
+        sut.viewModel.closeLanguageAlert()
+        XCTAssertFalse(sut.viewModel.showLanguageAlert)
     }
 
     func test_handleRecordButtonTap_권한허용_바로녹음화면이동() async {
@@ -183,6 +193,28 @@ final class MainViewModelTests: XCTestCase {
         await sut.mockVoiceRecordRepo.verify()
         XCTAssertFalse(sut.mockCoordinator.presentRecodingViewCalled)
         XCTAssertTrue(sut.viewModel.showPermissionAlert)
+    }
+    
+    // MARK: - Language Tests
+
+    func test_checkLanguage_언어데이터로드확인() {
+        let sut = makeSUT()
+        sut.mockLanguageRepo.setFetchResult(.en)
+        sut.mockLanguageRepo.expectFetch(callCount: 1)
+
+        let language = sut.viewModel.checkLanguage()
+
+        XCTAssertEqual(language, .en)
+        sut.mockLanguageRepo.verify()
+    }
+
+    func test_saveLanguage_언어설정값저장확인() {
+        let sut = makeSUT()
+
+        sut.viewModel.saveLanguage(.en)
+
+        sut.mockLanguageRepo.expectSave(language: .en, callCount: 1)
+        sut.mockLanguageRepo.verify()
     }
 
     // MARK: - Update Tests

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -151,10 +151,10 @@ final class MainViewModelTests: XCTestCase {
 
         sut.viewModel.closePermissionAlert()
         XCTAssertFalse(sut.viewModel.showPermissionAlert)
-        
+
         sut.viewModel.openLanguageAlert()
         XCTAssertTrue(sut.viewModel.showLanguageAlert)
-        
+
         sut.viewModel.closeLanguageAlert()
         XCTAssertFalse(sut.viewModel.showLanguageAlert)
     }
@@ -194,7 +194,7 @@ final class MainViewModelTests: XCTestCase {
         XCTAssertFalse(sut.mockCoordinator.presentRecodingViewCalled)
         XCTAssertTrue(sut.viewModel.showPermissionAlert)
     }
-    
+
     // MARK: - Language Tests
 
     func test_checkLanguage_언어데이터로드확인() {

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -143,10 +143,10 @@ final class MainViewModelTests: XCTestCase {
         let sut = makeSUT()
 
         sut.viewModel.openAlertView()
-        XCTAssertTrue(sut.viewModel.showAlert)
+        XCTAssertTrue(sut.viewModel.showPermissionAlert)
 
         sut.viewModel.closeAlertView()
-        XCTAssertFalse(sut.viewModel.showAlert)
+        XCTAssertFalse(sut.viewModel.showPermissionAlert)
     }
 
     func test_handleRecordButtonTap_권한허용_바로녹음화면이동() async {
@@ -158,7 +158,7 @@ final class MainViewModelTests: XCTestCase {
 
         await sut.mockVoiceRecordRepo.verify()
         XCTAssertTrue(sut.mockCoordinator.presentRecodingViewCalled)
-        XCTAssertFalse(sut.viewModel.showAlert)
+        XCTAssertFalse(sut.viewModel.showPermissionAlert)
     }
 
     func test_handleRecordButtonTap_권한거부_알럿노출() async {
@@ -170,7 +170,7 @@ final class MainViewModelTests: XCTestCase {
 
         await sut.mockVoiceRecordRepo.verify()
         XCTAssertFalse(sut.mockCoordinator.presentRecodingViewCalled)
-        XCTAssertTrue(sut.viewModel.showAlert)
+        XCTAssertTrue(sut.viewModel.showPermissionAlert)
     }
 
     func test_handleRecordButtonTap_권한미결정_알럿노출() async {
@@ -182,7 +182,7 @@ final class MainViewModelTests: XCTestCase {
 
         await sut.mockVoiceRecordRepo.verify()
         XCTAssertFalse(sut.mockCoordinator.presentRecodingViewCalled)
-        XCTAssertTrue(sut.viewModel.showAlert)
+        XCTAssertTrue(sut.viewModel.showPermissionAlert)
     }
 
     // MARK: - Update Tests


### PR DESCRIPTION
---

## ✨ 작업 요약
폴더 상세 및 목록 화면의 내비게이션 버튼 컴포넌트화 및 얼럿 노출 시 UX/UI 개선 (간격 조정, 내비바 투명도 제어, 유닛 테스트 업데이트)

## 📋 구체적인 내용
- **추가/변경된 동작**:
    - **내비게이션 버튼 컴포넌트화 (`NavigationItemButton`)**: 기존 `UIButton`의 상태 전환 시 발생하는 시각적 결함(Long-press 시 normal 복귀)을 `UIButton.Configuration` 기반 커스텀 컴포넌트로 해결하고 재사용성을 높였습니다.
    - **내비게이션 바 투명도 제어**: `UIViewController` 확장에 `updateNavigationBarAppearance(isTransparent:)`를 추가하여, 얼럿(삭제 overlay) 노출 시에는 투명하게, 일반 상태에서는 `gray50` 배경이 보이도록 구현했습니다.
    - **폴더 상세/목록 UI 개선**: 상세 폴더 리스트의 그룹 간격(spacing: 8) 및 인셋(all: 20)을 조정하고, 선택 모드에서 항목이 없을 시 자동으로 모드가 해제되도록 UX를 개선했습니다.
    - **유닛 테스트 업데이트**: `FolderDetailViewModel`의 변경된 로직(아이템 유무에 따른 얼럿 노출 가드 등)에 맞춰 테스트 코드를 갱신하고 검증 케이스를 추가했습니다.
- **영향 받는 화면/모듈**:
    - **Presentation**: `FolderDetailViewController`, `FolderViewController`, `FolderDetailViewModelTests`

---

## 🔗 연관 이슈

- closed #212

---

## 🧩 설계·구현 노트

- **선택한 방식**
    - **`UIButton.Configuration` 및 `automaticallyUpdateForSelection = false`**: 시스템의 자동 상태 업데이트를 끄고 `configurationUpdateHandler`에서 상태를 직접 제어함으로써, 버튼을 꾹 누르고 있을 때 이미지가 흔들리거나 기본 배경색이 나타나는 문제를 완벽히 해결했습니다.
    - **`UINavigationBarAppearance`**: iOS 13+ 표준 방식을 사용하여 내비게이션 바의 투명도를 안전하게 제어했습니다.
- **고려했다가 제외한 방식**
    - 기존 `UIButton(type: .custom)` 스타일 유지: `isSelected`와 `isHighlighted` 상태가 겹칠 때의 처리가 까다로워 현대적인 `Configuration` 방식으로 전환하기로 결정했습니다.

---

## ✅ 확인 사항

- [x] 정상 플로우 동작 확인
- [x] 엣지 케이스 / 빈 값·에러 처리 확인
- [x] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [x] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [x] **`NavigationItemButton`**의 재사용 구조가 다른 화면으로 확장하기에 적절한지
- [x] **`updateNavigationBarAppearance`** 호출 시점이 `FolderDetailViewController`의 생명주기와 잘 맞물리는지
- [x] **유닛 테스트**에서 `openAlertView`의 가드 로직 검증이 충분한지

**특히 봐줬으면 하는 부분**
- 버튼을 길게 누를 때 `.normal` 상태로 돌아가던 버그가 해결되었는지, 그리고 선택 모드에서 취소 시 내비게이션 바 상태가 정상 복구되는지 중점적으로 봐주세요.

---

## 📚 참고