### PR TITLE
휴지통 UX 및 기능 리펙토링 합니다.

### DIFF
--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -96,6 +96,10 @@ extension MainCoordinator: FolderCoordinatorDelegate {
 
 extension MainCoordinator: FolderDetailCoordinatorDelegate {}
 
+// MARK: TrashCoordinating
+
+extension MainCoordinator: TrashCoordinatorDelegate {}
+
 // MARK: VoiceNoteCoordinating
 
 extension MainCoordinator: VoiceNoteCoordinatorDelegate {}

--- a/Presentation/Sources/Component/Folder/FolderCardView.swift
+++ b/Presentation/Sources/Component/Folder/FolderCardView.swift
@@ -1,24 +1,98 @@
+import Domain
 import SwiftUI
 
 struct FolderCardView: View {
-    let name: String
-    let totalCount: Int
+    let isSelected: Bool
+    var select: SelectionMode
+    let folder: Folder
+    let action: ((Folder, Bool) -> Void)?
+    let completeAction: (() -> Void)?
+
+    init(
+        select: SelectionMode = .none,
+        isSelected: Bool = false,
+        folder: Folder,
+        action: ((Folder, Bool) -> Void)? = nil,
+        completeAction: (() -> Void)? = nil
+    ) {
+        self.select = select
+        self.isSelected = isSelected
+        self.folder = folder
+        self.action = action
+        self.completeAction = completeAction
+    }
+
+    var isEdit: Bool {
+        select != .none
+    }
 
     var body: some View {
+        HStack(spacing: 0) {
+            if isEdit {
+                checkIcon
+            }
+            cardContent
+        }
+        .editfolderCardStyle(isSelected: isSelected)
+        .onTapGesture {
+            if isEdit {
+                action?(folder, !isSelected)
+            } else {
+                completeAction?()
+            }
+        }
+    }
+
+    private var checkIcon: some View {
+        VStack(alignment: .center, spacing: 0) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.gray950, .point600)
+                .overlay {
+                    if !isSelected {
+                        Circle()
+                            .fill(.gray850)
+                    }
+                }
+        }
+        .padding(.trailing)
+    }
+
+    private var cardContent: some View {
         HStack(spacing: 8) {
             Group {
                 Image(systemName: "folder")
-                Text(name)
+                Text(folder.name)
                     .font(Font.custom("Pretendard", size: 16))
                 Spacer()
-                Text(String(totalCount))
+                Text(String(folder.content.count))
                     .font(Font.custom("Pretendard", size: 16))
                     .multilineTextAlignment(.trailing)
             }
             .foregroundColor(.gray800)
         }
-        .padding(16)
-        .background(.point200.opacity(0.2))
-        .glassEffect(.clear, in: .rect(cornerRadius: 20))
+    }
+}
+
+extension View {
+    func editfolderCardStyle(isSelected: Bool) -> some View {
+        modifier(EditFolderCardModifier(isSelected: isSelected))
+    }
+}
+
+struct EditFolderCardModifier: ViewModifier {
+    let isSelected: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .background(.point200.opacity(0.2))
+            .glassEffect(.clear, in: .rect(cornerRadius: 20))
+            .overlay {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(.point900, lineWidth: 1)
+                }
+            }
     }
 }

--- a/Presentation/Sources/Component/Trash/TrashFolderCardView.swift
+++ b/Presentation/Sources/Component/Trash/TrashFolderCardView.swift
@@ -1,0 +1,71 @@
+import Domain
+import SwiftUI
+
+struct TrashFolderCardView: View {
+    let isSelected: Bool
+    var select: SelectionMode
+    let folder: Folder
+    let action: ((Folder, Bool) -> Void)?
+    let completeAction: (() -> Void)?
+
+    init(
+        select: SelectionMode = .none,
+        isSelected: Bool = false,
+        folder: Folder,
+        action: ((Folder, Bool) -> Void)? = nil,
+        completeAction: (() -> Void)? = nil
+    ) {
+        self.select = select
+        self.isSelected = isSelected
+        self.folder = folder
+        self.action = action
+        self.completeAction = completeAction
+    }
+
+    var isEdit: Bool {
+        select != .none
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if isEdit {
+                checkIcon
+            }
+            cardContent
+        }
+        .editfolderCardStyle(isSelected: isSelected)
+        .onTapGesture {
+            if isEdit {
+                action?(folder, !isSelected)
+            } else {
+                completeAction?()
+            }
+        }
+    }
+
+    private var checkIcon: some View {
+        VStack(alignment: .center, spacing: 0) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.gray950, .point600)
+                .overlay {
+                    if !isSelected {
+                        Circle()
+                            .fill(.gray850)
+                    }
+                }
+        }
+        .padding(.trailing)
+    }
+
+    private var cardContent: some View {
+        HStack(spacing: 8) {
+            Group {
+                Image(systemName: "folder")
+                Text(folder.name)
+                    .font(Font.custom("Pretendard", size: 16))
+                Spacer()
+            }
+            .foregroundColor(.gray800)
+        }
+    }
+}

--- a/Presentation/Sources/Component/Trash/TrashVoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/Trash/TrashVoiceNoteCardView.swift
@@ -1,0 +1,71 @@
+import Domain
+import SwiftUI
+
+struct TrashVoiceNoteCardView: View {
+    let isSelected: Bool
+    var select: SelectionMode
+    let voiceNote: VoiceNote
+    let action: ((VoiceNote, Bool) -> Void)?
+    let completeAction: (() -> Void)?
+
+    init(
+        select: SelectionMode = .none,
+        isSelected: Bool = false,
+        voiceNote: VoiceNote,
+        action: ((VoiceNote, Bool) -> Void)? = nil,
+        completeAction: (() -> Void)? = nil
+    ) {
+        self.select = select
+        self.isSelected = isSelected
+        self.voiceNote = voiceNote
+        self.action = action
+        self.completeAction = completeAction
+    }
+
+    var isEdit: Bool {
+        select != .none
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if isEdit {
+                checkIcon
+            }
+            cardContent
+        }
+        .editfolderCardStyle(isSelected: isSelected)
+        .onTapGesture {
+            if isEdit {
+                action?(voiceNote, !isSelected)
+            } else {
+                completeAction?()
+            }
+        }
+    }
+
+    private var checkIcon: some View {
+        VStack(alignment: .center, spacing: 0) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.gray950, .point600)
+                .overlay {
+                    if !isSelected {
+                        Circle()
+                            .fill(.gray850)
+                    }
+                }
+        }
+        .padding(.trailing)
+    }
+
+    private var cardContent: some View {
+        HStack(spacing: 8) {
+            Group {
+                Image(systemName: "microphone")
+                Text(voiceNote.title)
+                    .font(Font.custom("Pretendard", size: 16))
+                Spacer()
+            }
+            .foregroundColor(.gray800)
+        }
+    }
+}

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
@@ -3,12 +3,12 @@ import SwiftUI
 
 struct VoiceNoteCardView: View {
     let isSelected: Bool
-    var select: FolderDetailViewModel.Select
+    var select: SelectionMode
     let voiceNote: VoiceNote
     let action: ((VoiceNote, Bool) -> Void)?
     let completeAction: (() -> Void)?
     init(
-        select: FolderDetailViewModel.Select = .none,
+        select: SelectionMode = .none,
         isSelected: Bool = false,
         voiceNote: VoiceNote,
         action: ((VoiceNote, Bool) -> Void)? = nil,

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
@@ -34,7 +34,7 @@ struct VoiceNoteCardView: View {
                 cardContent
             }
         }
-        .editCardStyle(isSelected: isSelected)
+        .editVoiceNoteCardStyle(isSelected: isSelected)
         .onTapGesture {
             if isEdit {
                 action?(voiceNote, !isSelected)
@@ -93,7 +93,7 @@ struct VoiceNoteCardView: View {
 }
 
 extension View {
-    func editCardStyle(isSelected: Bool) -> some View {
+    func editVoiceNoteCardStyle(isSelected: Bool) -> some View {
         modifier(
             EditVoiceNoteCardModifier(
                 isSelected: isSelected

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -211,10 +211,7 @@ public final class FolderDetailViewController: CollectionViewController {
             switch itemIdentifier {
             case .folder(let folder):
                 cell.contentConfiguration = UIHostingConfiguration {
-                    FolderCardView(
-                        name: folder.name,
-                        totalCount: folder.content.count
-                    )
+                    FolderCardView(folder: folder)
                 }
                 .margins(.all, 0)
             case .voiceNote(let voiceNote):

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -49,7 +49,7 @@ public final class FolderDetailViewController: CollectionViewController {
         title: "선택하기",
         image: nil
     ) { [weak self] _ in
-        self?.vm.setSelectionMode(.single)
+        self?.vm.setSelectionMode(.multiple)
     }
 
     private lazy var selectAllAction = UIAction(
@@ -264,7 +264,7 @@ extension FolderDetailViewController {
         }
     }
 
-    private func updateRightBarButtonMenu(_ select: FolderDetailViewModel.Select) {
+    private func updateRightBarButtonMenu(_ select: SelectionMode) {
         let dateSection: UIMenu = .init(
             title: "",
             options: .displayInline,
@@ -287,7 +287,7 @@ extension FolderDetailViewController {
         switch vm.select {
         case .none:
             [createdAtAction, updatedAtAction]
-        case .all, .single:
+        case .all, .multiple:
             []
         }
     }
@@ -296,12 +296,12 @@ extension FolderDetailViewController {
         switch vm.select {
         case .none:
             [selectAction, selectAllAction]
-        case .all, .single:
+        case .all, .multiple:
             []
         }
     }
 
-    private func updateNavigationItems(_ select: FolderDetailViewModel.Select) {
+    private func updateNavigationItems(_ select: SelectionMode) {
         let isEditMode = (select != .none)
         for item in [backButton, moreAndActionButton, searchAndMoveButton] {
             item.isSelected = isEditMode
@@ -340,7 +340,7 @@ private extension FolderDetailViewController {
             switch vm.select {
             case .none:
                 vm.didTapBack()
-            case .all, .single:
+            case .all, .multiple:
                 vm.setSelectionMode(.none)
             }
         }
@@ -353,7 +353,7 @@ private extension FolderDetailViewController {
             case .none:
                 // TODO: 더 보기 로직 실행 ( 실행 X )
                 print("더 보기 버튼 탭됨")
-            case .single, .all:
+            case .multiple, .all:
                 // TODO: 삭제 로직 실행
                 vm.openAlertView()
             }
@@ -367,7 +367,7 @@ private extension FolderDetailViewController {
             case .none:
                 // TODO: 검색 로직 실행
                 print("검색 버튼 탭됨")
-            case .all, .single:
+            case .all, .multiple:
                 // TODO: 이동 로직 실행
                 vm.presentMoveFolder { [weak self] name in
                     self?.vm.fetchItems()

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -224,7 +224,12 @@ extension FolderViewController {
                 cell.contentConfiguration = UIHostingConfiguration {
                     switch item {
                     case .folder(let data):
-                        FolderCardView(folder: data)
+                        FolderCardView(
+                            folder: data,
+                            completeAction: { [weak self] in
+                                self?.vm.pushDetail(data)
+                            }
+                        )
                     case .voiceNote(let data):
                         VoiceNoteCardView(
                             voiceNote: data

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -224,10 +224,7 @@ extension FolderViewController {
                 cell.contentConfiguration = UIHostingConfiguration {
                     switch item {
                     case .folder(let data):
-                        FolderCardView(
-                            name: data.name,
-                            totalCount: data.content.count
-                        )
+                        FolderCardView(folder: data)
                     case .voiceNote(let data):
                         VoiceNoteCardView(
                             voiceNote: data

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -220,10 +220,7 @@ public final class MainViewController: ViewController {
             cell.contentConfiguration = UIHostingConfiguration {
                 switch item {
                 case .folder(let data):
-                    FolderCardView(
-                        name: data.name,
-                        totalCount: data.content.count
-                    )
+                    FolderCardView(folder: data)
                 case .voiceNote(let data):
                     VoiceNoteCardView(
                         voiceNote: data,

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -75,6 +75,10 @@ public final class TrashViewController: CollectionViewController {
         let primary = GlassButton.danger("비우기")
         primary.addAction(UIAction { [weak self] _ in
             self?.vm.deleteAll()
+            self?.chagokBackgroundView.makeToast(
+                type: .normal,
+                "영구 삭제 되었습니다"
+            )
             self?.vm.closeTrashAlert()
         }, for: .touchUpInside)
         return primary
@@ -314,7 +318,7 @@ private extension TrashViewController {
                 vm.delete(items: vm.selectedItems)
                 chagokBackgroundView.makeToast(
                     type: .normal,
-                    "삭제되었습니다"
+                    "영구 삭제 되었습니다"
                 )
             default:
                 break

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -164,11 +164,23 @@ public final class TrashViewController: CollectionViewController {
             var backgroundConfig = UIBackgroundConfiguration.listCell()
             backgroundConfig.backgroundColor = .clear
             cell.backgroundConfiguration = backgroundConfig
-
+            
             switch itemIdentifier {
             case .folder(let folder):
                 cell.contentConfiguration = UIHostingConfiguration {
-                    FolderCardView(name: folder.name, totalCount: folder.content.count)
+                    FolderCardView(
+                        select: vm.select,
+                        isSelected: vm.selectedItems.contains(.folder(obj: folder)),
+                        folder: folder
+                    ) { [weak self] data, state in
+                        if state {
+                            self?.vm.selectItem(.folder(obj: data))
+                        } else {
+                            self?.vm.deselectItem(.folder(obj: data))
+                        }
+                    } completeAction: { [weak self] in
+                        self?.vm.pushDetailFolder(folder)
+                    }
                 }
                 .margins(.all, 0)
             case .voiceNote(let voiceNote):

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -300,9 +300,13 @@ private extension TrashViewController {
             guard let self else { return }
             switch vm.select {
             case .multiple:
-                print("선택 삭제하기")
+                vm.delete(items: vm.selectedItems)
+                chagokBackgroundView.makeToast(
+                    type: .normal,
+                    "삭제되었습니다"
+                )
             default:
-                print("안쓰는 부분")
+                break
             }
         }
     }
@@ -314,7 +318,11 @@ private extension TrashViewController {
             case .none:
                 print("검색 버튼 탭됨")
             case .multiple, .all:
-                print("선택 복원하기")
+                let restoredItems = vm.selectedItems
+                vm.restore(items: vm.selectedItems)
+                chagokBackgroundView.makeToast("원래 위치로 복원됐어요.") { [weak self] in
+                    self?.vm.cancelRestore(items: restoredItems)
+                }
             }
         }
     }

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -2,7 +2,7 @@ import Domain
 import SwiftUI
 import UIKit
 
-public final class TrashViewController: UICollectionViewController {
+public final class TrashViewController: CollectionViewController {
     enum Section {
         case main
     }
@@ -12,50 +12,54 @@ public final class TrashViewController: UICollectionViewController {
 
     private var dataSource: DataSource?
 
-    private lazy var backButton: UIButton = {
-        let btn = UIButton(type: .system)
-        let backImage = UIImage(systemName: "chevron.left")?
-            .withConfiguration(UIImage.SymbolConfiguration(weight: .bold))
-        btn.setImage(backImage, for: .normal)
-        btn.setTitle("휴지통", for: .normal)
-        btn.titleLabel?.setTypography(style: .title1)
-        btn.tintColor = UIColor.gray950
-        return btn
-    }()
-
     // MARK: - Component
 
-    private lazy var createdAtAction = UIAction(
-        title: "생성일 순"
-    ) { _ in
-        self.vm.touchCreatedAction()
-    }
+    private lazy var backButton: NavigationItemButton = .init(
+        normalItem: .init(title: " 휴지통", imageName: "chevron.left"),
+        selectedItem: .init(title: "", imageName: "xmark"),
+        attributedString: Typography.title1.textAttributes
+    )
 
-    private lazy var updatedAtAction = UIAction(
-        title: "수정일 순"
-    ) { _ in
-        self.vm.touchUpdatedAction()
-    }
+    private lazy var moreAndActionButton: NavigationItemButton = .init(
+        normalItem: .init(imageName: "ellipsis"),
+        selectedItem: .init(title: "삭제"),
+        attributedString: Typography.title1.textAttributes,
+        selectedForegroundColor: .danger
+    )
+
+    private lazy var searchAndMoveButton: NavigationItemButton = .init(
+        normalItem: .init(imageName: "magnifyingglass"),
+        selectedItem: .init(title: "복원"),
+        attributedString: Typography.title1.textAttributes
+    )
+
+    private let alertOverlayView: UIView = {
+        let overlay = UIView()
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        overlay.isHidden = true
+        return overlay
+    }()
 
     private lazy var emptyTrashAction = UIAction(
         title: "휴지통 비우기",
-        image: UIImage(systemName: "trash"),
+        image: nil,
         attributes: .destructive // 강조(빨간색) 효과
     ) { _ in
-        self.vm.toggleShowAlert()
+        self.vm.openTrashAlert()
     }
 
     private lazy var selectAction = UIAction(
-        title: vm.isSelectionMode ? "완료" : "선택하기",
-        image: UIImage(systemName: "checkmark.circle")
+        title: "선택하기",
+        image: nil
     ) { [weak self] _ in
-        self?.vm.toggleSelectionMode()
+        self?.vm.setSelectionMode(.multiple)
     }
 
     private lazy var cancelButton: GlassButton = {
         let cancel = GlassButton.close("취소")
         cancel.addAction(UIAction { [weak self] _ in
-            self?.vm.toggleShowAlert()
+            self?.vm.closeTrashAlert()
         }, for: .touchUpInside)
         return cancel
     }()
@@ -64,7 +68,7 @@ public final class TrashViewController: UICollectionViewController {
         let primary = GlassButton.danger("비우기")
         primary.addAction(UIAction { [weak self] _ in
             self?.vm.deleteAll()
-            self?.vm.toggleShowAlert()
+            self?.vm.closeTrashAlert()
         }, for: .touchUpInside)
         return primary
     }()
@@ -84,9 +88,11 @@ public final class TrashViewController: UICollectionViewController {
             var listConfiguration = UICollectionLayoutListConfiguration(appearance: .plain)
             listConfiguration.headerMode = .supplementary
             listConfiguration.showsSeparators = false
-            listConfiguration.backgroundColor = .gray50
+            listConfiguration.backgroundColor = .clear
 
             let section = NSCollectionLayoutSection.list(using: listConfiguration, layoutEnvironment: layoutEnvironment)
+            section.contentInsets = .init(top: 12, leading: 20, bottom: 20, trailing: 20)
+            section.interGroupSpacing = 8
             section.boundarySupplementaryItems.forEach { $0.pinToVisibleBounds = false }
             return section
         }
@@ -106,8 +112,9 @@ public final class TrashViewController: UICollectionViewController {
         setupDataSource()
         updateDataSource()
         setupAlertView()
+        updateNavigationBarAppearance(isTransparent: vm.showTrashAlert)
     }
-
+    
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         vm.fetchItems()
@@ -115,51 +122,28 @@ public final class TrashViewController: UICollectionViewController {
 
     override public func updateProperties() {
         super.updateProperties()
-        // menu
-        switch vm.selectedOrder {
-        case .createdAt:
-            createdAtAction.image = UIImage(systemName: "checkmark")
-            updatedAtAction.image = nil
-        case .updatedAt:
-            createdAtAction.image = nil
-            updatedAtAction.image = UIImage(systemName: "checkmark")
-        }
-        selectAction.title = vm.isSelectionMode ? "완료" : "선택하기"
+        // navigation item
+        updateNavigationItems(vm.select)
+        updateRightBarButtonMenu(vm.select)
         // dataSource
-        collectionView.allowsMultipleSelection = vm.isSelectionMode
-        if !vm.isSelectionMode {
-            collectionView.indexPathsForSelectedItems?.forEach {
-                collectionView.deselectItem(at: $0, animated: false)
-            }
-        }
         updateDataSource(reconfigure: true)
-        updateRightBarButtonMenu()
         // alert
-        alert.isHidden = !vm.showAlert
-    }
-
-    private func updateRightBarButtonMenu() {
-        let menu = UIMenu(
-            title: "",
-            children: [createdAtAction, updatedAtAction, selectAction, emptyTrashAction]
-        )
-        navigationItem.rightBarButtonItems?.first?.menu = menu
+        updateAlertState()
     }
 
     private func setupNavigation() {
         let leftItem = UIBarButtonItem(customView: backButton)
         navigationItem.leftBarButtonItem = leftItem
 
-        backButton.addAction(
-            UIAction { [weak self] _ in
-                self?.vm.didTapBack()
-            }, for: .touchUpInside
-        )
+        backButton.addAction(backButtonAction(), for: .touchUpInside)
         navigationItem.rightBarButtonItems = [
-            UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: nil),
-            UIBarButtonItem(image: UIImage(systemName: "magnifyingglass"), menu: nil)
+            UIBarButtonItem(customView: moreAndActionButton),
+            UIBarButtonItem(customView: searchAndMoveButton)
         ]
-        updateRightBarButtonMenu()
+        moreAndActionButton.addAction(moreAndActionButtonAction(), for: .touchUpInside)
+        searchAndMoveButton.addAction(searchAndMoveButtonAction(), for: .touchUpInside)
+
+        updateRightBarButtonMenu(vm.select)
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
         navigationItem.rightBarButtonItems?.forEach {
             $0.hidesSharedBackground = true
@@ -181,19 +165,29 @@ public final class TrashViewController: UICollectionViewController {
             backgroundConfig.backgroundColor = .clear
             cell.backgroundConfiguration = backgroundConfig
 
-            cell.accessories = vm.isSelectionMode ? [.multiselect(displayed: .always)] : []
-
             switch itemIdentifier {
             case .folder(let folder):
                 cell.contentConfiguration = UIHostingConfiguration {
                     FolderCardView(name: folder.name, totalCount: folder.content.count)
                 }
+                .margins(.all, 0)
             case .voiceNote(let voiceNote):
                 cell.contentConfiguration = UIHostingConfiguration {
                     VoiceNoteCardView(
+                        select: vm.select,
+                        isSelected: vm.selectedItems.contains(.voiceNote(obj: voiceNote)),
                         voiceNote: voiceNote
-                    )
+                    ) { [weak self] data, state in
+                        if state {
+                            self?.vm.selectItem(.voiceNote(obj: data))
+                        } else {
+                            self?.vm.deselectItem(.voiceNote(obj: data))
+                        }
+                    } completeAction: { [weak self] in
+                        self?.vm.pushVoiceNote(voiceNote)
+                    }
                 }
+                .margins(.all, 0)
             }
         }
 
@@ -213,6 +207,49 @@ public final class TrashViewController: UICollectionViewController {
         }
     }
 
+    private func setupAlertView() {
+        view.addSubview(alertOverlayView)
+        alertOverlayView.addSubview(alert)
+        NSLayoutConstraint.activate([
+            alertOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
+            alertOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            alertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            alertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            alert.centerXAnchor.constraint(equalTo: alertOverlayView.centerXAnchor),
+            alert.centerYAnchor.constraint(equalTo: alertOverlayView.centerYAnchor)
+        ])
+    }
+}
+
+// MARK: - Update Method
+extension TrashViewController {
+    private func updateRightBarButtonMenu(_ select: SelectionMode) {
+        let menu: UIMenu = .init(
+            title: "",
+            children: [selectAction, emptyTrashAction]
+        )
+        moreAndActionButton.menu = menu
+    }
+    
+    private func updateNavigationItems(_ select: SelectionMode) {
+        let isEditMode = (select != .none)
+        for item in [backButton, moreAndActionButton, searchAndMoveButton] {
+            item.isSelected = isEditMode
+            item.sizeToFit()
+        }
+        moreAndActionButton.showsMenuAsPrimaryAction = !isEditMode
+    }
+
+    private func updateAlertState() {
+        let shouldShowAlert = vm.showTrashAlert
+        alertOverlayView.isHidden = !shouldShowAlert
+        updateInteractionForAlert(isPresented: shouldShowAlert)
+        if shouldShowAlert {
+            view.bringSubviewToFront(alertOverlayView)
+        }
+        updateNavigationBarAppearance(isTransparent: shouldShowAlert)
+    }
+    
     private func updateDataSource(reconfigure: Bool = false) {
         var snapshot = SnapShot()
         snapshot.appendSections([.main])
@@ -222,46 +259,61 @@ public final class TrashViewController: UICollectionViewController {
         }
         dataSource?.apply(snapshot, animatingDifferences: true)
     }
-
-    private func setupAlertView() {
-        alert.isHidden = !vm.showAlert
-        view.addSubview(alert)
-        NSLayoutConstraint.activate([
-            alert.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            alert.centerYAnchor.constraint(equalTo: view.centerYAnchor)
-        ])
+    
+    func updateInteractionForAlert(isPresented: Bool) {
+        collectionView.isUserInteractionEnabled = !isPresented
+        backButton.isUserInteractionEnabled = !isPresented
+        moreAndActionButton.isUserInteractionEnabled = !isPresented
+        searchAndMoveButton.isUserInteractionEnabled = !isPresented
     }
 }
 
-// MARK: - Delegate
+// MARK: - Helper Method
 
-public extension TrashViewController {
-    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard vm.isSelectionMode, let item = dataSource?.itemIdentifier(for: indexPath) else { return }
-
-        let wasteBasketItem: WasteBasketItem = switch item {
-        case .folder(let folder):
-            .folder(obj: folder)
-        case .voiceNote(let voiceNote):
-            .voiceNote(obj: voiceNote)
+private extension TrashViewController {
+    func backButtonAction() -> UIAction {
+        UIAction { [weak self] _ in
+            guard let self else { return }
+            switch vm.select {
+            case .none:
+                vm.didTapBack()
+            case .all, .multiple:
+                vm.setSelectionMode(.none)
+            }
         }
-        vm.selectItem(wasteBasketItem)
     }
 
-    override func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        guard vm.isSelectionMode, let item = dataSource?.itemIdentifier(for: indexPath) else { return }
-
-        let wasteBasketItem: WasteBasketItem = switch item {
-        case .folder(let folder):
-            .folder(obj: folder)
-        case .voiceNote(let voiceNote):
-            .voiceNote(obj: voiceNote)
+    func moreAndActionButtonAction() -> UIAction {
+        UIAction { [weak self] _ in
+            guard let self else { return }
+            switch vm.select {
+            case .multiple:
+                print("선택 삭제하기")
+            default:
+                print("안쓰는 부분")
+            }
         }
-        vm.deselectItem(wasteBasketItem)
+    }
+
+    func searchAndMoveButtonAction() -> UIAction {
+        UIAction { [weak self] _ in
+            guard let self else { return }
+            switch vm.select {
+            case .none:
+                print("검색 버튼 탭됨")
+            case .multiple, .all:
+                print("선택 복원하기")
+            }
+        }
     }
 }
 
-//
-// #Preview {
-//    UINavigationController(rootViewController: TrashViewController(vm: TrashViewModel()))
-// }
+#if DEBUG
+ #Preview {
+    UINavigationController(
+        rootViewController: TrashViewController(
+            vm: .preview()
+        )
+    )
+ }
+#endif

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -55,7 +55,7 @@ public final class TrashViewController: CollectionViewController {
     ) { [weak self] _ in
         self?.vm.setSelectionMode(.multiple)
     }
-    
+
     private lazy var selectAllAction = UIAction(
         title: "전체 선택하기",
         image: nil
@@ -125,7 +125,7 @@ public final class TrashViewController: CollectionViewController {
         setupAlertView()
         updateNavigationBarAppearance(isTransparent: vm.showTrashAlert)
     }
-    
+
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         vm.fetchItems()
@@ -175,7 +175,7 @@ public final class TrashViewController: CollectionViewController {
             var backgroundConfig = UIBackgroundConfiguration.listCell()
             backgroundConfig.backgroundColor = .clear
             cell.backgroundConfiguration = backgroundConfig
-            
+
             switch itemIdentifier {
             case .folder(let folder):
                 cell.contentConfiguration = UIHostingConfiguration {
@@ -245,6 +245,7 @@ public final class TrashViewController: CollectionViewController {
 }
 
 // MARK: - Update Method
+
 extension TrashViewController {
     private func updateRightBarButtonMenu(_ select: SelectionMode) {
         let menu: UIMenu = .init(
@@ -253,7 +254,7 @@ extension TrashViewController {
         )
         moreAndActionButton.menu = menu
     }
-    
+
     private func updateNavigationItems(_ select: SelectionMode) {
         let isEditMode = (select != .none)
         for item in [backButton, moreAndActionButton, searchAndMoveButton] {
@@ -272,7 +273,7 @@ extension TrashViewController {
         }
         updateNavigationBarAppearance(isTransparent: shouldShowAlert)
     }
-    
+
     private func updateDataSource(reconfigure: Bool = false) {
         var snapshot = SnapShot()
         snapshot.appendSections([.main])
@@ -282,7 +283,7 @@ extension TrashViewController {
         }
         dataSource?.apply(snapshot, animatingDifferences: true)
     }
-    
+
     func updateInteractionForAlert(isPresented: Bool) {
         collectionView.isUserInteractionEnabled = !isPresented
         backButton.isUserInteractionEnabled = !isPresented
@@ -348,11 +349,11 @@ private extension TrashViewController {
 }
 
 #if DEBUG
- #Preview {
-    UINavigationController(
-        rootViewController: TrashViewController(
-            vm: .preview()
+    #Preview {
+        UINavigationController(
+            rootViewController: TrashViewController(
+                vm: .preview()
+            )
         )
-    )
- }
+    }
 #endif

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -179,7 +179,7 @@ public final class TrashViewController: CollectionViewController {
             switch itemIdentifier {
             case .folder(let folder):
                 cell.contentConfiguration = UIHostingConfiguration {
-                    FolderCardView(
+                    TrashFolderCardView(
                         select: vm.select,
                         isSelected: vm.selectedItems.contains(.folder(obj: folder)),
                         folder: folder
@@ -196,7 +196,7 @@ public final class TrashViewController: CollectionViewController {
                 .margins(.all, 0)
             case .voiceNote(let voiceNote):
                 cell.contentConfiguration = UIHostingConfiguration {
-                    VoiceNoteCardView(
+                    TrashVoiceNoteCardView(
                         select: vm.select,
                         isSelected: vm.selectedItems.contains(.voiceNote(obj: voiceNote)),
                         voiceNote: voiceNote

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -55,6 +55,13 @@ public final class TrashViewController: CollectionViewController {
     ) { [weak self] _ in
         self?.vm.setSelectionMode(.multiple)
     }
+    
+    private lazy var selectAllAction = UIAction(
+        title: "전체 선택하기",
+        image: nil
+    ) { [weak self] _ in
+        self?.vm.setSelectionMode(.all)
+    }
 
     private lazy var cancelButton: GlassButton = {
         let cancel = GlassButton.close("취소")
@@ -238,7 +245,7 @@ extension TrashViewController {
     private func updateRightBarButtonMenu(_ select: SelectionMode) {
         let menu: UIMenu = .init(
             title: "",
-            children: [selectAction, emptyTrashAction]
+            children: [selectAllAction, selectAction, emptyTrashAction]
         )
         moreAndActionButton.menu = menu
     }
@@ -300,6 +307,10 @@ private extension TrashViewController {
             guard let self else { return }
             switch vm.select {
             case .multiple:
+                guard !vm.selectedItems.isEmpty else {
+                    vm.setSelectionMode(.none)
+                    return
+                }
                 vm.delete(items: vm.selectedItems)
                 chagokBackgroundView.makeToast(
                     type: .normal,
@@ -318,6 +329,10 @@ private extension TrashViewController {
             case .none:
                 print("검색 버튼 탭됨")
             case .multiple, .all:
+                guard !vm.selectedItems.isEmpty else {
+                    vm.setSelectionMode(.none)
+                    return
+                }
                 let restoredItems = vm.selectedItems
                 vm.restore(items: vm.selectedItems)
                 chagokBackgroundView.makeToast("원래 위치로 복원됐어요.") { [weak self] in

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -12,12 +12,6 @@ public protocol FolderDetailCoordinatorDelegate: BaseCoordinatorDelegate {
 public final class FolderDetailViewModel {
     // MARK: - State
 
-    enum Select: Equatable {
-        case none
-        case all
-        case single
-    }
-
     enum Order {
         case createdAt
         case updatedAt
@@ -28,7 +22,7 @@ public final class FolderDetailViewModel {
     private(set) var items: [LibraryItem] = []
     private(set) var errorMessage: String?
     private(set) var order: Order = .createdAt
-    private(set) var select: Select = .none
+    private(set) var select: SelectionMode = .none
     private(set) var selectedItems: [VoiceNote] = []
     private(set) var showAlert: Bool = false
 
@@ -63,7 +57,7 @@ extension FolderDetailViewModel {
         sortItems()
     }
 
-    func setSelectionMode(_ select: Select) {
+    func setSelectionMode(_ select: SelectionMode) {
         self.select = select
         if select == .none {
             allClearSelected()
@@ -73,6 +67,7 @@ extension FolderDetailViewModel {
     }
 
     func selectItem(_ item: VoiceNote) {
+        if select == .none { setSelectionMode(.multiple) }
         selectedItems.append(item)
     }
 

--- a/Presentation/Sources/ViewModel/Main/MainDataType.swift
+++ b/Presentation/Sources/ViewModel/Main/MainDataType.swift
@@ -32,6 +32,13 @@ public enum LibraryItem: Hashable, Sendable {
         case .voiceNote(let voiceNote): return voiceNote.id
         }
     }
+
+    public var deletedAt: Date? {
+        switch self {
+        case .folder(let folder): return folder.deletedAt
+        case .voiceNote(let voiceNote): return voiceNote.deletedAt
+        }
+    }
 }
 
 public struct CategoryToggle: Hashable, Sendable {

--- a/Presentation/Sources/ViewModel/SelectionMode.swift
+++ b/Presentation/Sources/ViewModel/SelectionMode.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum SelectionMode: Equatable {
-    case none       // 선택 모드 아님
-    case multiple   // 선택 모드 (일부 항목 선택됨)
-    case all        // 전체 선택 모드
+    case none // 선택 모드 아님
+    case multiple // 선택 모드 (일부 항목 선택됨)
+    case all // 전체 선택 모드
 }

--- a/Presentation/Sources/ViewModel/SelectionMode.swift
+++ b/Presentation/Sources/ViewModel/SelectionMode.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum SelectionMode: Equatable {
+    case none       // 선택 모드 아님
+    case multiple   // 선택 모드 (일부 항목 선택됨)
+    case all        // 전체 선택 모드
+}

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -19,7 +19,7 @@ public final class TrashViewModel {
     private(set) var select: SelectionMode = .none
     private(set) var selectedItems: [WasteBasketItem] = []
     private(set) var showTrashAlert: Bool = false
-    
+
     public weak var coordinator: TrashCoordinatorDelegate?
 
     // MARK: - UseCase
@@ -65,7 +65,7 @@ extension TrashViewModel {
     func openTrashAlert() {
         showTrashAlert = true
     }
-    
+
     func closeTrashAlert() {
         showTrashAlert = false
     }
@@ -77,20 +77,20 @@ extension TrashViewModel {
     func didTapBack() {
         coordinator?.pop()
     }
-    
+
     func pushVoiceNote(_ voiceNote: VoiceNote) {
         coordinator?.pushVoiceNoteView(voiceNote: voiceNote)
     }
-    
+
     func pushDetailFolder(_ folder: Folder) {
         coordinator?.pushMyFolderDetailView(folder)
     }
-    
+
     func selectItem(_ item: WasteBasketItem) {
         if select == .none { setSelectionMode(.multiple) }
         selectedItems.append(item)
     }
-    
+
     func deselectItem(_ item: WasteBasketItem) {
         selectedItems.removeAll { $0.id == item.id }
     }
@@ -111,7 +111,7 @@ extension TrashViewModel {
     }
 
     private func sortItems() {
-        items.sort { (lhs, rhs) -> Bool in
+        items.sort { lhs, rhs -> Bool in
             let lhsDate = lhs.deletedAt ?? .distantPast
             let rhsDate = rhs.deletedAt ?? .distantPast
             return lhsDate > rhsDate
@@ -182,7 +182,7 @@ extension TrashViewModel {
             errorMessage = error.localizedDescription
         }
     }
-    
+
     func cancelRestore(item: WasteBasketItem) {
         do {
             try repository.moveToWasteBasket(item: item)

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -19,7 +19,7 @@ public final class TrashViewModel {
     private(set) var select: SelectionMode = .none
     private(set) var selectedItems: [WasteBasketItem] = []
     private(set) var showTrashAlert: Bool = false
-
+    
     public weak var coordinator: TrashCoordinatorDelegate?
 
     // MARK: - UseCase
@@ -103,9 +103,18 @@ extension TrashViewModel {
         do {
             let wasteBaskets: [WasteBasketItem] = try repository.fetchAll()
             items = wasteBaskets.map(\.toLibraryItem)
+            sortItems()
         } catch {
             AppLogger.error(error)
             errorMessage = error.localizedDescription
+        }
+    }
+
+    private func sortItems() {
+        items.sort { (lhs, rhs) -> Bool in
+            let lhsDate = lhs.deletedAt ?? .distantPast
+            let rhsDate = rhs.deletedAt ?? .distantPast
+            return lhsDate > rhsDate
         }
     }
 }
@@ -168,6 +177,28 @@ extension TrashViewModel {
             let restoreIDs = Set(restoreItems.map(\.id))
             items.removeAll { restoreIDs.contains($0.id) }
             setSelectionMode(.none)
+        } catch {
+            AppLogger.error(error)
+            errorMessage = error.localizedDescription
+        }
+    }
+    
+    func cancelRestore(item: WasteBasketItem) {
+        do {
+            try repository.moveToWasteBasket(item: item)
+            items.append(item.toLibraryItem)
+            sortItems()
+        } catch {
+            AppLogger.error(error)
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func cancelRestore(items restoreItems: [WasteBasketItem]) {
+        do {
+            try repository.moveAllToWasteBasket(items: restoreItems)
+            items.append(contentsOf: restoreItems.map(\.toLibraryItem))
+            sortItems()
         } catch {
             AppLogger.error(error)
             errorMessage = error.localizedDescription

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -2,28 +2,25 @@ import Core
 import Domain
 import Foundation
 
+public protocol TrashCoordinatorDelegate: BaseCoordinatorDelegate {
+    /// 음성 노트 이동
+    func pushVoiceNoteView(voiceNote: VoiceNote)
+    /// 상세 폴더 이동
+    func pushMyFolderDetailView(_ folder: Folder)
+}
+
 @MainActor
 @Observable
 public final class TrashViewModel {
     // MARK: - State
 
-    enum Order {
-        case createdAt
-        case updatedAt
-    }
-
     private(set) var items: [LibraryItem] = []
     private(set) var errorMessage: String?
-    private(set) var selectedOrder: Order = .createdAt
-    private(set) var isSelectionMode: Bool = false
+    private(set) var select: SelectionMode = .none
     private(set) var selectedItems: [WasteBasketItem] = []
-    private(set) var showAlert: Bool = false
+    private(set) var showTrashAlert: Bool = false
 
-    var isEmpty: Bool {
-        items.isEmpty
-    }
-
-    public weak var coordinator: BaseCoordinatorDelegate?
+    public weak var coordinator: TrashCoordinatorDelegate?
 
     // MARK: - UseCase
 
@@ -35,53 +32,42 @@ public final class TrashViewModel {
         repository: WasteBasketRepository
     ) {
         self.repository = repository
-        sortItems()
     }
 }
 
 // MARK: - Setter / Getter
 
 extension TrashViewModel {
-    private func setSelectedOrder(_ order: Order) {
-        selectedOrder = order
-        sortItems()
-    }
-
-    private func sortItems() {
-        switch selectedOrder {
-        case .createdAt:
-            items.sort { $0.createdAt > $1.createdAt }
-        case .updatedAt:
-            items.sort { $0.updatedAt > $1.updatedAt }
+    func setSelectionMode(_ select: SelectionMode) {
+        self.select = select
+        if select == .none {
+            allClearSelected()
+        } else if select == .all {
+            allSelected()
         }
     }
 
-    func toggleSelectionMode() {
-        isSelectionMode.toggle()
-        if !isSelectionMode {
-            delete(items: selectedItems)
-            selectedItems.removeAll()
+    private func allSelected() {
+        selectedItems = items.compactMap {
+            switch $0 {
+            case .folder(let folder):
+                return .folder(obj: folder)
+            case .voiceNote(let voiceNote):
+                return .voiceNote(obj: voiceNote)
+            }
         }
     }
 
-    func toggleShowAlert() {
-        showAlert.toggle()
+    private func allClearSelected() {
+        selectedItems.removeAll()
     }
 
-    func selectItem(_ item: WasteBasketItem) {
-        selectedItems.insert(item, at: 0)
+    func openTrashAlert() {
+        showTrashAlert = true
     }
-
-    func deselectItem(_ item: WasteBasketItem) {
-        selectedItems.removeAll { $0 == item }
-    }
-
-    func touchCreatedAction() {
-        setSelectedOrder(.createdAt)
-    }
-
-    func touchUpdatedAction() {
-        setSelectedOrder(.updatedAt)
+    
+    func closeTrashAlert() {
+        showTrashAlert = false
     }
 }
 
@@ -90,6 +76,23 @@ extension TrashViewModel {
 extension TrashViewModel {
     func didTapBack() {
         coordinator?.pop()
+    }
+    
+    func pushVoiceNote(_ voiceNote: VoiceNote) {
+        coordinator?.pushVoiceNoteView(voiceNote: voiceNote)
+    }
+    
+    func pushDetailFolder(_ folder: Folder) {
+        coordinator?.pushMyFolderDetailView(folder)
+    }
+    
+    func selectItem(_ item: WasteBasketItem) {
+        if select == .none { setSelectionMode(.multiple) }
+        selectedItems.append(item)
+    }
+    
+    func deselectItem(_ item: WasteBasketItem) {
+        selectedItems.removeAll { $0.id == item.id }
     }
 }
 
@@ -114,6 +117,7 @@ extension TrashViewModel {
         do {
             try repository.allClear()
             items.removeAll()
+            setSelectionMode(.none)
         } catch {
             AppLogger.error(error)
             errorMessage = error.localizedDescription
@@ -124,17 +128,19 @@ extension TrashViewModel {
         do {
             try repository.delete(item: item)
             items.removeAll { $0.id == item.id }
+            setSelectionMode(.none)
         } catch {
             AppLogger.error(error)
             errorMessage = error.localizedDescription
         }
     }
 
-    private func delete(items deleteItems: [WasteBasketItem]) {
+    func delete(items deleteItems: [WasteBasketItem]) {
         do {
             try repository.deleteAll(items: deleteItems)
             let deleteIDs = Set(deleteItems.map(\.id))
             items.removeAll { deleteIDs.contains($0.id) }
+            setSelectionMode(.none)
         } catch {
             AppLogger.error(error)
             errorMessage = error.localizedDescription
@@ -149,6 +155,7 @@ extension TrashViewModel {
         do {
             try repository.restore(item: item)
             items.removeAll { $0.id == item.id }
+            setSelectionMode(.none)
         } catch {
             AppLogger.error(error)
             errorMessage = error.localizedDescription
@@ -160,9 +167,84 @@ extension TrashViewModel {
             try repository.restoreAll(items: restoreItems)
             let restoreIDs = Set(restoreItems.map(\.id))
             items.removeAll { restoreIDs.contains($0.id) }
+            setSelectionMode(.none)
         } catch {
             AppLogger.error(error)
             errorMessage = error.localizedDescription
         }
     }
 }
+
+#if DEBUG
+    extension TrashViewModel {
+        static func preview() -> TrashViewModel {
+            let previewData = PreviewData.make()
+            let viewModel = TrashViewModel(
+                repository: PreviewWasteBasketRepository(items: previewData.items)
+            )
+            viewModel.fetchItems()
+            return viewModel
+        }
+    }
+
+    private extension TrashViewModel {
+        struct PreviewData {
+            let items: [WasteBasketItem]
+
+            static func make(now: Date = .now) -> Self {
+                let items: [WasteBasketItem] = (0 ..< 10).map { index in
+                    if index.isMultiple(of: 2) {
+                        let createdOffset = TimeInterval((index + 2) * 43200) * -1
+                        let updatedOffset = TimeInterval((index + 1) * 21600) * -1
+
+                        return .voiceNote(
+                            obj: VoiceNote(
+                                title: "휴지통 메모 \(index + 1)",
+                                createdAt: now.addingTimeInterval(createdOffset),
+                                updatedAt: now.addingTimeInterval(updatedOffset),
+                                folderID: UUID(),
+                                voiceRecord: VoiceRecord(
+                                    createdAt: now.addingTimeInterval(createdOffset),
+                                    audioFilePath: "VoiceRecords/preview-\(index).m4a",
+                                    duration: Double(120 + index * 15)
+                                ),
+                                transcript: nil,
+                                summary: nil
+                            )
+                        )
+                    } else {
+                        let createdOffset = TimeInterval((index + 1) * 64800) * -1
+                        let deletedOffset = TimeInterval((index + 1) * 10800) * -1
+
+                        return .folder(
+                            obj: Folder(
+                                name: "휴지통 폴더 \(index + 1)",
+                                createdAt: now.addingTimeInterval(createdOffset),
+                                content: [],
+                                isDeletable: true,
+                                deletedAt: now.addingTimeInterval(deletedOffset)
+                            )
+                        )
+                    }
+                }
+                return PreviewData(items: items)
+            }
+        }
+
+        struct PreviewWasteBasketRepository: WasteBasketRepository {
+            let items: [WasteBasketItem]
+
+            func fetchAll() throws(FetchWasteBasketRepositoryError) -> [WasteBasketItem] {
+                items
+            }
+
+            func allClear() throws(DeleteWasteBasketRepositoryError) {}
+            func delete(item: WasteBasketItem) throws(DeleteWasteBasketRepositoryError) {}
+            func deleteAll(items: [WasteBasketItem]) throws(DeleteWasteBasketRepositoryError) {}
+            func moveToWasteBasket(item: WasteBasketItem) throws(MoveWasteBasketRepositoryError) {}
+            func moveAllToWasteBasket(items: [WasteBasketItem]) throws(MoveWasteBasketRepositoryError) {}
+            func restore(item: WasteBasketItem) throws(RestoreWasteBasketRepositoryError) {}
+            func restoreAll(items: [WasteBasketItem]) throws(RestoreWasteBasketRepositoryError) {}
+        }
+    }
+#endif

--- a/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
@@ -126,8 +126,8 @@ final class FolderDetailViewModelTests: XCTestCase {
         let sut = makeSUT()
 
         // 선택 모드이지만 아이템은 없는 상태
-        sut.viewModel.setSelectionMode(.single)
-        XCTAssertEqual(sut.viewModel.select, .single)
+        sut.viewModel.setSelectionMode(.multiple)
+        XCTAssertEqual(sut.viewModel.select, .multiple)
 
         // 아이템 없이 얼럿 오픈 시도
         sut.viewModel.openAlertView()
@@ -168,8 +168,8 @@ final class FolderDetailViewModelTests: XCTestCase {
         let voiceNote = VoiceNote.stub(title: "테스트 노트")
 
         // 선택 모드 켜기
-        sut.viewModel.setSelectionMode(.single)
-        XCTAssertEqual(sut.viewModel.select, .single)
+        sut.viewModel.setSelectionMode(.multiple)
+        XCTAssertEqual(sut.viewModel.select, .multiple)
 
         // 아이템 선택
         sut.viewModel.selectItem(voiceNote)

--- a/Presentation/Tests/Trash/TrashViewModelTests.swift
+++ b/Presentation/Tests/Trash/TrashViewModelTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @MainActor
 final class MockTrashCoordinatorDelegate: TrashCoordinatorDelegate {
     func presentFolderList(with: Receive, dismiss: ((String) -> Void)?) {}
-    
+
     var popCalled = false
     var pushedVoiceNote: VoiceNote?
     var pushedFolder: Folder?
@@ -198,7 +198,8 @@ final class TrashViewModelTests: XCTestCase {
         sut.mockRepo.verify()
         XCTAssertTrue(sut.viewModel.items.isEmpty, "복원 후 휴지통 목록에서 항목이 제거되어야 합니다.")
     }
-    func test_cancelRestoreItem_단일항목복원취소() async {
+
+    func test_cancelRestoreItem_단일항목복원취소() {
         // Given
         let sut = makeSUT()
         let item = WasteBasketItem.folder(obj: Folder(name: "복원취소용 폴더"))
@@ -213,7 +214,7 @@ final class TrashViewModelTests: XCTestCase {
         XCTAssertEqual(sut.viewModel.items.count, 1, "복원 취소 후 항목이 다시 휴지통에 추가되어야 합니다.")
     }
 
-    func test_cancelRestoreItems_복수항목복원취소() async {
+    func test_cancelRestoreItems_복수항목복원취소() {
         // Given
         let sut = makeSUT()
         let items = [

--- a/Presentation/Tests/Trash/TrashViewModelTests.swift
+++ b/Presentation/Tests/Trash/TrashViewModelTests.swift
@@ -4,18 +4,39 @@ import DomainTesting
 import XCTest
 
 @MainActor
+final class MockTrashCoordinatorDelegate: TrashCoordinatorDelegate {
+    func presentFolderList(with: Receive, dismiss: ((String) -> Void)?) {}
+    
+    var popCalled = false
+    var pushedVoiceNote: VoiceNote?
+    var pushedFolder: Folder?
+
+    func pop() {
+        popCalled = true
+    }
+
+    func pushVoiceNoteView(voiceNote: VoiceNote) {
+        pushedVoiceNote = voiceNote
+    }
+
+    func pushMyFolderDetailView(_ folder: Folder) {
+        pushedFolder = folder
+    }
+}
+
+@MainActor
 final class TrashViewModelTests: XCTestCase {
     // MARK: - SUT
 
     private struct SUT {
         let viewModel: TrashViewModel
         let mockRepo: MockWasteBasketRepository // Use single repo for all DefaultUseCases
-        let mockCoordinator: MockBaseCoordinatorDelegate
+        let mockCoordinator: MockTrashCoordinatorDelegate
     }
 
     private func makeSUT() -> SUT {
         let mockRepo = MockWasteBasketRepository()
-        let mockCoordinator = MockBaseCoordinatorDelegate()
+        let mockCoordinator = MockTrashCoordinatorDelegate()
 
         let viewModel = TrashViewModel(
             repository: mockRepo
@@ -38,69 +59,19 @@ final class TrashViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(sut.viewModel.items.isEmpty, "초기 항목 배열은 비어있어야 합니다.")
         XCTAssertNil(sut.viewModel.errorMessage, "초기 에러 메시지는 없어야 합니다.")
-        XCTAssertEqual(sut.viewModel.selectedOrder, .createdAt, "기본 정렬 순서는 생성일(.createdAt)이어야 합니다.")
-        XCTAssertFalse(sut.viewModel.isSelectionMode, "초기 선택 모드는 false여야 합니다.")
-        XCTAssertTrue(sut.viewModel.selectedItems.isEmpty, "선택된 아이템 초기 배열은 비어있어야 합니다.")
-        XCTAssertFalse(sut.viewModel.showAlert, "초기 경고창 상태는 false여야 합니다.")
-        XCTAssertTrue(sut.viewModel.isEmpty, "초기 isEmpty 속성은 true여야 합니다.")
+        XCTAssertFalse(sut.viewModel.showTrashAlert, "초기 경고창 상태는 false여야 합니다.")
     }
 
-    // MARK: - Action Tests
-
-    func test_toggleSelectionMode_토글확인_및_선택아이템초기화() {
+    func test_openTrashAlert_상태변경() {
         // Given
         let sut = makeSUT()
-        let dummyItem = WasteBasketItem.folder(
-            obj: Folder(name: "테스트 폴더", createdAt: Date().addingTimeInterval(-86400 * 5))
-        )
-        sut.mockRepo.setDeleteResult(.success(()))
-        sut.viewModel.toggleSelectionMode() // isSelectionMode = true
-        XCTAssertTrue(sut.viewModel.isSelectionMode, "토글 후 true가 되어야 합니다.")
-
-        sut.viewModel.selectItem(dummyItem)
-        XCTAssertEqual(sut.viewModel.selectedItems.count, 1, "선택 시 배열에 추가되어야 합니다.")
+        XCTAssertFalse(sut.viewModel.showTrashAlert)
 
         // When
-        sut.viewModel.toggleSelectionMode() // isSelectionMode = false
+        sut.viewModel.openTrashAlert()
 
         // Then
-        XCTAssertFalse(sut.viewModel.isSelectionMode, "다시 토글 후 false가 되어야 합니다.")
-        XCTAssertTrue(sut.viewModel.selectedItems.isEmpty, "선택 모드 해제 시 선택된 아이템 배열이 초기화되어야 합니다.")
-    }
-
-    func test_touchCreatedAction_정렬방식변경() {
-        // Given
-        let sut = makeSUT()
-        sut.viewModel.touchUpdatedAction() // 일단 강제로 수정일 순으로 변경
-
-        // When
-        sut.viewModel.touchCreatedAction()
-
-        // Then
-        XCTAssertEqual(sut.viewModel.selectedOrder, .createdAt, "선택된 정렬 방식이 생성일(.createdAt) 순이어야 합니다.")
-    }
-
-    func test_touchUpdatedAction_정렬방식변경() {
-        // Given
-        let sut = makeSUT()
-
-        // When
-        sut.viewModel.touchUpdatedAction()
-
-        // Then
-        XCTAssertEqual(sut.viewModel.selectedOrder, .updatedAt, "선택된 정렬 방식이 수정일(.updatedAt) 순이어야 합니다.")
-    }
-
-    func test_toggleShowAlert_상태토글() {
-        // Given
-        let sut = makeSUT()
-        XCTAssertFalse(sut.viewModel.showAlert)
-
-        // When
-        sut.viewModel.toggleShowAlert()
-
-        // Then
-        XCTAssertTrue(sut.viewModel.showAlert, "알럿 상태가 true가 되어야 합니다.")
+        XCTAssertTrue(sut.viewModel.showTrashAlert, "알럿 상태가 true가 되어야 합니다.")
     }
 
     func test_didTapBack_코디네이터pop호출() {
@@ -139,6 +110,28 @@ final class TrashViewModelTests: XCTestCase {
         // Then
         sut.mockRepo.verify()
         XCTAssertEqual(sut.viewModel.items.count, 2, "2개의 항목을 정상적으로 불러와야 합니다.")
+    }
+
+    func test_fetchItems_정렬_확인() async {
+        // Given
+        let sut = makeSUT()
+        let now = Date()
+        let items: [WasteBasketItem] = [
+            .folder(obj: Folder(name: "오래된 삭제", deletedAt: now.addingTimeInterval(-1000))),
+            .folder(obj: Folder(name: "최근 삭제", deletedAt: now)),
+            .folder(obj: Folder(name: "중간 삭제", deletedAt: now.addingTimeInterval(-500)))
+        ]
+        sut.mockRepo.setFetchAllResult(.success(items))
+
+        // When
+        sut.viewModel.fetchItems()
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        // Then
+        XCTAssertEqual(sut.viewModel.items.count, 3)
+        XCTAssertEqual(sut.viewModel.items[0].deletedAt, now, "가장 최근 삭제된 항목이 첫 번째여야 합니다.")
+        XCTAssertEqual(sut.viewModel.items[1].deletedAt, now.addingTimeInterval(-500))
+        XCTAssertEqual(sut.viewModel.items[2].deletedAt, now.addingTimeInterval(-1000), "가장 오래된 삭제된 항목이 마지막이어야 합니다.")
     }
 
     // MARK: - Delete & Restore Tests
@@ -204,5 +197,41 @@ final class TrashViewModelTests: XCTestCase {
         // Then
         sut.mockRepo.verify()
         XCTAssertTrue(sut.viewModel.items.isEmpty, "복원 후 휴지통 목록에서 항목이 제거되어야 합니다.")
+    }
+    func test_cancelRestoreItem_단일항목복원취소() async {
+        // Given
+        let sut = makeSUT()
+        let item = WasteBasketItem.folder(obj: Folder(name: "복원취소용 폴더"))
+        sut.mockRepo.setMoveResult(.success(()))
+        sut.mockRepo.expectMoveToWasteBasket(item: item, callCount: 1)
+
+        // When
+        sut.viewModel.cancelRestore(item: item)
+
+        // Then
+        sut.mockRepo.verify()
+        XCTAssertEqual(sut.viewModel.items.count, 1, "복원 취소 후 항목이 다시 휴지통에 추가되어야 합니다.")
+    }
+
+    func test_cancelRestoreItems_복수항목복원취소() async {
+        // Given
+        let sut = makeSUT()
+        let items = [
+            WasteBasketItem.folder(obj: Folder(name: "복원취소용 폴더 1")),
+            WasteBasketItem.voiceNote(obj: VoiceNote(
+                title: "복원취소용 노트 1",
+                folderID: UUID(),
+                voiceRecord: VoiceRecord(audioFilePath: "test.m4a", duration: 10)
+            ))
+        ]
+        sut.mockRepo.setMoveResult(.success(()))
+        sut.mockRepo.expectMoveAllToWasteBasket(items: items, callCount: 1)
+
+        // When
+        sut.viewModel.cancelRestore(items: items)
+
+        // Then
+        sut.mockRepo.verify()
+        XCTAssertEqual(sut.viewModel.items.count, 2, "복원 취소 후 모든 항목이 다시 휴지통에 추가되어야 합니다.")
     }
 }


### PR DESCRIPTION
---

## ✨ 작업 요약
> 휴지통 UX 전면 리팩토링 및 폴더/삭제 항목 선택 기능 공용화

## 📋 구체적인 내용
- **휴지통 UI/UX 개선**:
  - 완전히 독립된 휴지통 전담 Cell(`TrashCell`)을 정의하여 휴지통만의 UI 레이아웃 적용
  - 삭제 및 복원 시 하단 Toast 알림을 통해 상태 피드백 제공
  - **복원 취소(Undo)** 기능 추가: 복원 완료 Toast의 액션 버튼을 통해 복원된 항목을 다시 휴지통으로 되돌리는 기능 구현
  - 휴지통 내 전체 비우기 시 영구 삭제 확인 Alert 추가
- **선택 모드(`SelectionMode`) 강화**:
  - `single`, `multiple` 등으로 분산되어 있던 선택 상태를 `SelectionMode` 공용 Enum으로 통합하여 `Trash`, `FolderDetail`에서 상호 운용 가능하도록 개선
  - **전체 선택하기** 기능 추가 및 선택 아이템 유무에 따른 자동 모드 전환 로직 적용
  - 폴더 셀(`FolderCardView`)에도 선택 모드 UI 대응 및 메인/폴더 뷰 연동
- **데이터 정렬 및 관리**:
  - 휴지통 아이템을 삭제일(`deletedAt`) 기준 내림차순(최신순)으로 자동 정렬하도록 수정
  - `LibraryItem` 모델에 `deletedAt` 연산 프로퍼티 추가
- **테스트 코드 업데이트**:
  - 변경된 ViewModel API 및 Coordinator Delegate 구조에 맞춰 `TrashViewModelTests`, `FolderViewModelTests`, `MainViewModelTests` 동기화 및 신규 기능(복원 취소 등) 검증 케이스 추가

---

## 🔗 연관 이슈

- closed #219

---

## 🧩 설계·구현 노트

- **선택한 방식: 독립된 TrashCell 정의**
  - 기존 `VoiceNoteCardView`를 재사용할 경우 휴지통 특유의 UI 요구사항(삭제일 표시 등) 대응 시 조건문이 복잡해지는 문제가 있어, 휴지통 전용 Cell을 만들어 유지보수성을 높였습니다.
- **선택한 방식: SelectionMode 공용화**
  - 휴지통과 폴더 상세 뷰에서 공통적으로 사용하는 '선택 후 삭제/이동' 로직의 파편화를 방지하기 위해 단일 Enum으로 관리하여 UX 일관성을 확보했습니다.

---

## ✅ 확인 사항
- [x] 휴지통 아이템 삭제/복원 및 복원 취소(Undo) 정상 동작 확인
- [x] 전체 선택 및 전체 비우기 플로우 확인
- [x] `deletedAt` 기준 정렬 정상 여부 확인
- [x] 폴더 선택 모드 진입 및 UI 변경 확인
- [x] 관련 유닛 테스트(`presentationTests`) 전체 통과 확인

---

## 👀 리뷰 포인트

- [x] **설계·구조**: `SelectionMode` 공용화에 따른 각 ViewController/ViewModel 간의 의존성 전파가 적절한가
- [x] **로직**: 복원 취소 시 `WasteBasketRepository`의 데이터 이동 로직이 안전하게 처리되었는가
- [x] **UI/UX**: Toast 메시지와 Alert의 노출 타이밍 및 텍스트 문구가 사용자 경험에 적합한가

**특히 봐줬으면 하는 부분**

- `TrashViewModel`에서 `fetchItems` 시 `deletedAt`으로 정렬하는 로직과, 복원 취소(`cancelRestore`) 시 다시 Repository에 데이터를 집어넣는 흐름을 중점적으로 봐주시면 감사하겠습니다.

---

## 📚 참고

- 기존 피그마 디자인 가이드의 휴지통 UX 변경안 준수 
- `NavigationItemButton` 도입을 통한 네비게이션 바 버튼 상태 관리 최적화 내역 포함