### PR TITLE
보이스 노트 재생 영역 위에 페이드 그래디언트를 적용합니다.

### DIFF
--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteBottomFadeView.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteBottomFadeView.swift
@@ -1,0 +1,59 @@
+import UIKit
+
+final class VoiceNoteBottomFadeView: UIView {
+    private let gradientLayer = CAGradientLayer()
+
+    init() {
+        super.init(frame: .zero)
+
+        translatesAutoresizingMaskIntoConstraints = false
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+        gradientLayer.colors = [
+            UIColor.gray0.withAlphaComponent(0).cgColor,
+            UIColor.gray0.cgColor
+        ]
+        layer.addSublayer(gradientLayer)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer.frame = bounds
+    }
+}
+
+#Preview {
+    let container = UIView()
+    container.backgroundColor = .gray0
+
+    let content = UILabel()
+    content.text = Array(repeating: "컨텐츠 컨텐츠 컨텐츠 컨텐츠 컨텐츠", count: 8).joined(separator: "\n")
+    content.numberOfLines = 0
+    content.textColor = .gray950
+    content.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(content)
+
+    let fade = VoiceNoteBottomFadeView()
+    container.addSubview(fade)
+
+    NSLayoutConstraint.activate([
+        content.topAnchor.constraint(equalTo: container.topAnchor, constant: 20),
+        content.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 20),
+        content.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -20),
+
+        fade.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+        fade.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        fade.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        fade.heightAnchor.constraint(equalToConstant: 80)
+    ])
+
+    return container
+}

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -12,6 +12,7 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
     private let titleContainerView = NavigationTitleContainerView()
     private let playerView = AudioPlayerView()
     private let segmentedControl = UnderlineSegmentedControl(items: Page.allCases.map(\.title))
+    private let bottomFadeView = VoiceNoteBottomFadeView()
 
     private let backItem = UIBarButtonItem(image: .chevronLeft)
     private let editCancelItem = UIBarButtonItem(image: .cornerUpLeft)
@@ -71,6 +72,7 @@ private extension VoiceNoteViewController {
         pageViewController.setViewControllers([pages[0]], direction: .forward, animated: false)
 
         view.addSubview(pageViewController.view)
+        view.addSubview(bottomFadeView)
         view.addSubview(playerView)
         view.addSubview(segmentedControl)
 
@@ -97,6 +99,11 @@ private extension VoiceNoteViewController {
             segmentedControl.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             segmentedControl.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             segmentedControl.heightAnchor.constraint(equalToConstant: 42),
+
+            bottomFadeView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bottomFadeView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bottomFadeView.bottomAnchor.constraint(equalTo: playerView.topAnchor),
+            bottomFadeView.heightAnchor.constraint(equalToConstant: 169),
 
             playerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             playerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),


### PR DESCRIPTION
## ✨ 작업 요약
> 보이스 노트 상세 화면 스크롤 컨텐츠와 하단 재생 영역 사이에 페이드 그래디언트 오버레이를 추가합니다.

- 재사용 없이 현 화면 전용으로 `VoiceNoteBottomFadeView` 컴포넌트 신규 작성
- `VoiceNoteViewController`에 오버레이로 배치하여 컨텐츠가 재생 영역과 닿는 경계를 자연스럽게 페이드아웃

## 📋 구체적인 내용
- 추가/변경된 동작:
  - 요약·스크립트 탭 모두에서 스크롤 컨텐츠가 `AudioPlayerView` 상단에 닿는 부분이 `gray0` 색으로 페이드
  - 오버레이는 터치 이벤트를 통과시켜 스크롤·셀 탭 동작에 영향 없음
- 영향 받는 화면/모듈:
  - Presentation: `VoiceNoteViewController` (추가 subview 1개)
  - Presentation/Component: `VoiceNoteBottomFadeView` 신규

---

## 🔗 연관 이슈

- closed #228

---

## 🧩 설계·구현 노트

- **선택한 방식**
  - `UIView` + `CAGradientLayer` sublayer — Auto Layout으로 배치하기 위해 UIView 래퍼 유지, `layoutSubviews`에서 layer frame 갱신
  - 색상은 `UIColor.gray0` 하드코딩 — 앱이 다크 모드 고정(`public let style = "Dark"`)이고 `gray0` colorset이 라이트/다크 동일 값이라 dynamic color 대응 코드 생략
  - `init` 인자 없음 — 현재 단일 사용처이므로 색상/방향 주입 생략, 향후 재사용 필요 시점에 확장
- **고려했다가 제외한 방식**
  - `CAGradientLayer` 서브클래스 — 레이어 계층이 한 단계 줄지만 사용처에서 frame 관리·레이어 추가 부담. 일관성 위해 제외
  - `UIView + layerClass` 오버라이드 — sublayer 중복 제거 가능하나 `as!` force cast 관용구가 필요해 제외
  - `registerForTraitChanges` 등록 — 다크/라이트 전환이 없어 불필요

---

## ✅ 확인 사항

- [ ] 요약 탭: 하단 컨텐츠가 재생 영역과 닿는 부분 자연스럽게 페이드
- [ ] 스크립트 탭: 동일하게 페이드 적용
- [ ] 스크롤/셀 탭 인터랙션: 오버레이 영역에서도 정상 동작 (터치 패스스루 확인)
- [ ] `AudioPlayerView` 상단 경계 시각적 분리 개선 확인
- [x] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [ ] (로직 추가 시) 테스트 추가 여부 — 단순 렌더링 컴포넌트로 단위 테스트 생략

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [x] UI/UX
- [ ] 성능·의존성

**특히 봐줬으면 하는 부분**

- `VoiceNoteBottomFadeView` 위치(`Component/VoiceNote/`)와 전용성 판단 — 재사용 고려해서 `Common/`으로 올릴지 여부
- 오버레이 높이(현재 `169pt`) 및 배치 제약이 디자인 의도에 맞는지
- `UIColor.gray0` 하드코딩과 dynamic color 대응 생략의 판단