### PR TITLE
검색 모드 매치 바를 키보드 위/하단에 고정하고 Summary 포커스 하이라이트를 추가합니다.

### DIFF
--- a/Presentation/Sources/Component/VoiceNote/KeywordChipLabel.swift
+++ b/Presentation/Sources/Component/VoiceNote/KeywordChipLabel.swift
@@ -21,7 +21,13 @@ public final class KeywordChipLabel: TypographyLabel {
 
     /// 텍스트 내 `query`에 일치하는 모든 범위에 형광펜 스타일의 배경 하이라이트를 적용합니다.
     /// `query`가 비어 있으면 기본 타이포그래피로 복원됩니다.
-    public func applyHighlight(query: String, highlightBackgroundColor: UIColor) {
+    /// `focusedRange`가 지정되면 해당 범위는 `focusedHighlightBackgroundColor`로 덮어씌웁니다.
+    public func applyHighlight(
+        query: String,
+        highlightBackgroundColor: UIColor,
+        focusedRange: NSRange? = nil,
+        focusedHighlightBackgroundColor: UIColor? = nil
+    ) {
         guard !query.isEmpty else {
             text = baseText
             return
@@ -29,7 +35,9 @@ public final class KeywordChipLabel: TypographyLabel {
         attributedText = baseText.highlighted(
             query: query,
             baseAttributes: typography.textAttributes,
-            highlightBackgroundColor: highlightBackgroundColor
+            highlightBackgroundColor: highlightBackgroundColor,
+            focusedRange: focusedRange,
+            focusedHighlightBackgroundColor: focusedHighlightBackgroundColor
         )
     }
 

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteMatchAccessoryBar.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteMatchAccessoryBar.swift
@@ -71,7 +71,7 @@ public final class VoiceNoteMatchAccessoryBar: UIView {
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: 12),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12)
+            stackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -12)
         ])
     }
 

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteMatchAccessoryBar.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteMatchAccessoryBar.swift
@@ -6,7 +6,6 @@ public final class VoiceNoteMatchAccessoryBar: UIView {
 
     private let countLabel: TypographyLabel = {
         let label = TypographyLabel(typography: .title3)
-        label.text = "1 / 2"
         label.textColor = .gray950
         label.textAlignment = .center
         return label

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteMatchAccessoryBar.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteMatchAccessoryBar.swift
@@ -34,8 +34,7 @@ public final class VoiceNoteMatchAccessoryBar: UIView {
     }()
 
     public init() {
-        super.init(frame: CGRect(x: 0, y: 0, width: 0, height: 48))
-        autoresizingMask = [.flexibleWidth]
+        super.init(frame: .zero)
         backgroundColor = .gray200
         setupUI()
         setupActions()
@@ -70,7 +69,7 @@ public final class VoiceNoteMatchAccessoryBar: UIView {
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: 12),
-            stackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -12)
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12)
         ])
     }
 

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteMatchAccessoryBar.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteMatchAccessoryBar.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public final class VoiceNoteMatchAccessoryBar: UIView {
+public final class VoiceNoteMatchAccessoryBar: UIVisualEffectView {
     public var onPrev: (() -> Void)?
     public var onNext: (() -> Void)?
 
@@ -34,8 +34,11 @@ public final class VoiceNoteMatchAccessoryBar: UIView {
     }()
 
     public init() {
-        super.init(frame: .zero)
-        backgroundColor = .gray200
+        let effect = UIGlassEffect(style: .regular)
+        effect.tintColor = .gray200.withAlphaComponent(0.2)
+        super.init(effect: effect)
+        clipsToBounds = true
+        layer.cornerRadius = 20
         setupUI()
         setupActions()
         configure(countText: "0 / 0", hasMatches: false)
@@ -64,12 +67,12 @@ public final class VoiceNoteMatchAccessoryBar: UIView {
         }
 
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(stackView)
+        contentView.addSubview(stackView)
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
-            stackView.topAnchor.constraint(equalTo: topAnchor, constant: 12),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12)
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12)
         ])
     }
 

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteSearchBar.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteSearchBar.swift
@@ -3,7 +3,6 @@ import UIKit
 public final class VoiceNoteSearchBar: UIView {
     public var onClose: (() -> Void)?
     public var onReturn: ((String) -> Void)?
-    public var onEditingEnded: (() -> Void)?
 
     private let searchContainer: UIVisualEffectView = {
         let effect = UIGlassEffect(style: .clear)
@@ -77,10 +76,6 @@ public final class VoiceNoteSearchBar: UIView {
         textField.text = query
     }
 
-    public func setFieldInputAccessoryView(_ view: UIView?) {
-        textField.inputAccessoryView = view
-    }
-
     // MARK: - Setup
 
     private func setupUI() {
@@ -127,10 +122,6 @@ public final class VoiceNoteSearchBar: UIView {
             guard let self else { return }
             onReturn?(textField.text ?? "")
         }, for: .editingDidEndOnExit)
-
-        textField.addAction(UIAction { [weak self] _ in
-            self?.onEditingEnded?()
-        }, for: .editingDidEnd)
 
         closeButton.addAction(UIAction { [weak self] _ in
             self?.onClose?()

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteSearchBar.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteSearchBar.swift
@@ -3,10 +3,7 @@ import UIKit
 public final class VoiceNoteSearchBar: UIView {
     public var onClose: (() -> Void)?
     public var onReturn: ((String) -> Void)?
-    public var onMatchPrev: (() -> Void)?
-    public var onMatchNext: (() -> Void)?
-
-    private let matchAccessoryBar = VoiceNoteMatchAccessoryBar()
+    public var onEditingEnded: (() -> Void)?
 
     private let searchContainer: UIVisualEffectView = {
         let effect = UIGlassEffect(style: .clear)
@@ -55,9 +52,6 @@ public final class VoiceNoteSearchBar: UIView {
         super.init(frame: .zero)
         setupUI()
         setupActions()
-        textField.inputAccessoryView = matchAccessoryBar
-        matchAccessoryBar.onPrev = { [weak self] in self?.onMatchPrev?() }
-        matchAccessoryBar.onNext = { [weak self] in self?.onMatchNext?() }
     }
 
     @available(*, unavailable)
@@ -83,8 +77,8 @@ public final class VoiceNoteSearchBar: UIView {
         textField.text = query
     }
 
-    public func configureMatch(countText: String, hasMatches: Bool) {
-        matchAccessoryBar.configure(countText: countText, hasMatches: hasMatches)
+    public func setFieldInputAccessoryView(_ view: UIView?) {
+        textField.inputAccessoryView = view
     }
 
     // MARK: - Setup
@@ -133,6 +127,10 @@ public final class VoiceNoteSearchBar: UIView {
             guard let self else { return }
             onReturn?(textField.text ?? "")
         }, for: .editingDidEndOnExit)
+
+        textField.addAction(UIAction { [weak self] _ in
+            self?.onEditingEnded?()
+        }, for: .editingDidEnd)
 
         closeButton.addAction(UIAction { [weak self] _ in
             self?.onClose?()

--- a/Presentation/Sources/View/VoiceNote/Cells/KeyPointCell.swift
+++ b/Presentation/Sources/View/VoiceNote/Cells/KeyPointCell.swift
@@ -6,6 +6,7 @@ struct KeyPointContentConfiguration: UIContentConfiguration {
     var number: Int = 0
     var text: String = ""
     var searchQuery: String = ""
+    var currentMatchRange: NSRange?
 
     func makeContentView() -> UIView & UIContentView {
         KeyPointContentView(configuration: self)
@@ -103,7 +104,9 @@ final class KeyPointContentView: UIView, UIContentView {
             textLabel.attributedText = config.text.highlighted(
                 query: config.searchQuery,
                 baseAttributes: Typography.body1.textAttributes,
-                highlightBackgroundColor: UIColor.point700
+                highlightBackgroundColor: UIColor.point700,
+                focusedRange: config.currentMatchRange,
+                focusedHighlightBackgroundColor: .systemRed
             )
         }
     }

--- a/Presentation/Sources/View/VoiceNote/Cells/KeywordsCell.swift
+++ b/Presentation/Sources/View/VoiceNote/Cells/KeywordsCell.swift
@@ -3,6 +3,8 @@ import UIKit
 struct KeywordsContentConfiguration: UIContentConfiguration {
     var keywords: [String] = []
     var searchQuery: String = ""
+    var focusedKeywordIndex: Int?
+    var focusedRange: NSRange?
 
     func makeContentView() -> UIView & UIContentView {
         KeywordsContentView(configuration: self)
@@ -46,9 +48,15 @@ final class KeywordsContentView: UIView, UIContentView {
         guard let config = configuration as? KeywordsContentConfiguration else { return }
 
         chipLabels.forEach { $0.removeFromSuperview() }
-        chipLabels = config.keywords.map { keyword in
+        chipLabels = config.keywords.enumerated().map { index, keyword in
             let chip = KeywordChipLabel(text: keyword)
-            chip.applyHighlight(query: config.searchQuery, highlightBackgroundColor: UIColor.point700)
+            let focusedRange = index == config.focusedKeywordIndex ? config.focusedRange : nil
+            chip.applyHighlight(
+                query: config.searchQuery,
+                highlightBackgroundColor: UIColor.point700,
+                focusedRange: focusedRange,
+                focusedHighlightBackgroundColor: .systemRed
+            )
             return chip
         }
         chipLabels.forEach(addSubview)

--- a/Presentation/Sources/View/VoiceNote/Cells/ScriptCell.swift
+++ b/Presentation/Sources/View/VoiceNote/Cells/ScriptCell.swift
@@ -109,7 +109,7 @@ final class ScriptContentView: UIView, UIContentView {
                 baseAttributes: baseTextAttributes,
                 highlightBackgroundColor: UIColor.point700,
                 focusedRange: config.currentMatchRange,
-                focusedHighlightBackgroundColor: UIColor.point800
+                focusedHighlightBackgroundColor: .systemRed
             )
         }
     }

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteScriptViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteScriptViewController.swift
@@ -282,7 +282,7 @@ private extension UIView {
 
 extension VoiceNoteScriptViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        viewModel.editingMode != .script
+        viewModel.editingMode != .script && !viewModel.searchMode
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteSummaryViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteSummaryViewController.swift
@@ -31,6 +31,7 @@ final class VoiceNoteSummaryViewController: UIViewController {
         applySnapshot()
         observeAnalysisState()
         observeSearchQuery()
+        observeCurrentMatch()
     }
 
     /// 지정한 매치 위치로 컬렉션을 스크롤합니다.
@@ -118,19 +119,37 @@ private extension VoiceNoteSummaryViewController {
         }
 
         let keyPointCellReg = UICollectionView
-            .CellRegistration<UICollectionViewCell, Item> { [weak self] cell, _, item in
+            .CellRegistration<UICollectionViewCell, Item> { [weak self] cell, indexPath, item in
                 guard case .keyPoint(let number, let text) = item else { return }
+                let focusedRange: NSRange? = {
+                    guard let match = self?.viewModel.currentMatch,
+                          case .keyPoint(let idx) = match.location,
+                          idx == indexPath.item else { return nil }
+                    return match.range
+                }()
                 cell.contentConfiguration = KeyPointContentConfiguration(
                     number: number,
                     text: text,
-                    searchQuery: self?.viewModel.searchQuery ?? ""
+                    searchQuery: self?.viewModel.searchQuery ?? "",
+                    currentMatchRange: focusedRange
                 )
             }
 
         let keywordsCellReg = UICollectionView.CellRegistration<UICollectionViewCell, Item> { [weak self] cell, _, _ in
+            let focusedKeywordIndex: Int?
+            let focusedRange: NSRange?
+            if let match = self?.viewModel.currentMatch, case .keyword(let idx) = match.location {
+                focusedKeywordIndex = idx
+                focusedRange = match.range
+            } else {
+                focusedKeywordIndex = nil
+                focusedRange = nil
+            }
             cell.contentConfiguration = KeywordsContentConfiguration(
                 keywords: self?.viewModel.keywords ?? [],
-                searchQuery: self?.viewModel.searchQuery ?? ""
+                searchQuery: self?.viewModel.searchQuery ?? "",
+                focusedKeywordIndex: focusedKeywordIndex,
+                focusedRange: focusedRange
             )
         }
 
@@ -235,6 +254,19 @@ private extension VoiceNoteSummaryViewController {
             Task { @MainActor in
                 self.reconfigureForSearch()
                 self.observeSearchQuery()
+            }
+        }
+    }
+
+    func observeCurrentMatch() {
+        withObservationTracking {
+            _ = viewModel.currentMatchIndex
+            _ = viewModel.currentPage
+        } onChange: { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                self.reconfigureForSearch()
+                self.observeCurrentMatch()
             }
         }
     }

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -135,9 +135,9 @@ private extension VoiceNoteViewController {
             dimOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             dimOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
-            matchAccessoryBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            matchAccessoryBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            matchAccessoryBar.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor)
+            matchAccessoryBar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            matchAccessoryBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            matchAccessoryBar.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor, constant: -8)
         ])
     }
 

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -17,6 +17,8 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
     private let matchAccessoryBar = VoiceNoteMatchAccessoryBar()
 
     private var searchModeLastApplied = false
+    private var bottomFadeToPlayerTop: NSLayoutConstraint?
+    private var bottomFadeToViewBottom: NSLayoutConstraint?
     private let dimOverlayView: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor.dimBackground
@@ -123,7 +125,6 @@ private extension VoiceNoteViewController {
 
             bottomFadeView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomFadeView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            bottomFadeView.bottomAnchor.constraint(equalTo: playerView.topAnchor),
             bottomFadeView.heightAnchor.constraint(equalToConstant: 169),
 
             playerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
@@ -139,6 +140,10 @@ private extension VoiceNoteViewController {
             matchAccessoryBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
             matchAccessoryBar.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor, constant: -8)
         ])
+
+        bottomFadeToPlayerTop = bottomFadeView.bottomAnchor.constraint(equalTo: playerView.topAnchor)
+        bottomFadeToViewBottom = bottomFadeView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        bottomFadeToPlayerTop?.isActive = true
     }
 
     func setupDimOverlay() {
@@ -445,6 +450,8 @@ private extension VoiceNoteViewController {
         if didToggle {
             playerView.isHidden = isSearching
             matchAccessoryBar.isHidden = !isSearching
+            bottomFadeToPlayerTop?.isActive = !isSearching
+            bottomFadeToViewBottom?.isActive = isSearching
             if isSearching {
                 searchBar.becomeFirstResponder()
             } else {

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -73,7 +73,10 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
 
     // MARK: - Responder
 
-    override public var canBecomeFirstResponder: Bool { viewModel.searchMode }
+    override public var canBecomeFirstResponder: Bool {
+        viewModel.searchMode
+    }
+
     override public var inputAccessoryView: UIView? {
         viewModel.searchMode ? matchAccessoryBar : nil
     }
@@ -301,7 +304,8 @@ private extension VoiceNoteViewController {
         let target = pages[page.rawValue]
         if let current = pageViewController.viewControllers?.first,
            let currentIndex = pages.firstIndex(of: current),
-           current !== target {
+           current !== target
+        {
             let direction: UIPageViewController.NavigationDirection = page.rawValue > currentIndex ? .forward : .reverse
             pageViewController.setViewControllers([target], direction: direction, animated: true)
         }

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -70,16 +70,6 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
         super.viewWillDisappear(animated)
         viewModel.onDisappear()
     }
-
-    // MARK: - Responder
-
-    override public var canBecomeFirstResponder: Bool {
-        viewModel.searchMode
-    }
-
-    override public var inputAccessoryView: UIView? {
-        viewModel.searchMode ? matchAccessoryBar : nil
-    }
 }
 
 // MARK: - Setup
@@ -88,15 +78,16 @@ private extension VoiceNoteViewController {
     func setupUI() {
         view.backgroundColor = UIColor.gray0
 
-        addChild(pageViewController)
-        pageViewController.setViewControllers([pages[0]], direction: .forward, animated: false)
-
         view.addSubview(pageViewController.view)
         view.addSubview(bottomFadeView)
         view.addSubview(playerView)
         view.addSubview(segmentedControl)
         view.addSubview(dimOverlayView)
+        view.addSubview(matchAccessoryBar)
+        matchAccessoryBar.isHidden = true
 
+        addChild(pageViewController)
+        pageViewController.setViewControllers([pages[0]], direction: .forward, animated: false)
         pageViewController.didMove(toParent: self)
 
         setupConstraints()
@@ -108,7 +99,14 @@ private extension VoiceNoteViewController {
     }
 
     func setupConstraints() {
-        for subview in [pageViewController.view, playerView, segmentedControl, bottomFadeView, dimOverlayView] {
+        for subview in [
+            pageViewController.view,
+            playerView,
+            segmentedControl,
+            bottomFadeView,
+            dimOverlayView,
+            matchAccessoryBar
+        ] {
             subview?.translatesAutoresizingMaskIntoConstraints = false
         }
 
@@ -135,7 +133,11 @@ private extension VoiceNoteViewController {
             dimOverlayView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             dimOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             dimOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            dimOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            dimOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            matchAccessoryBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            matchAccessoryBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            matchAccessoryBar.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor)
         ])
     }
 
@@ -226,17 +228,11 @@ private extension VoiceNoteViewController {
     }
 
     func setupSearchBar() {
-        searchBar.setFieldInputAccessoryView(matchAccessoryBar)
         searchBar.onReturn = { [weak self] query in
             self?.viewModel.updateSearchQuery(query)
         }
         searchBar.onClose = { [weak self] in
             self?.viewModel.exitSearchMode()
-        }
-        searchBar.onEditingEnded = { [weak self] in
-            guard let self, viewModel.searchMode else { return }
-            becomeFirstResponder()
-            reloadInputViews()
         }
         matchAccessoryBar.onPrev = { [weak self] in
             self?.viewModel.previousMatch()
@@ -448,15 +444,12 @@ private extension VoiceNoteViewController {
 
         if didToggle {
             playerView.isHidden = isSearching
+            matchAccessoryBar.isHidden = !isSearching
             if isSearching {
-                becomeFirstResponder()
-                reloadInputViews()
                 searchBar.becomeFirstResponder()
             } else {
                 searchBar.setQuery("")
                 searchBar.resignFirstResponder()
-                resignFirstResponder()
-                reloadInputViews()
             }
         }
 

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -299,12 +299,12 @@ private extension VoiceNoteViewController {
         segmentedControl.selectSegment(index: page.rawValue)
 
         let target = pages[page.rawValue]
-        guard let current = pageViewController.viewControllers?.first,
-              let currentIndex = pages.firstIndex(of: current),
-              current !== target else { return }
-
-        let direction: UIPageViewController.NavigationDirection = page.rawValue > currentIndex ? .forward : .reverse
-        pageViewController.setViewControllers([target], direction: direction, animated: true)
+        if let current = pageViewController.viewControllers?.first,
+           let currentIndex = pages.firstIndex(of: current),
+           current !== target {
+            let direction: UIPageViewController.NavigationDirection = page.rawValue > currentIndex ? .forward : .reverse
+            pageViewController.setViewControllers([target], direction: direction, animated: true)
+        }
 
         if viewModel.searchMode {
             applySearchState()

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -137,7 +137,10 @@ private extension VoiceNoteViewController {
             dimOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
             matchAccessoryBar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            matchAccessoryBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            matchAccessoryBar.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+                constant: -20
+            ),
             matchAccessoryBar.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor, constant: -8)
         ])
 

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -14,6 +14,7 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
     private let segmentedControl = UnderlineSegmentedControl(items: Page.allCases.map(\.title))
     private let bottomFadeView = VoiceNoteBottomFadeView()
     private let searchBar = VoiceNoteSearchBar()
+    private let matchAccessoryBar = VoiceNoteMatchAccessoryBar()
 
     private var searchModeLastApplied = false
     private let dimOverlayView: UIView = {
@@ -68,6 +69,13 @@ public final class VoiceNoteViewController: UIViewController, Alertable {
     override public func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         viewModel.onDisappear()
+    }
+
+    // MARK: - Responder
+
+    override public var canBecomeFirstResponder: Bool { viewModel.searchMode }
+    override public var inputAccessoryView: UIView? {
+        viewModel.searchMode ? matchAccessoryBar : nil
     }
 }
 
@@ -215,16 +223,22 @@ private extension VoiceNoteViewController {
     }
 
     func setupSearchBar() {
+        searchBar.setFieldInputAccessoryView(matchAccessoryBar)
         searchBar.onReturn = { [weak self] query in
             self?.viewModel.updateSearchQuery(query)
         }
         searchBar.onClose = { [weak self] in
             self?.viewModel.exitSearchMode()
         }
-        searchBar.onMatchPrev = { [weak self] in
+        searchBar.onEditingEnded = { [weak self] in
+            guard let self, viewModel.searchMode else { return }
+            becomeFirstResponder()
+            reloadInputViews()
+        }
+        matchAccessoryBar.onPrev = { [weak self] in
             self?.viewModel.previousMatch()
         }
-        searchBar.onMatchNext = { [weak self] in
+        matchAccessoryBar.onNext = { [weak self] in
             self?.viewModel.nextMatch()
         }
     }
@@ -421,7 +435,7 @@ private extension VoiceNoteViewController {
         segmentedControl.setCount(viewModel.summaryMatchCount, at: Page.summary.rawValue)
         segmentedControl.setCount(viewModel.scriptMatchCount, at: Page.script.rawValue)
 
-        searchBar.configureMatch(
+        matchAccessoryBar.configure(
             countText: viewModel.matchCountText,
             hasMatches: viewModel.hasCurrentPageMatches
         )
@@ -429,13 +443,17 @@ private extension VoiceNoteViewController {
         updateNavigationItems()
 
         if didToggle {
+            playerView.isHidden = isSearching
             if isSearching {
+                becomeFirstResponder()
+                reloadInputViews()
                 searchBar.becomeFirstResponder()
             } else {
                 searchBar.setQuery("")
                 searchBar.resignFirstResponder()
+                resignFirstResponder()
+                reloadInputViews()
             }
-            view.layoutIfNeeded()
         }
 
         if let match = viewModel.currentMatch {

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -235,6 +235,7 @@ public final class VoiceNoteViewModel {
     }
 
     public func regenerateSummary() {
+        if searchMode { exitSearchMode() }
         voiceNoteUseCase.regenerateSummary(id: voiceNote.id)
     }
 


### PR DESCRIPTION
## ✨ 작업 요약
> 음성 노트 검색 UX 개선: 매치 바 키보드 추종 + 하단 고정, Summary 포커스 색 구분, 검색 모드 부수 동작 정리

- 검색 모드 매치 바를 `UIVisualEffectView` 기반 pill로 재설계하고 `keyboardLayoutGuide`에 바인딩
- Summary 페이지(KeyPoint/Keyword)에도 현재 포커스 매치를 구분 표시 (`systemRed`)
- 검색 모드에서 스크립트 재생 방지, 재생성 시 검색 모드 자동 종료, `bottomFadeView` 하단 이동 등 상태 일관성 보강

## 📋 구체적인 내용

**추가/변경된 동작**
- 매치 바가 키보드 up 시 키보드 바로 위(-8pt 여백), 키보드 down 시 `safeAreaLayoutGuide.bottomAnchor` 위로 자동 docking
- 매치 바에 glass effect(regular) + gray200 0.2 tint, cornerRadius 20 적용, 좌우 safeArea 20pt margin
- Summary 페이지의 KeyPoint/Keyword 셀에도 `focusedRange`/`focusedHighlightBackgroundColor` 주입, 현재 포커스만 `systemRed`로 구분
- Script 포커스 색을 기존 `point800` → `systemRed`로 통일
- 스와이프 페이지 전환 시 매치 바 카운트 갱신 누락 수정
- 검색 모드 진입 시 `playerView` 숨김, `bottomFadeView`를 `view.bottomAnchor`로 이동
- 검색 모드에서 스크립트 셀 선택 비활성화(재생 방지), 요약 재생성 시 `exitSearchMode` 선행 호출

---

## 🔗 연관 이슈

- closed #235

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점

- **선택한 방식**: `UIView.keyboardLayoutGuide.topAnchor`에 매치 바 bottom 바인딩 (iOS 15+)
  - 기본 `usesBottomSafeArea = true` 동작으로 키보드 up/down 두 상태 자동 커버
  - NotificationCenter keyboard observer 불필요, UIKit이 애니메이션까지 동기화
- **고려했다가 제외한 방식**
  - `inputAccessoryView` + VC `canBecomeFirstResponder`: 키보드 down 시 safe area 처리가 UIKit 내부 동작과 충돌 (accessoryView의 `safeAreaInsets.bottom` 0으로 전파되는 케이스)
  - `intrinsicContentSize = 48 + safeAreaInsets.bottom`: UIKit이 accessoryView를 `reloadInputViews()` 없이는 재측정하지 않아 타이밍 불안정
  - 자체 `UIResponder.keyboardWillChangeFrameNotification` 옵저버: 커브/duration 수동 동기화 필요, `keyboardLayoutGuide`로 대체 가능

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [x] 검색 진입 → 재생 중이면 일시정지, playerView 숨김, 키보드 + 매치 바 표시
- [x] 키보드 스와이프 다운 → 매치 바가 safeArea 위로 하단 고정
- [x] textField 재탭 → 매치 바가 키보드 위로 이동
- [x] 스와이프/세그먼트 둘 다 페이지 전환 시 매치 바 카운트/포커스 갱신
- [x] Summary 페이지에서 prev/next 탭 시 포커스 색(`systemRed`) 이동
- [x] 검색 모드에서 스크립트 탭 → 재생 안 됨
- [x] 검색 모드에서 재생성 버튼 탭 → 검색 모드 자동 종료 후 재생성 실행
- [ ] (UI 변경) 스크린샷/GIF 첨부 예정

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [x] 로직·엣지 케이스
- [x] UI/UX (해당 시)

**특히 봐줬으면 하는 부분**
- `keyboardLayoutGuide` 기반 접근이 inputAccessoryView 대비 해당 레이어에서 적절한 선택인지
- 옵셔널 `NSLayoutConstraint?` 프로퍼티(`bottomFadeToPlayerTop`/`bottomFadeToViewBottom`) 저장 방식의 적절성 (lazy var / identifier lookup 등과의 트레이드오프)
- `VoiceNoteMatchAccessoryBar`를 `UIVisualEffectView` 상속 구조로 가져가는 선택이 유지보수 측면에서 OK인지
- 검색 모드 부수 동작(스크립트 탭 차단, 재생성 시 검색 종료)을 VM / VC 어디에 둘지의 선택

---

## 📚 참고

- iOS 15+ `UIView.keyboardLayoutGuide` 공식 문서: https://developer.apple.com/documentation/uikit/uiview/keyboardlayoutguide

---

## 🗺 아키텍처 다이어그램

### 매치 바 위치 전환 흐름

```mermaid
stateDiagram-v2
    [*] --> 일반모드
    일반모드 --> 검색모드진입: 검색 아이콘 탭
    검색모드진입 --> 키보드Up: searchBar.becomeFirstResponder
    키보드Up --> 키보드Down: 스와이프로 내리기
    키보드Down --> 키보드Up: textField 재탭
    키보드Up --> 일반모드: close 탭 / 재생성 탭
    키보드Down --> 일반모드: close 탭 / 재생성 탭

    note right of 키보드Up
        matchBar.bottom = keyboardLayoutGuide.top (-8)
        = 실제 키보드 top
    end note

    note right of 키보드Down
        matchBar.bottom = keyboardLayoutGuide.top (-8)
        = safeAreaLayoutGuide.bottom
    end note
```

### 하이라이트 색 매핑

```mermaid
flowchart LR
    query[검색어 매칭] --> match[일반 매치<br/>point700]
    query --> focus[현재 포커스 매치<br/>systemRed]
    focus -.overrides.-> match
```
