### PR TITLE
노트 화면 스켈레톤 뷰 구현

### DIFF
--- a/Presentation/Sources/Component/VoiceNote/KeywordChipLabel.swift
+++ b/Presentation/Sources/Component/VoiceNote/KeywordChipLabel.swift
@@ -1,6 +1,13 @@
 import UIKit
 
 public final class KeywordChipLabel: TypographyLabel {
+    /// 한 줄 텍스트 기준 KeywordChipLabel의 표준 높이.
+    /// (typography line height + vertical padding × 2)
+    public static var standardHeight: CGFloat {
+        Typography.label.font.pointSize * Typography.label.lineHeightRatio
+            + 2 * Constant.keywordChipVerticalPadding
+    }
+
     private let insets = UIEdgeInsets(
         top: Constant.keywordChipVerticalPadding,
         left: Constant.keywordChipHorizontalPadding,

--- a/Presentation/Sources/Component/VoiceNote/SkeletonLineView.swift
+++ b/Presentation/Sources/Component/VoiceNote/SkeletonLineView.swift
@@ -1,0 +1,79 @@
+import UIKit
+
+final class SkeletonLineView: UIView {
+    private static let animationKey = "skeleton.scaleX"
+
+    private let gradientLayer = CAGradientLayer()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        layer.addSublayer(gradientLayer)
+        gradientLayer.startPoint = .init(x: 0, y: 0.5)
+        gradientLayer.endPoint = .init(x: 1, y: 0.5)
+        gradientLayer.cornerRadius = Constant.skeletonLineHeight / 2
+        gradientLayer.colors = [
+            UIColor.gray400.cgColor,
+            UIColor.gray900.withAlphaComponent(Constant.skeletonLineTrailingAlpha).cgColor,
+        ]
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.noIntrinsicMetric, height: Constant.skeletonLineHeight)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer.anchorPoint = .init(x: 0, y: 0.5)
+        gradientLayer.bounds = CGRect(origin: .zero, size: bounds.size)
+        gradientLayer.position = CGPoint(x: 0, y: bounds.midY)
+    }
+
+    func startAnimating(beginOffset: CFTimeInterval = 0) {
+        let animation = CABasicAnimation(keyPath: "transform.scale.x")
+        animation.fromValue = Constant.skeletonScaleFrom
+        animation.toValue = Constant.skeletonScaleTo
+        animation.duration = Constant.skeletonAnimationDuration
+        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        animation.autoreverses = true
+        animation.repeatCount = .infinity
+        animation.beginTime = CACurrentMediaTime() + beginOffset
+        animation.fillMode = .both
+        gradientLayer.add(animation, forKey: Self.animationKey)
+    }
+
+    func stopAnimating() {
+        gradientLayer.removeAnimation(forKey: Self.animationKey)
+    }
+}
+
+#Preview {
+    let container = UIView()
+    container.backgroundColor = UIColor.gray100
+
+    let widths: [CGFloat] = [204, 173, 225]
+    let stack = UIStackView()
+    stack.axis = .vertical
+    stack.spacing = 6
+    stack.alignment = .leading
+    stack.translatesAutoresizingMaskIntoConstraints = false
+
+    for (index, w) in widths.enumerated() {
+        let line = SkeletonLineView()
+        line.translatesAutoresizingMaskIntoConstraints = false
+        line.widthAnchor.constraint(equalToConstant: w).isActive = true
+        line.startAnimating(beginOffset: Double(index) * 0.2)
+        stack.addArrangedSubview(line)
+    }
+
+    container.addSubview(stack)
+    NSLayoutConstraint.activate([
+        stack.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+        stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+    ])
+    return container
+}

--- a/Presentation/Sources/Component/VoiceNote/SkeletonLineView.swift
+++ b/Presentation/Sources/Component/VoiceNote/SkeletonLineView.swift
@@ -14,7 +14,7 @@ final class SkeletonLineView: UIView {
         gradientLayer.cornerRadius = Constant.skeletonLineHeight / 2
         gradientLayer.colors = [
             UIColor.gray400.cgColor,
-            UIColor.gray900.withAlphaComponent(Constant.skeletonLineTrailingAlpha).cgColor,
+            UIColor.gray900.withAlphaComponent(Constant.skeletonLineTrailingAlpha).cgColor
         ]
     }
 
@@ -73,7 +73,7 @@ final class SkeletonLineView: UIView {
     container.addSubview(stack)
     NSLayoutConstraint.activate([
         stack.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-        stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        stack.centerYAnchor.constraint(equalTo: container.centerYAnchor)
     ])
     return container
 }

--- a/Presentation/Sources/DesignSystem/Constant.swift
+++ b/Presentation/Sources/DesignSystem/Constant.swift
@@ -233,6 +233,25 @@ public extension Constant {
     static let underlineSegmentedControlTopMargin: CGFloat = 16
 }
 
+// MARK: - SkeletonLineView Constants
+
+public extension Constant {
+    /// SkeletonLineView 높이 (14) — cornerRadius는 이 값의 1/2로 파생
+    static let skeletonLineHeight: CGFloat = 14
+
+    /// SkeletonLineView 그라디언트 끝(투명) alpha
+    static let skeletonLineTrailingAlpha: CGFloat = 0.05
+
+    /// SkeletonLineView scaleX 애니메이션 시작값
+    static let skeletonScaleFrom: CGFloat = 0.1
+
+    /// SkeletonLineView scaleX 애니메이션 끝값
+    static let skeletonScaleTo: CGFloat = 1.0
+
+    /// SkeletonLineView scaleX 애니메이션 편도 주기 (초)
+    static let skeletonAnimationDuration: CFTimeInterval = 1.0
+}
+
 // MARK: - BackgroundView Constants
 
 public extension Constant {

--- a/Presentation/Sources/View/VoiceNote/Cells/KeyPointSkeletonCell.swift
+++ b/Presentation/Sources/View/VoiceNote/Cells/KeyPointSkeletonCell.swift
@@ -82,7 +82,7 @@ final class KeyPointSkeletonContentView: UIView, UIContentView {
             contentStack.leadingAnchor.constraint(equalTo: leadingAnchor),
             contentStack.trailingAnchor.constraint(equalTo: trailingAnchor),
             contentStack.topAnchor.constraint(equalTo: topAnchor),
-            contentStack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
     }
 
@@ -102,7 +102,7 @@ final class KeyPointSkeletonContentView: UIView, UIContentView {
         let configs = [
             KeyPointSkeletonContentConfiguration(number: 1, beginOffset: 0.0),
             KeyPointSkeletonContentConfiguration(number: 2, beginOffset: 0.2),
-            KeyPointSkeletonContentConfiguration(number: 3, beginOffset: 0.4),
+            KeyPointSkeletonContentConfiguration(number: 3, beginOffset: 0.4)
         ]
 
         let stack = UIStackView(arrangedSubviews: configs.map { $0.makeContentView() })
@@ -118,7 +118,7 @@ final class KeyPointSkeletonContentView: UIView, UIContentView {
         NSLayoutConstraint.activate([
             stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 20),
             stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -20),
-            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor)
         ])
 
         return container

--- a/Presentation/Sources/View/VoiceNote/Cells/KeyPointSkeletonCell.swift
+++ b/Presentation/Sources/View/VoiceNote/Cells/KeyPointSkeletonCell.swift
@@ -1,0 +1,128 @@
+import UIKit
+
+// MARK: - KeyPointSkeletonContentConfiguration
+
+struct KeyPointSkeletonContentConfiguration: UIContentConfiguration {
+    var number: Int = 0
+    var beginOffset: CFTimeInterval = 0
+
+    func makeContentView() -> UIView & UIContentView {
+        KeyPointSkeletonContentView(configuration: self)
+    }
+
+    func updated(for state: UIConfigurationState) -> KeyPointSkeletonContentConfiguration {
+        self
+    }
+}
+
+// MARK: - KeyPointSkeletonContentView
+
+final class KeyPointSkeletonContentView: UIView, UIContentView {
+    var configuration: UIContentConfiguration {
+        didSet { apply(configuration: configuration) }
+    }
+
+    // MARK: - UI Components
+
+    private let badgeLabel: TypographyLabel = {
+        let label = TypographyLabel(typography: .title3, alignment: .center)
+        label.textColor = .white
+        label.backgroundColor = UIColor.point600
+        label.layer.cornerRadius = Constant.keyPointBadgeSize / 2
+        label.clipsToBounds = true
+        return label
+    }()
+
+    private let skeletonLine = SkeletonLineView()
+
+    private let contentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = Constant.keyPointContentSpacing
+        stack.isLayoutMarginsRelativeArrangement = true
+        stack.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: Constant.keyPointCardVerticalPadding,
+            leading: Constant.keyPointCardHorizontalPadding,
+            bottom: Constant.keyPointCardVerticalPadding,
+            trailing: Constant.keyPointCardHorizontalPadding
+        )
+        stack.backgroundColor = UIColor.gray100
+        stack.layer.cornerRadius = Constant.cornerRadius
+        return stack
+    }()
+
+    // MARK: - Init
+
+    init(configuration: UIContentConfiguration) {
+        self.configuration = configuration
+        super.init(frame: .zero)
+        setupUI()
+        apply(configuration: configuration)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        contentStack.addArrangedSubview(badgeLabel)
+        contentStack.addArrangedSubview(skeletonLine)
+        addSubview(contentStack)
+
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            badgeLabel.widthAnchor.constraint(equalToConstant: Constant.keyPointBadgeSize),
+            badgeLabel.heightAnchor.constraint(equalToConstant: Constant.keyPointBadgeSize),
+
+            contentStack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentStack.topAnchor.constraint(equalTo: topAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    // MARK: - Apply
+
+    private func apply(configuration: UIContentConfiguration) {
+        guard let config = configuration as? KeyPointSkeletonContentConfiguration else { return }
+        badgeLabel.text = "\(config.number)"
+        skeletonLine.startAnimating(beginOffset: config.beginOffset)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    let preview: UIView = {
+        let configs = [
+            KeyPointSkeletonContentConfiguration(number: 1, beginOffset: 0.0),
+            KeyPointSkeletonContentConfiguration(number: 2, beginOffset: 0.2),
+            KeyPointSkeletonContentConfiguration(number: 3, beginOffset: 0.4),
+        ]
+
+        let stack = UIStackView(arrangedSubviews: configs.map { $0.makeContentView() })
+        stack.axis = .vertical
+        stack.spacing = 6
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = UIView()
+        container.backgroundColor = .systemPink
+        container.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -20),
+            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+
+        return container
+    }()
+
+    preview
+}

--- a/Presentation/Sources/View/VoiceNote/Cells/KeywordsSkeletonCell.swift
+++ b/Presentation/Sources/View/VoiceNote/Cells/KeywordsSkeletonCell.swift
@@ -62,7 +62,7 @@ final class KeywordsSkeletonContentView: UIView, UIContentView {
                 equalTo: trailingAnchor,
                 constant: -Constant.keywordChipHorizontalPadding
             ),
-            skeletonLine.centerYAnchor.constraint(equalTo: centerYAnchor),
+            skeletonLine.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
 
@@ -80,7 +80,7 @@ final class KeywordsSkeletonContentView: UIView, UIContentView {
     let preview: UIView = {
         let configs = [
             KeywordsSkeletonContentConfiguration(beginOffset: 0.0),
-            KeywordsSkeletonContentConfiguration(beginOffset: 0.2),
+            KeywordsSkeletonContentConfiguration(beginOffset: 0.2)
         ]
 
         let stack = UIStackView(arrangedSubviews: configs.map { $0.makeContentView() })
@@ -96,7 +96,7 @@ final class KeywordsSkeletonContentView: UIView, UIContentView {
         NSLayoutConstraint.activate([
             stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 20),
             stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -20),
-            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor)
         ])
 
         return container

--- a/Presentation/Sources/View/VoiceNote/Cells/KeywordsSkeletonCell.swift
+++ b/Presentation/Sources/View/VoiceNote/Cells/KeywordsSkeletonCell.swift
@@ -43,6 +43,10 @@ final class KeywordsSkeletonContentView: UIView, UIContentView {
         layer.cornerRadius = bounds.height / 2
     }
 
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.noIntrinsicMetric, height: KeywordChipLabel.standardHeight)
+    }
+
     // MARK: - Setup
 
     private func setupUI() {
@@ -58,14 +62,7 @@ final class KeywordsSkeletonContentView: UIView, UIContentView {
                 equalTo: trailingAnchor,
                 constant: -Constant.keywordChipHorizontalPadding
             ),
-            skeletonLine.topAnchor.constraint(
-                equalTo: topAnchor,
-                constant: Constant.keywordChipVerticalPadding
-            ),
-            skeletonLine.bottomAnchor.constraint(
-                equalTo: bottomAnchor,
-                constant: -Constant.keywordChipVerticalPadding
-            ),
+            skeletonLine.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
     }
 

--- a/Presentation/Sources/View/VoiceNote/Cells/KeywordsSkeletonCell.swift
+++ b/Presentation/Sources/View/VoiceNote/Cells/KeywordsSkeletonCell.swift
@@ -1,0 +1,109 @@
+import UIKit
+
+// MARK: - KeywordsSkeletonContentConfiguration
+
+struct KeywordsSkeletonContentConfiguration: UIContentConfiguration {
+    var beginOffset: CFTimeInterval = 0
+
+    func makeContentView() -> UIView & UIContentView {
+        KeywordsSkeletonContentView(configuration: self)
+    }
+
+    func updated(for state: UIConfigurationState) -> KeywordsSkeletonContentConfiguration {
+        self
+    }
+}
+
+// MARK: - KeywordsSkeletonContentView
+
+final class KeywordsSkeletonContentView: UIView, UIContentView {
+    var configuration: UIContentConfiguration {
+        didSet { apply(configuration: configuration) }
+    }
+
+    private let skeletonLine = SkeletonLineView()
+
+    // MARK: - Init
+
+    init(configuration: UIContentConfiguration) {
+        self.configuration = configuration
+        super.init(frame: .zero)
+        backgroundColor = UIColor.gray100
+        setupUI()
+        apply(configuration: configuration)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.cornerRadius = bounds.height / 2
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        skeletonLine.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(skeletonLine)
+
+        NSLayoutConstraint.activate([
+            skeletonLine.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: Constant.keywordChipHorizontalPadding
+            ),
+            skeletonLine.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -Constant.keywordChipHorizontalPadding
+            ),
+            skeletonLine.topAnchor.constraint(
+                equalTo: topAnchor,
+                constant: Constant.keywordChipVerticalPadding
+            ),
+            skeletonLine.bottomAnchor.constraint(
+                equalTo: bottomAnchor,
+                constant: -Constant.keywordChipVerticalPadding
+            ),
+        ])
+    }
+
+    // MARK: - Apply
+
+    private func apply(configuration: UIContentConfiguration) {
+        guard let config = configuration as? KeywordsSkeletonContentConfiguration else { return }
+        skeletonLine.startAnimating(beginOffset: config.beginOffset)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    let preview: UIView = {
+        let configs = [
+            KeywordsSkeletonContentConfiguration(beginOffset: 0.0),
+            KeywordsSkeletonContentConfiguration(beginOffset: 0.2),
+        ]
+
+        let stack = UIStackView(arrangedSubviews: configs.map { $0.makeContentView() })
+        stack.axis = .vertical
+        stack.spacing = Constant.keywordChipLineSpacing
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = UIView()
+        container.backgroundColor = .systemPink
+        container.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -20),
+            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+
+        return container
+    }()
+
+    preview
+}

--- a/Presentation/Sources/View/VoiceNote/Cells/ScriptCell.swift
+++ b/Presentation/Sources/View/VoiceNote/Cells/ScriptCell.swift
@@ -82,7 +82,7 @@ final class ScriptContentView: UIView, UIContentView {
             timeLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: spacing),
             timeLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
 
-            textView.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: spacing),
+            textView.topAnchor.constraint(equalTo: timeLabel.bottomAnchor),
             textView.leadingAnchor.constraint(equalTo: leadingAnchor),
             textView.trailingAnchor.constraint(equalTo: trailingAnchor),
             textView.bottomAnchor.constraint(equalTo: bottomAnchor)

--- a/Presentation/Sources/View/VoiceNote/Cells/ScriptSkeletonCell.swift
+++ b/Presentation/Sources/View/VoiceNote/Cells/ScriptSkeletonCell.swift
@@ -1,0 +1,60 @@
+import UIKit
+
+// MARK: - ScriptSkeletonContentConfiguration
+
+struct ScriptSkeletonContentConfiguration: UIContentConfiguration {
+    var beginOffset: CFTimeInterval = 0
+
+    func makeContentView() -> UIView & UIContentView {
+        ScriptSkeletonContentView(configuration: self)
+    }
+
+    func updated(for state: UIConfigurationState) -> ScriptSkeletonContentConfiguration {
+        self
+    }
+}
+
+// MARK: - ScriptSkeletonContentView
+
+final class ScriptSkeletonContentView: UIView, UIContentView {
+    var configuration: UIContentConfiguration {
+        didSet { apply(configuration: configuration) }
+    }
+
+    private let skeletonLine = SkeletonLineView()
+
+    // MARK: - Init
+
+    init(configuration: UIContentConfiguration) {
+        self.configuration = configuration
+        super.init(frame: .zero)
+        setupUI()
+        apply(configuration: configuration)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        skeletonLine.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(skeletonLine)
+
+        NSLayoutConstraint.activate([
+            skeletonLine.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constant.scriptCellSpacing),
+            skeletonLine.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constant.scriptCellSpacing),
+            skeletonLine.topAnchor.constraint(equalTo: topAnchor),
+            skeletonLine.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    // MARK: - Apply
+
+    private func apply(configuration: UIContentConfiguration) {
+        guard let config = configuration as? ScriptSkeletonContentConfiguration else { return }
+        skeletonLine.startAnimating(beginOffset: config.beginOffset)
+    }
+}

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteScriptViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteScriptViewController.swift
@@ -35,6 +35,7 @@ final class VoiceNoteScriptViewController: UIViewController {
         observePlayingParagraph()
         observeEditingMode()
         observeSearchState()
+        observeAnalysisState()
     }
 
     /// 지정한 매치 위치의 스크립트 섹션으로 컬렉션을 스크롤합니다.
@@ -61,7 +62,7 @@ final class VoiceNoteScriptViewController: UIViewController {
 
 private extension VoiceNoteScriptViewController {
     func makeLayout() -> UICollectionViewLayout {
-        UICollectionViewCompositionalLayout { _, environment in
+        UICollectionViewCompositionalLayout { [weak self] _, environment in
             var config = UICollectionLayoutListConfiguration(appearance: .plain)
             config.backgroundColor = .clear
             config.showsSeparators = false
@@ -72,15 +73,25 @@ private extension VoiceNoteScriptViewController {
             for item in section.boundarySupplementaryItems {
                 item.pinToVisibleBounds = false
                 item.edgeSpacing = NSCollectionLayoutEdgeSpacing(
-                    leading: nil, top: .fixed(32),
+                    leading: nil, top: .fixed(22),
                     trailing: nil, bottom: nil
                 )
             }
 
             section.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 0, bottom: 0, trailing: 0)
-            section.interGroupSpacing = 16
+            section.interGroupSpacing = self?.isShowingSkeleton == true ? Constant.scriptCellSpacing : 16
 
             return section
+        }
+    }
+
+    var isShowingSkeleton: Bool {
+        switch viewModel.voiceNote.analysisState {
+        case .pending, .transcribing:
+            return true
+        case .transcribed, .summarizing, .regenerating, .completed,
+             .transcriptionFailed, .summarizationFailed:
+            return false
         }
     }
 }
@@ -121,10 +132,20 @@ private extension VoiceNoteScriptViewController {
             )
         }
 
+        let scriptSkeletonCellReg = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, _, item in
+            guard case .scriptSkeleton(_, let beginOffset) = item else { return }
+            cell.contentConfiguration = ScriptSkeletonContentConfiguration(beginOffset: beginOffset)
+        }
+
         let dataSource = UICollectionViewDiffableDataSource<Section, Item>(
             collectionView: collectionView
         ) { col, indexPath, item in
-            col.dequeueConfiguredReusableCell(using: scriptCellReg, for: indexPath, item: item)
+            switch item {
+            case .script:
+                return col.dequeueConfiguredReusableCell(using: scriptCellReg, for: indexPath, item: item)
+            case .scriptSkeleton:
+                return col.dequeueConfiguredReusableCell(using: scriptSkeletonCellReg, for: indexPath, item: item)
+            }
         }
 
         let headerReg = makeHeaderRegistration()
@@ -146,9 +167,17 @@ private extension VoiceNoteScriptViewController {
     func applySnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections([.scripts])
-        let scriptItems = viewModel.scriptSections.indices.map { Item.script(index: $0) }
-        snapshot.appendItems(scriptItems, toSection: .scripts)
-        snapshot.reconfigureItems(scriptItems)
+
+        let items: [Item] = if isShowingSkeleton {
+            (0 ..< 30).map { idx in
+                .scriptSkeleton(index: idx, beginOffset: Double(idx % 3) * 0.2)
+            }
+        } else {
+            viewModel.scriptSections.indices.map { Item.script(index: $0) }
+        }
+
+        snapshot.appendItems(items, toSection: .scripts)
+        snapshot.reconfigureItems(items)
         dataSource.apply(snapshot, animatingDifferences: true)
     }
 
@@ -172,6 +201,19 @@ private extension VoiceNoteScriptViewController {
             Task { @MainActor in
                 self.applySnapshot()
                 self.observeTranscriptSections()
+            }
+        }
+    }
+
+    func observeAnalysisState() {
+        withObservationTracking {
+            _ = viewModel.voiceNote.analysisState
+        } onChange: { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                self.collectionView.collectionViewLayout.invalidateLayout()
+                self.applySnapshot()
+                self.observeAnalysisState()
             }
         }
     }
@@ -302,5 +344,6 @@ extension VoiceNoteScriptViewController {
 
     enum Item: Hashable {
         case script(index: Int)
+        case scriptSkeleton(index: Int, beginOffset: CFTimeInterval)
     }
 }

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteSummaryViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteSummaryViewController.swift
@@ -98,6 +98,7 @@ private extension VoiceNoteSummaryViewController {
 
             section.interGroupSpacing = switch sectionType {
             case .keyPoints: 6
+            case .keywords: Constant.keywordChipLineSpacing
             default: 0
             }
 
@@ -153,6 +154,19 @@ private extension VoiceNoteSummaryViewController {
             )
         }
 
+        let keyPointSkeletonCellReg = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, _, item in
+            guard case .keyPointSkeleton(let number, let beginOffset) = item else { return }
+            cell.contentConfiguration = KeyPointSkeletonContentConfiguration(
+                number: number,
+                beginOffset: beginOffset
+            )
+        }
+
+        let keywordsSkeletonCellReg = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, _, item in
+            guard case .keywordsSkeleton(let beginOffset) = item else { return }
+            cell.contentConfiguration = KeywordsSkeletonContentConfiguration(beginOffset: beginOffset)
+        }
+
         let dataSource = UICollectionViewDiffableDataSource<Section, Item>(
             collectionView: collectionView
         ) { col, indexPath, item in
@@ -163,6 +177,10 @@ private extension VoiceNoteSummaryViewController {
                 return col.dequeueConfiguredReusableCell(using: keyPointCellReg, for: indexPath, item: item)
             case .keywords:
                 return col.dequeueConfiguredReusableCell(using: keywordsCellReg, for: indexPath, item: item)
+            case .keyPointSkeleton:
+                return col.dequeueConfiguredReusableCell(using: keyPointSkeletonCellReg, for: indexPath, item: item)
+            case .keywordsSkeleton:
+                return col.dequeueConfiguredReusableCell(using: keywordsSkeletonCellReg, for: indexPath, item: item)
             }
         }
 
@@ -203,15 +221,36 @@ private extension VoiceNoteSummaryViewController {
         }
     }
 
+    var isShowingSkeleton: Bool {
+        switch viewModel.voiceNote.analysisState {
+        case .pending, .transcribing, .transcribed, .summarizing, .regenerating:
+            return true
+        case .completed, .transcriptionFailed, .summarizationFailed:
+            return false
+        }
+    }
+
     func applySnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections(Section.allCases)
 
         let metadataItems: [Item] = [.metadata]
-        let keyPointItems = viewModel.keyPoints.map { Item.keyPoint(number: $0.number, text: $0.text) }
-        let keywordItems: [Item] = [.keywords]
-
         snapshot.appendItems(metadataItems, toSection: .metadata)
+
+        let keyPointItems: [Item]
+        let keywordItems: [Item]
+        if isShowingSkeleton {
+            keyPointItems = (0 ..< 3).map { idx in
+                .keyPointSkeleton(number: idx + 1, beginOffset: Double(idx) * 0.2)
+            }
+            keywordItems = (0 ..< 2).map { idx in
+                .keywordsSkeleton(beginOffset: Double(idx) * 0.2)
+            }
+        } else {
+            keyPointItems = viewModel.keyPoints.map { Item.keyPoint(number: $0.number, text: $0.text) }
+            keywordItems = [.keywords]
+        }
+
         snapshot.appendItems(keyPointItems, toSection: .keyPoints)
         snapshot.appendItems(keywordItems, toSection: .keywords)
 
@@ -231,14 +270,9 @@ private extension VoiceNoteSummaryViewController {
             guard let self else { return }
             Task { @MainActor in
                 switch self.viewModel.voiceNote.analysisState {
-                case .transcribing, .summarizing, .regenerating:
-                    var snapshot = self.dataSource.snapshot()
-                    snapshot.reconfigureItems([.metadata])
-                    snapshot.reloadSections([.keyPoints])
-                    self.dataSource.apply(snapshot, animatingDifferences: false)
-                case .completed, .transcribed:
+                case .pending, .transcribing, .transcribed, .summarizing, .regenerating, .completed:
                     self.applySnapshot()
-                case .pending, .transcriptionFailed, .summarizationFailed:
+                case .transcriptionFailed, .summarizationFailed:
                     break
                 }
                 self.observeAnalysisState()
@@ -304,5 +338,7 @@ extension VoiceNoteSummaryViewController {
         case metadata
         case keyPoint(number: Int, text: String)
         case keywords
+        case keyPointSkeleton(number: Int, beginOffset: CFTimeInterval)
+        case keywordsSkeleton(beginOffset: CFTimeInterval)
     }
 }


### PR DESCRIPTION
## ✨ 작업 요약
> 한 줄로 무엇을 추가/변경했는지

- 보이스 노트 상세 화면(요약 / 스크립트)에서 분석·요약이 진행 중일 때 빈 화면 대신 로딩 스켈레톤을 노출

## 📋 구체적인 내용
- 추가/변경된 동작:
    - `analysisState`별로 핵심 포인트·키워드·스크립트 영역에 스켈레톤 셀 노출
    - 스켈레톤은 좌측 고정 + scaleX 애니메이션이 무한 반복되는 가로 그라디언트 막대 (`SkeletonLineView`)
    - 셀별 `beginOffset`으로 애니메이션 위상 어긋남
    - 키워드 스켈레톤 셀 높이를 실제 `KeywordChipLabel` 1줄 높이와 일치시켜 스켈레톤 ↔ 실제 데이터 전환 시 셀 높이 점프 제거
    - 스크립트 페이지: 스켈레톤 표시 중에는 셀 간격 8 / 실제 표시 중에는 16으로 분기 + `analysisState` 변경 시 `invalidateLayout`
    - 부수: `ScriptCell`의 `timeLabel ↔ textView` 간격 중복(layout constraint 8 + textContainerInset.top 8) 제거
- 영향 받는 화면/모듈:
    - 보이스 노트 상세 (요약 / 스크립트 페이지)
    - `Presentation/Component/VoiceNote`, `Presentation/View/VoiceNote/Cells`, `Presentation/View/VoiceNote/VoiceNote(Summary|Script)ViewController`

---

## 🔗 연관 이슈

- closed #242

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
    - 셀 1개당 라인 1개 패턴으로 통일 (KeyPoint / Keywords / Script 모두 동일) — 셀 책임이 명확하고 행 개수 결정은 데이터소스로 위임
    - `regenerating` 상태도 스켈레톤 표시 — 재생성 진행 중임을 더 명확히 전달
    - `SkeletonLineView`는 `CAGradientLayer` sublayer + `anchorPoint = (0, 0.5)`로 좌측 고정. scaleX 1.0 ↔ 0.7 호흡으로 라인 길이 변주를 동적으로 표현 (정적 너비 차이 없음)
    - 키워드 스켈레톤 셀의 캡슐 cornerRadius는 `bounds.height / 2` (layoutSubviews) — 셀 높이 변화에 자동 추적
- **고려했다가 제외한 방식**
    - 핵심 포인트 라인을 디자인 너비(204/173/225) 그대로 외부 주입 → scaleX 호흡이 이미 변주를 만들고 있어 정적 너비 차이가 묻힘. 컨테이너 가득 채우는 단순 방식 채택
    - 스크립트 스켈레톤에 타임스탬프 라인 별도 처리 → 스켈레톤은 타임스탬프 없음으로 단순화
    - shimmer(좌→우 흐름) 애니메이션 → 디자인의 "라인 길이가 가변" 의도와 결이 다른 scaleX 호흡 방식 채택

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [ ] 정상 플로우 동작 확인 (pending / transcribing / transcribed / summarizing / regenerating / completed 전환 시 스켈레톤 ↔ 실제 데이터 매끄러운 전환)
- [ ] 엣지 케이스 / 빈 값·에러 처리 확인 (`transcriptionFailed` / `summarizationFailed`는 스켈레톤 / 실제 표시 변화 없음)
- [x] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [ ] (로직 추가 시) 테스트 추가 여부 — 본 변경은 UI 표현이라 단위 테스트 대상 외

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [x] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [x] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- `analysisState`별 표시 매트릭스가 의도와 일치하는지 (요약: pending/transcribing/transcribed/summarizing/regenerating → 스켈레톤 / 스크립트: pending/transcribing → 스켈레톤). 특히 `regenerating`을 스켈레톤으로 처리한 결정
- `VoiceNoteScriptViewController.makeLayout`에서 `isShowingSkeleton` 평가 + `invalidateLayout`으로 spacing 동적 전환 — 더 좋은 패턴이 있을지
- 부수 변경(`ScriptCell` 타임스탬프-본문 간격 중복 제거)을 본 PR에 묶은 게 적절한지
- 재생성 직후 → 뒤로가기 → 재진입 시 스켈레톤 미노출 이슈는 #243(부모 화면들 stream 전환)에서 별도 처리 예정 — 본 PR에선 의식하지 않음

---

## 🗺 표시 매트릭스

| AnalysisState | 핵심 포인트 | 키워드 | 스크립트 |
|---|---|---|---|
| pending, transcribing | 스켈레톤 | 스켈레톤 | 스켈레톤 |
| transcribed, summarizing, regenerating | 스켈레톤 | 스켈레톤 | 실제 |
| completed | 실제 | 실제 | 실제 |
| transcriptionFailed, summarizationFailed | 변경 없음 | 변경 없음 | 변경 없음 |
