### PR TITLE
검색 기능을 구현합니다

### DIFF
--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -129,6 +129,10 @@ public final class AppDIContainer {
     public func makeNewFolderViewModel() -> NewFolderViewModel {
         return NewFolderViewModel(folderUseCase: folderUseCase)
     }
+    
+    public func makeSearchViewModel() -> SearchViewModel {
+        return SearchViewModel()
+    }
 
     #if DEBUG
         public func seedDebugDataIfNeeded() {

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -130,8 +130,8 @@ public final class AppDIContainer {
         return NewFolderViewModel(folderUseCase: folderUseCase)
     }
 
-    public func makeSearchViewModel() -> SearchViewModel {
-        return SearchViewModel()
+    public func makeSearchViewModel(type: SearchViewModel.SearchType, items: [Presentation.LibraryItem]) -> SearchViewModel {
+        return SearchViewModel(type: type, items: items)
     }
 
     #if DEBUG

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -129,7 +129,7 @@ public final class AppDIContainer {
     public func makeNewFolderViewModel() -> NewFolderViewModel {
         return NewFolderViewModel(folderUseCase: folderUseCase)
     }
-    
+
     public func makeSearchViewModel() -> SearchViewModel {
         return SearchViewModel()
     }

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -130,7 +130,7 @@ public final class AppDIContainer {
         return NewFolderViewModel(folderUseCase: folderUseCase)
     }
 
-    public func makeSearchViewModel(type: SearchViewModel.SearchType, items: [Presentation.LibraryItem]) -> SearchViewModel {
+    public func makeSearchViewModel(type: SearchViewModel.SearchType, items: [ContentItem]) -> SearchViewModel {
         return SearchViewModel(type: type, items: items)
     }
 

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -67,11 +67,12 @@ extension MainCoordinator: MainCoordinatorDelegate {
         let voiceNoteVC = VoiceNoteViewController(viewModel: voiceNoteVM)
         presenter.pushViewController(voiceNoteVC, animated: true)
     }
-    
+
     func pushSearchView() {
         let searchVM = dependencyContainer.makeSearchViewModel()
+        searchVM.coordinator = self
         let searchVC = SearchViewController(vm: searchVM)
-        
+
         presenter.pushViewController(searchVC, animated: true)
     }
 
@@ -122,6 +123,10 @@ extension MainCoordinator: VoiceNoteCoordinatorDelegate {
         presentMoveFolder(voiceNotes: [voiceNote], onComplete: onComplete, topDetentStyle: .belowSegmentControl)
     }
 }
+
+// MARK: - SearchCoordinatorDelegate
+
+extension MainCoordinator: SearchCoordinatorDelegate {}
 
 // MARK: - Helpers
 

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -67,6 +67,13 @@ extension MainCoordinator: MainCoordinatorDelegate {
         let voiceNoteVC = VoiceNoteViewController(viewModel: voiceNoteVM)
         presenter.pushViewController(voiceNoteVC, animated: true)
     }
+    
+    func pushSearchView() {
+        let searchVM = dependencyContainer.makeSearchViewModel()
+        let searchVC = SearchViewController(vm: searchVM)
+        
+        presenter.pushViewController(searchVC, animated: true)
+    }
 
     // TODO: Present
 

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -68,7 +68,7 @@ extension MainCoordinator: MainCoordinatorDelegate {
         presenter.pushViewController(voiceNoteVC, animated: true)
     }
 
-    func pushSearchView(type: SearchViewModel.SearchType, items: [Presentation.LibraryItem]) {
+    func pushSearchView(type: SearchViewModel.SearchType, items: [ContentItem]) {
         let searchVM = dependencyContainer.makeSearchViewModel(type: type, items: items)
         searchVM.coordinator = self
         let searchVC = SearchViewController(vm: searchVM)

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -68,8 +68,8 @@ extension MainCoordinator: MainCoordinatorDelegate {
         presenter.pushViewController(voiceNoteVC, animated: true)
     }
 
-    func pushSearchView() {
-        let searchVM = dependencyContainer.makeSearchViewModel()
+    func pushSearchView(type: SearchViewModel.SearchType, items: [Presentation.LibraryItem]) {
+        let searchVM = dependencyContainer.makeSearchViewModel(type: type, items: items)
         searchVM.coordinator = self
         let searchVC = SearchViewController(vm: searchVM)
 

--- a/Presentation/Sources/Component/Common/ChagokSearchBar.swift
+++ b/Presentation/Sources/Component/Common/ChagokSearchBar.swift
@@ -14,8 +14,16 @@ final class ChagokSearchBar: UIView {
             effect.isInteractive = true
             view.effect = effect
         }
-        view.layer.borderWidth = 1
-        view.layer.borderColor = UIColor.gray600.cgColor
+        view.setGradientBorder(
+            colors: [
+                UIColor.gray900,
+                UIColor.gray300
+            ],
+            width: 1,
+            cornerRadius: Constant.cornerRadius,
+            startPoint: CGPoint(x: 0, y: 0),
+            endPoint: CGPoint(x: 1, y: 1)
+        )
         return view
     }()
 
@@ -41,13 +49,23 @@ final class ChagokSearchBar: UIView {
         return field
     }()
 
-    let closeButton: UIButton = {
-        var config = UIButton.Configuration.prominentClearGlass()
-        config.image = UIImage(systemName: "xmark", withConfiguration: UIImage.SymbolConfiguration(pointSize: 12))
-        config.baseForegroundColor = .white
-        config.baseBackgroundColor = .point100.withAlphaComponent(0.2)
-        config.contentInsets = .zero
-        return UIButton(configuration: config)
+    let closeButton: GlassButton = {
+        let btn = GlassButton()
+        btn.configure(
+            "",
+            typography: .body1,
+            border: .init(
+                color: .gradient([
+                    UIColor.gray300,
+                    UIColor.gray900
+                ]),
+                width: 1,
+            ),
+            image: .init(imageName: "xmark", type: .system, configuration: .init(pointSize: 12)),
+            backgroundColor: .color(.point100.withAlphaComponent(0.2)),
+            foregroundColor: .white
+        )
+        return btn
     }()
 
     // MARK: - Initialize

--- a/Presentation/Sources/Component/Common/ChagokSearchBar.swift
+++ b/Presentation/Sources/Component/Common/ChagokSearchBar.swift
@@ -1,9 +1,8 @@
 import UIKit
 
 final class ChagokSearchBar: UIView {
-    
     // MARK: - Component
-    
+
     private let searchContainer: UIVisualEffectView = {
         let effect = UIGlassEffect(style: .clear)
         effect.tintColor = .point100.withAlphaComponent(0.2)
@@ -50,33 +49,32 @@ final class ChagokSearchBar: UIView {
         config.contentInsets = .zero
         return UIButton(configuration: config)
     }()
-    
+
     // MARK: - Initialize
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
     }
-    
+
     required init?(coder: NSCoder) {
         nil
     }
-    
+
     override var intrinsicContentSize: CGSize {
         CGSize(width: UIView.layoutFittingExpandedSize.width, height: 46)
     }
-    
-    
+
     // MARK: - Setup
-    
+
     private func setupUI() {
         addSubview(searchContainer)
         addSubview(closeButton)
         searchContainer.contentView.addSubview(iconView)
         searchContainer.contentView.addSubview(textField)
 
-        [searchContainer, closeButton, iconView, textField].forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
+        for item in [searchContainer, closeButton, iconView, textField] {
+            item.translatesAutoresizingMaskIntoConstraints = false
         }
 
         NSLayoutConstraint.activate([

--- a/Presentation/Sources/Component/Common/ChagokSearchBar.swift
+++ b/Presentation/Sources/Component/Common/ChagokSearchBar.swift
@@ -59,7 +59,7 @@ final class ChagokSearchBar: UIView {
                     UIColor.gray300,
                     UIColor.gray900
                 ]),
-                width: 1,
+                width: 1
             ),
             image: .init(imageName: "xmark", type: .system, configuration: .init(pointSize: 12)),
             backgroundColor: .color(.point100.withAlphaComponent(0.2)),

--- a/Presentation/Sources/Component/Common/ChagokSearchBar.swift
+++ b/Presentation/Sources/Component/Common/ChagokSearchBar.swift
@@ -80,7 +80,7 @@ final class ChagokSearchBar: UIView {
     }
 
     override var intrinsicContentSize: CGSize {
-        CGSize(width: UIView.layoutFittingExpandedSize.width, height: 46)
+        CGSize(width: UIView.layoutFittingExpandedSize.width, height: 44)
     }
 
     // MARK: - Setup
@@ -96,7 +96,7 @@ final class ChagokSearchBar: UIView {
         }
 
         NSLayoutConstraint.activate([
-            heightAnchor.constraint(equalToConstant: 46),
+            heightAnchor.constraint(equalToConstant: 44),
 
             searchContainer.topAnchor.constraint(equalTo: topAnchor),
             searchContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -105,8 +105,8 @@ final class ChagokSearchBar: UIView {
 
             closeButton.topAnchor.constraint(equalTo: topAnchor),
             closeButton.trailingAnchor.constraint(equalTo: trailingAnchor),
-            closeButton.widthAnchor.constraint(equalToConstant: 46),
-            closeButton.heightAnchor.constraint(equalToConstant: 46),
+            closeButton.widthAnchor.constraint(equalToConstant: 44),
+            closeButton.heightAnchor.constraint(equalToConstant: 44),
 
             iconView.leadingAnchor.constraint(equalTo: searchContainer.contentView.leadingAnchor, constant: 16),
             iconView.centerYAnchor.constraint(equalTo: searchContainer.contentView.centerYAnchor),

--- a/Presentation/Sources/Component/Common/ChagokSearchBar.swift
+++ b/Presentation/Sources/Component/Common/ChagokSearchBar.swift
@@ -1,0 +1,121 @@
+import UIKit
+
+final class ChagokSearchBar: UIView {
+    
+    // MARK: - Component
+    
+    private let searchContainer: UIVisualEffectView = {
+        let effect = UIGlassEffect(style: .clear)
+        effect.tintColor = .point100.withAlphaComponent(0.2)
+        let view = UIVisualEffectView()
+        view.cornerConfiguration = .corners(
+            radius: .fixed(Constant.cornerRadius)
+        )
+        UIView.animate {
+            effect.isInteractive = true
+            view.effect = effect
+        }
+        view.layer.borderWidth = 1
+        view.layer.borderColor = UIColor.gray600.cgColor
+        return view
+    }()
+
+    private let iconView: UIImageView = {
+        let imageView = UIImageView(image: .search)
+        imageView.tintColor = .gray850
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    let textField: TypographyTextField = {
+        let field = TypographyTextField(typography: .body1)
+        field.textColor = .white
+        field.tintColor = .white
+        field.returnKeyType = .search
+        field.clearButtonMode = .never
+        field.autocorrectionType = .no
+        field.autocapitalizationType = .none
+        field.spellCheckingType = .no
+        var placeholderAttrs = Typography.body1.textAttributes
+        placeholderAttrs[.foregroundColor] = UIColor.gray950
+        field.attributedPlaceholder = NSAttributedString(string: "검색", attributes: placeholderAttrs)
+        return field
+    }()
+
+    let closeButton: UIButton = {
+        var config = UIButton.Configuration.prominentClearGlass()
+        config.image = UIImage(systemName: "xmark", withConfiguration: UIImage.SymbolConfiguration(pointSize: 12))
+        config.baseForegroundColor = .white
+        config.baseBackgroundColor = .point100.withAlphaComponent(0.2)
+        config.contentInsets = .zero
+        return UIButton(configuration: config)
+    }()
+    
+    // MARK: - Initialize
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        nil
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.layoutFittingExpandedSize.width, height: 46)
+    }
+    
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        addSubview(searchContainer)
+        addSubview(closeButton)
+        searchContainer.contentView.addSubview(iconView)
+        searchContainer.contentView.addSubview(textField)
+
+        [searchContainer, closeButton, iconView, textField].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 46),
+
+            searchContainer.topAnchor.constraint(equalTo: topAnchor),
+            searchContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
+            searchContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
+            searchContainer.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor, constant: -12),
+
+            closeButton.topAnchor.constraint(equalTo: topAnchor),
+            closeButton.trailingAnchor.constraint(equalTo: trailingAnchor),
+            closeButton.widthAnchor.constraint(equalToConstant: 46),
+            closeButton.heightAnchor.constraint(equalToConstant: 46),
+
+            iconView.leadingAnchor.constraint(equalTo: searchContainer.contentView.leadingAnchor, constant: 16),
+            iconView.centerYAnchor.constraint(equalTo: searchContainer.contentView.centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 20),
+            iconView.heightAnchor.constraint(equalToConstant: 20),
+
+            textField.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 8),
+            textField.trailingAnchor.constraint(equalTo: searchContainer.contentView.trailingAnchor, constant: -16),
+            textField.topAnchor.constraint(equalTo: searchContainer.contentView.topAnchor),
+            textField.bottomAnchor.constraint(equalTo: searchContainer.contentView.bottomAnchor)
+        ])
+    }
+}
+
+#Preview {
+    let vc = UIViewController()
+    vc.view.backgroundColor = .gray50
+    let bar = ChagokSearchBar()
+    bar.translatesAutoresizingMaskIntoConstraints = false
+    vc.view.addSubview(bar)
+    NSLayoutConstraint.activate([
+        bar.leadingAnchor.constraint(equalTo: vc.view.leadingAnchor, constant: 16),
+        bar.trailingAnchor.constraint(equalTo: vc.view.trailingAnchor, constant: -16),
+        bar.centerYAnchor.constraint(equalTo: vc.view.centerYAnchor),
+        bar.heightAnchor.constraint(equalToConstant: 46)
+    ])
+    return vc
+}

--- a/Presentation/Sources/Component/Common/GlassButton.swift
+++ b/Presentation/Sources/Component/Common/GlassButton.swift
@@ -266,7 +266,7 @@ extension GlassButton {
         let imageName: String
         let type: GlassImageType
         let configuration: UIImage.SymbolConfiguration?
-        
+
         init(imageName: String, type: GlassImageType, configuration: UIImage.SymbolConfiguration? = nil) {
             self.imageName = imageName
             self.type = type

--- a/Presentation/Sources/Component/Common/GlassButton.swift
+++ b/Presentation/Sources/Component/Common/GlassButton.swift
@@ -108,7 +108,7 @@ extension GlassButton {
             case .resource:
                 config.image = UIImage(named: image.imageName)
             case .system:
-                config.image = UIImage(systemName: image.imageName)
+                config.image = UIImage(systemName: image.imageName, withConfiguration: image.configuration)
             }
         }
 
@@ -265,6 +265,13 @@ extension GlassButton {
     struct ImageAsset {
         let imageName: String
         let type: GlassImageType
+        let configuration: UIImage.SymbolConfiguration?
+        
+        init(imageName: String, type: GlassImageType, configuration: UIImage.SymbolConfiguration? = nil) {
+            self.imageName = imageName
+            self.type = type
+            self.configuration = configuration
+        }
     }
 
     enum GlassImageType {

--- a/Presentation/Sources/Component/Common/LanguagePickertAlert.swift
+++ b/Presentation/Sources/Component/Common/LanguagePickertAlert.swift
@@ -48,6 +48,7 @@ final class LanguagePickerAlert: UIView {
         self.languagePicker = languagePicker
         self.primaryButton = primaryButton
         super.init(frame: frame)
+        applyGlassEffect(tintColor: .point200.withAlphaComponent(0.2))
         setup()
         setupButton()
         childSetup()

--- a/Presentation/Sources/Component/Common/TextFieldView.swift
+++ b/Presentation/Sources/Component/Common/TextFieldView.swift
@@ -144,7 +144,6 @@ final class TextFieldView: UIView {
 
     private func setup() {
         translatesAutoresizingMaskIntoConstraints = false
-        backgroundColor = .point200.withAlphaComponent(0.2)
         layer.cornerRadius = Constant.cornerRadius
         layer.borderColor = UIColor.gray600.cgColor
         layer.borderWidth = Constant.borderWidth

--- a/Presentation/Sources/Component/Folder/SearchFolderCardView.swift
+++ b/Presentation/Sources/Component/Folder/SearchFolderCardView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct SearchFolderCardView: View {
+    let fullText: String
+    let keyword: String
+    let timeline: String
+    let action: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(
+                fullText: fullText,
+                keyword: keyword
+            )
+            .typography(.title3)
+            Text(timeline)
+                .typography(.label)
+                .foregroundStyle(.gray750)
+        }
+        .padding()
+        .glassEffect(.clear.tint(.point200.opacity(0.2)), in: .rect(cornerRadius: Constant.cornerRadius))
+        .onTapGesture {
+            action()
+        }
+    }
+}
+
+#Preview {
+    SearchFolderCardView(
+        fullText: "가을 하늘 맑고 푸른데",
+        keyword: "맑고",
+        timeline: "2025.02.03 (2026.03.04 수정됨)·2시간 29분",
+        action: {},
+    )
+}

--- a/Presentation/Sources/Component/Folder/SearchFolderCardView.swift
+++ b/Presentation/Sources/Component/Folder/SearchFolderCardView.swift
@@ -3,25 +3,34 @@ import SwiftUI
 struct SearchFolderCardView: View {
     let fullText: String
     let keyword: String
-    let timeline: String
+    let createdAt: String
+    let voiceNoteCount: Int
     let action: () -> Void
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(
-                fullText: fullText,
-                keyword: keyword
-            )
-            .typography(.title3)
-            Text(timeline)
-                .typography(.label)
+        HStack(spacing: 16) {
+            Image(systemName: "folder")
+                .frame(maxWidth: 20, maxHeight: 20)
+            VStack(alignment: .leading, spacing: 12) {
+                Text(
+                    fullText: fullText,
+                    keyword: keyword
+                )
+                .typography(.title3)
+                Text(createdAt)
+                    .typography(.label)
+                    .foregroundStyle(.gray750)
+            }
+            Spacer()
+            Text(String(voiceNoteCount))
+                .typography(.body2)
                 .foregroundStyle(.gray750)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .glassEffect(.clear.tint(.point200.opacity(0.2)), in: .rect(cornerRadius: Constant.cornerRadius))
-        .onTapGesture {
-            action()
-        }
+        .contentShape(.rect(cornerRadius: Constant.cornerRadius))
+        .onTapGesture { action() }
     }
 }
 
@@ -29,7 +38,9 @@ struct SearchFolderCardView: View {
     SearchFolderCardView(
         fullText: "가을 하늘 맑고 푸른데",
         keyword: "맑고",
-        timeline: "2025.02.03 (2026.03.04 수정됨)·2시간 29분",
+        createdAt: Date.now.description,
+        voiceNoteCount: 3,
         action: {},
     )
+    .padding()
 }

--- a/Presentation/Sources/Component/Folder/SearchFolderCardView.swift
+++ b/Presentation/Sources/Component/Folder/SearchFolderCardView.swift
@@ -6,7 +6,7 @@ struct SearchFolderCardView: View {
     let createdAt: String
     let voiceNoteCount: Int
     let action: () -> Void
-    
+
     var body: some View {
         HStack(spacing: 16) {
             Image(systemName: "folder")
@@ -40,7 +40,7 @@ struct SearchFolderCardView: View {
         keyword: "맑고",
         createdAt: Date.now.description,
         voiceNoteCount: 3,
-        action: {},
+        action: {}
     )
     .padding()
 }

--- a/Presentation/Sources/Component/VoiceNote/SearchVoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/VoiceNote/SearchVoiceNoteCardView.swift
@@ -2,117 +2,44 @@ import SwiftUI
 import Domain
 
 struct SearchVoiceNoteCardView: View {
-    let folderTitle: String
-    let voiceNoteTitle: String
+    let title: String
     let keyword: String
-    let transcript: Transcript
-    let keywords: [Keyword]
+    let timeline: String
+    let action: () -> Void
     
     var body: some View {
-        VStack(alignment: .leading) {
-            topContent
-            Divider().background(.gray300).padding(.vertical, 12)
-            keywordContent
-            Divider().background(.gray300).padding(.vertical, 12)
-            bottomContent
+        HStack(spacing: 16) {
+            Image(systemName: "microphone")
+                .frame(maxWidth: 20, maxHeight: 20)
+                .foregroundStyle(.gray750)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(fullText: title, keyword: keyword)
+                    .typography(.title3)
+                    .foregroundStyle(.gray950)
+                Text(timeline)
+                    .typography(.label)
+                    .foregroundStyle(.gray750)
+            }
         }
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .glassEffect(
             .clear.tint(.point200.opacity(0.2)),
             in: .rect(cornerRadius: Constant.cornerRadius)
         )
+        .contentShape(.rect(cornerRadius: Constant.cornerRadius))
+        .onTapGesture { action() }
     }
     
-    private var topContent: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Image(systemName: "folder")
-                Text(folderTitle).typography(.label)
-            }
-            Text(fullText: voiceNoteTitle, keyword: keyword)
-                .typography(.title3)
-                .foregroundStyle(.gray750)
-            Text(transcript: transcript, keyword: keyword)
-                .typography(.body3)
-                .lineLimit(2)
-        }
-    }
     
-    private var keywordContent: some View {
-        return VStack(alignment: .leading, spacing: 8) {
-            Text("키워드 매치 결과")
-                .typography(.caption)
-                .foregroundStyle(.gray400)
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 10) {
-                    ForEach(keywords) { item in
-                        Text(fullText: "#\(item.word)", keyword: keyword)
-                    }
-                }
-                .typography(.label)
-            }
-        }
-    }
-    
-    private var bottomContent: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("일치 위치로 이동")
-                .typography(.caption)
-                .foregroundStyle(.gray400)
-            HStack(spacing: 10) {
-                indicatorCard(title: "AI요약 n곳", fill: .point600)
-                indicatorCard(title: "스크립트 n곳", fill: .info)
-            }
-            Text("2025.02.03 (2026.03.04 수정됨)·2시간 29분")
-                .typography(.label)
-                .foregroundStyle(.gray750)
-        }
-    }
-}
-
-// MARK: - Helper Method
-extension SearchVoiceNoteCardView {
-    fileprivate func indicatorCard(
-        title: String,
-        fill: Color
-    ) -> some View {
-        HStack {
-            Circle().fill(fill)
-                .frame(maxWidth: 10, maxHeight: 10)
-            Text(title).typography(.body2)
-        }
-        .padding(.vertical, 4)
-        .padding(.horizontal, 12)
-        .overlay {
-            RoundedRectangle(cornerRadius: 99)
-                .fill(.clear)
-                .stroke(.gray350)
-        }
-    }
 }
 
 #Preview {
     SearchVoiceNoteCardView(
-        folderTitle: "강의",
-        voiceNoteTitle: "녹음을 요약한 기록 제목 가을",
-        keyword: "가을",
-        transcript: .init(
-            sections: [
-                TranscriptSection(timestamp: 0.0, text: "안녕하세요, 차곡입니다."),
-                TranscriptSection(timestamp: 2.5, text: "음성 메모에서 가을 키워드를 검색하는 테스트입니다."),
-                TranscriptSection(timestamp: 5.0, text: "텍스트 강조 기능이 잘 동작하는지 확인해볼게요.")
-            ]
-        ),
-        keywords: [
-            Keyword(noteID: UUID(), word: "가을"),
-            Keyword(noteID: UUID(), word: "123"),
-            Keyword(noteID: UUID(), word: "asd"),
-            Keyword(noteID: UUID(), word: "5324"),
-            Keyword(noteID: UUID(), word: "asdasf"),
-            Keyword(noteID: UUID(), word: "cas"),
-            Keyword(noteID: UUID(), word: "안녕")
-        ]
+        title: "녹음을 요약한 기록 제목 가을",
+        keyword: "녹음",
+        timeline: "오후 4:30 * 1시간 54분",
+        action: {}
     )
     .padding()
 }

--- a/Presentation/Sources/Component/VoiceNote/SearchVoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/VoiceNote/SearchVoiceNoteCardView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+import Domain
+
+struct SearchVoiceNoteCardView: View {
+    let folderTitle: String
+    let voiceNoteTitle: String
+    let keyword: String
+    let transcript: Transcript
+    let keywords: [Keyword]
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            topContent
+            Divider().background(.gray300).padding(.vertical, 12)
+            keywordContent
+            Divider().background(.gray300).padding(.vertical, 12)
+            bottomContent
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .glassEffect(
+            .clear.tint(.point200.opacity(0.2)),
+            in: .rect(cornerRadius: Constant.cornerRadius)
+        )
+    }
+    
+    private var topContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "folder")
+                Text(folderTitle).typography(.label)
+            }
+            Text(fullText: voiceNoteTitle, keyword: keyword)
+                .typography(.title3)
+                .foregroundStyle(.gray750)
+            Text(transcript: transcript, keyword: keyword)
+                .typography(.body3)
+                .lineLimit(2)
+        }
+    }
+    
+    private var keywordContent: some View {
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("키워드 매치 결과")
+                .typography(.caption)
+                .foregroundStyle(.gray400)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(keywords) { item in
+                        Text(fullText: "#\(item.word)", keyword: keyword)
+                    }
+                }
+                .typography(.label)
+            }
+        }
+    }
+    
+    private var bottomContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("일치 위치로 이동")
+                .typography(.caption)
+                .foregroundStyle(.gray400)
+            HStack(spacing: 10) {
+                indicatorCard(title: "AI요약 n곳", fill: .point600)
+                indicatorCard(title: "스크립트 n곳", fill: .info)
+            }
+            Text("2025.02.03 (2026.03.04 수정됨)·2시간 29분")
+                .typography(.label)
+                .foregroundStyle(.gray750)
+        }
+    }
+}
+
+// MARK: - Helper Method
+extension SearchVoiceNoteCardView {
+    fileprivate func indicatorCard(
+        title: String,
+        fill: Color
+    ) -> some View {
+        HStack {
+            Circle().fill(fill)
+                .frame(maxWidth: 10, maxHeight: 10)
+            Text(title).typography(.body2)
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 12)
+        .overlay {
+            RoundedRectangle(cornerRadius: 99)
+                .fill(.clear)
+                .stroke(.gray350)
+        }
+    }
+}
+
+#Preview {
+    SearchVoiceNoteCardView(
+        folderTitle: "강의",
+        voiceNoteTitle: "녹음을 요약한 기록 제목 가을",
+        keyword: "가을",
+        transcript: .init(
+            sections: [
+                TranscriptSection(timestamp: 0.0, text: "안녕하세요, 차곡입니다."),
+                TranscriptSection(timestamp: 2.5, text: "음성 메모에서 가을 키워드를 검색하는 테스트입니다."),
+                TranscriptSection(timestamp: 5.0, text: "텍스트 강조 기능이 잘 동작하는지 확인해볼게요.")
+            ]
+        ),
+        keywords: [
+            Keyword(noteID: UUID(), word: "가을"),
+            Keyword(noteID: UUID(), word: "123"),
+            Keyword(noteID: UUID(), word: "asd"),
+            Keyword(noteID: UUID(), word: "5324"),
+            Keyword(noteID: UUID(), word: "asdasf"),
+            Keyword(noteID: UUID(), word: "cas"),
+            Keyword(noteID: UUID(), word: "안녕")
+        ]
+    )
+    .padding()
+}

--- a/Presentation/Sources/Component/VoiceNote/SearchVoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/VoiceNote/SearchVoiceNoteCardView.swift
@@ -1,12 +1,12 @@
-import SwiftUI
 import Domain
+import SwiftUI
 
 struct SearchVoiceNoteCardView: View {
     let title: String
     let keyword: String
     let timeline: String
     let action: () -> Void
-    
+
     var body: some View {
         HStack(spacing: 16) {
             Image(systemName: "microphone")
@@ -30,8 +30,6 @@ struct SearchVoiceNoteCardView: View {
         .contentShape(.rect(cornerRadius: Constant.cornerRadius))
         .onTapGesture { action() }
     }
-    
-    
 }
 
 #Preview {

--- a/Presentation/Sources/DesignSystem/Font/Typography.swift
+++ b/Presentation/Sources/DesignSystem/Font/Typography.swift
@@ -1,5 +1,5 @@
-import UIKit
 import SwiftUI
+import UIKit
 
 public enum Typography {
     case header1
@@ -99,9 +99,8 @@ public extension View {
     func typography(_ style: Typography) -> some View {
         let targetLineHeight = style.font.pointSize * style.lineHeightRatio
         let spacing = targetLineHeight - style.font.lineHeight
-        
-        return self
-            .font(Font(style.font))
+
+        return font(Font(style.font))
             .tracking(style.letterSpacing)
             .lineSpacing(max(0, spacing))
     }

--- a/Presentation/Sources/DesignSystem/Font/Typography.swift
+++ b/Presentation/Sources/DesignSystem/Font/Typography.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SwiftUI
 
 public enum Typography {
     case header1
@@ -90,5 +91,18 @@ public extension UILabel {
         }
 
         attributedText = NSAttributedString(string: textToUse, attributes: attributes)
+    }
+}
+
+public extension View {
+    /// SwiftUI View에 Typography를 적용합니다.
+    func typography(_ style: Typography) -> some View {
+        let targetLineHeight = style.font.pointSize * style.lineHeightRatio
+        let spacing = targetLineHeight - style.font.lineHeight
+        
+        return self
+            .font(Font(style.font))
+            .tracking(style.letterSpacing)
+            .lineSpacing(max(0, spacing))
     }
 }

--- a/Presentation/Sources/DesignSystem/Text+HighlightedMultipleText.swift
+++ b/Presentation/Sources/DesignSystem/Text+HighlightedMultipleText.swift
@@ -1,8 +1,7 @@
-import SwiftUI
 import Domain
+import SwiftUI
 
 extension Text {
-    
     /// 문자열에서 키워드를 통해 강조색을 표현하는 이니셜라이저
     /// - Parameters:
     ///   - fullText: 전체 문장을 넣습니다.
@@ -12,30 +11,29 @@ extension Text {
             self.init(fullText)
             return
         }
-        
+
         var attributedString = AttributedString(fullText)
-        
+
         // 검색할 전체 범위
-        var searchRange = attributedString.startIndex..<attributedString.endIndex
-        
+        var searchRange = attributedString.startIndex ..< attributedString.endIndex
+
         // 범위 내에 키워드가 존재하는 한 계속 반복해서 찾습니다.
         while let range = attributedString[searchRange].range(of: keyword, options: .caseInsensitive) {
-            
             // 스타일 적용
             attributedString[range].foregroundColor = .point900
             attributedString[range].font = .body.weight(.bold)
-            
+
             // 찾은 부분 다음부터 다시 검색하도록 범위를 업데이트
-            searchRange = range.upperBound..<attributedString.endIndex
+            searchRange = range.upperBound ..< attributedString.endIndex
         }
-        
+
         self.init(attributedString)
     }
-    
+
     init(transcript: Transcript, keyword: String) {
         let targetText = transcript.sections.first { $0.text.localizedCaseInsensitiveContains(keyword) }?.text
-                         ?? transcript.sections.first?.text
-                         ?? ""
+            ?? transcript.sections.first?.text
+            ?? ""
         self.init(fullText: targetText, keyword: keyword)
     }
 }

--- a/Presentation/Sources/DesignSystem/Text+HighlightedMultipleText.swift
+++ b/Presentation/Sources/DesignSystem/Text+HighlightedMultipleText.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import Domain
+
+extension Text {
+    
+    /// 문자열에서 키워드를 통해 강조색을 표현하는 이니셜라이저
+    /// - Parameters:
+    ///   - fullText: 전체 문장을 넣습니다.
+    ///   - keyword: 강조하고 싶은 String 키워드
+    init(fullText: String, keyword: String) {
+        guard !keyword.isEmpty, fullText.localizedCaseInsensitiveContains(keyword) else {
+            self.init(fullText)
+            return
+        }
+        
+        var attributedString = AttributedString(fullText)
+        
+        // 검색할 전체 범위
+        var searchRange = attributedString.startIndex..<attributedString.endIndex
+        
+        // 범위 내에 키워드가 존재하는 한 계속 반복해서 찾습니다.
+        while let range = attributedString[searchRange].range(of: keyword, options: .caseInsensitive) {
+            
+            // 스타일 적용
+            attributedString[range].foregroundColor = .point900
+            attributedString[range].font = .body.weight(.bold)
+            
+            // 찾은 부분 다음부터 다시 검색하도록 범위를 업데이트
+            searchRange = range.upperBound..<attributedString.endIndex
+        }
+        
+        self.init(attributedString)
+    }
+    
+    init(transcript: Transcript, keyword: String) {
+        let targetText = transcript.sections.first { $0.text.localizedCaseInsensitiveContains(keyword) }?.text
+                         ?? transcript.sections.first?.text
+                         ?? ""
+        self.init(fullText: targetText, keyword: keyword)
+    }
+}

--- a/Presentation/Sources/DesignSystem/UIView+GlassEffect.swift
+++ b/Presentation/Sources/DesignSystem/UIView+GlassEffect.swift
@@ -11,8 +11,8 @@ extension UIView {
         glassEffect.isInteractive = false
         glassEffect.tintColor = tintColor
         let visualEffectView = UIVisualEffectView(effect: glassEffect)
+        visualEffectView.cornerConfiguration = .corners(radius: .fixed(cornerRadius))
         visualEffectView.translatesAutoresizingMaskIntoConstraints = false
-        visualEffectView.layer.cornerRadius = cornerRadius
         addSubview(visualEffectView)
         NSLayoutConstraint.activate([
             visualEffectView.topAnchor.constraint(equalTo: topAnchor),

--- a/Presentation/Sources/DesignSystem/UIVisualEffectView+GradientBorder.swift
+++ b/Presentation/Sources/DesignSystem/UIVisualEffectView+GradientBorder.swift
@@ -1,0 +1,120 @@
+import UIKit
+
+private final class GradientBorderOverlayView: UIView {
+    private let gradientLayer = CAGradientLayer()
+    private let borderMaskLayer = CAShapeLayer()
+
+    private var borderWidth: CGFloat = 1
+    private var borderCornerRadius: CGFloat = 0
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+
+        borderMaskLayer.fillColor = UIColor.clear.cgColor
+        borderMaskLayer.strokeColor = UIColor.black.cgColor
+        gradientLayer.mask = borderMaskLayer
+
+        layer.addSublayer(gradientLayer)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    func configure(
+        colors: [UIColor],
+        width: CGFloat,
+        cornerRadius: CGFloat,
+        startPoint: CGPoint,
+        endPoint: CGPoint
+    ) {
+        borderWidth = width
+        borderCornerRadius = cornerRadius
+        gradientLayer.colors = colors.map(\.cgColor)
+        gradientLayer.startPoint = startPoint
+        gradientLayer.endPoint = endPoint
+        borderMaskLayer.lineWidth = width
+
+        setNeedsLayout()
+    }
+
+    func updateCornerRadius(_ cornerRadius: CGFloat) {
+        borderCornerRadius = cornerRadius
+        setNeedsLayout()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        gradientLayer.frame = bounds
+
+        let inset = borderWidth / 2
+        let borderRect = bounds.insetBy(dx: inset, dy: inset)
+        let path = UIBezierPath(
+            roundedRect: borderRect,
+            cornerRadius: max(borderCornerRadius - inset, 0)
+        )
+
+        borderMaskLayer.path = path.cgPath
+    }
+}
+
+private extension UIVisualEffectView {
+    var gradientBorderOverlayView: GradientBorderOverlayView? {
+        contentView.subviews.first { $0 is GradientBorderOverlayView } as? GradientBorderOverlayView
+    }
+}
+
+extension UIVisualEffectView {
+    func setGradientBorder(
+        colors: [UIColor],
+        width: CGFloat = 1,
+        cornerRadius: CGFloat,
+        startPoint: CGPoint = CGPoint(x: 0, y: 0.5),
+        endPoint: CGPoint = CGPoint(x: 1, y: 0.5)
+    ) {
+        guard !colors.isEmpty else {
+            removeGradientBorder()
+            return
+        }
+
+        let overlayView: GradientBorderOverlayView
+
+        if let existingOverlay = gradientBorderOverlayView {
+            overlayView = existingOverlay
+        } else {
+            overlayView = GradientBorderOverlayView()
+            overlayView.translatesAutoresizingMaskIntoConstraints = false
+
+            contentView.addSubview(overlayView)
+            NSLayoutConstraint.activate([
+                overlayView.topAnchor.constraint(equalTo: contentView.topAnchor),
+                overlayView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                overlayView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                overlayView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            ])
+        }
+
+        overlayView.configure(
+            colors: colors,
+            width: width,
+            cornerRadius: cornerRadius,
+            startPoint: startPoint,
+            endPoint: endPoint
+        )
+
+        contentView.bringSubviewToFront(overlayView)
+    }
+
+    func updateGradientBorderCornerRadius(_ cornerRadius: CGFloat) {
+        gradientBorderOverlayView?.updateCornerRadius(cornerRadius)
+    }
+
+    func removeGradientBorder() {
+        gradientBorderOverlayView?.removeFromSuperview()
+    }
+}

--- a/Presentation/Sources/View/EmptyListCell.swift
+++ b/Presentation/Sources/View/EmptyListCell.swift
@@ -1,26 +1,29 @@
 import UIKit
 
-struct MainEmptyContentConfiguration: UIContentConfiguration {
+struct EmptyContentConfiguration: UIContentConfiguration {
+    let message: String
     func makeContentView() -> any UIView & UIContentView {
-        MainEmptyContentView(configuration: self)
+        EmptyContentView(configuration: self, message: message)
     }
 
-    func updated(for state: any UIConfigurationState) -> MainEmptyContentConfiguration {
+    func updated(for state: any UIConfigurationState) -> EmptyContentConfiguration {
         self
     }
 }
 
-final class MainEmptyContentView: UIView, UIContentView {
+final class EmptyContentView: UIView, UIContentView {
     var configuration: UIContentConfiguration {
         didSet { apply(configuration: configuration) }
     }
+    let message: String
 
     // MARK: - Component
 
-    private let messageLabel: UILabel = {
+    private lazy var messageLabel: UILabel = {
         let l = UILabel()
         l.translatesAutoresizingMaskIntoConstraints = false
-        l.setTypography(text: "아직 녹음된 기록이 없습니다", style: .subtitle2)
+        l.setTypography(text: message, style: .subtitle2)
+        l.numberOfLines = 0
         l.textColor = UIColor.gray600
         l.textAlignment = .center
         return l
@@ -28,8 +31,9 @@ final class MainEmptyContentView: UIView, UIContentView {
 
     // MARK: Initialize
 
-    init(configuration: UIContentConfiguration) {
+    init(configuration: UIContentConfiguration, message: String) {
         self.configuration = configuration
+        self.message = message
         super.init(frame: .zero)
         setup()
         apply(configuration: configuration)
@@ -53,6 +57,6 @@ final class MainEmptyContentView: UIView, UIContentView {
     // MARK: - Apply
 
     private func apply(configuration: UIContentConfiguration) {
-        guard configuration is MainEmptyContentConfiguration else { return }
+        guard configuration is EmptyContentConfiguration else { return }
     }
 }

--- a/Presentation/Sources/View/EmptyListCell.swift
+++ b/Presentation/Sources/View/EmptyListCell.swift
@@ -15,6 +15,7 @@ final class EmptyContentView: UIView, UIContentView {
     var configuration: UIContentConfiguration {
         didSet { apply(configuration: configuration) }
     }
+
     let message: String
 
     // MARK: - Component

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -355,7 +355,7 @@ private extension FolderDetailViewController {
             switch vm.select {
             case .none:
                 // TODO: 더 보기 로직 실행 ( 실행 X )
-                print("더 보기 버튼 탭됨")
+                break
             case .multiple, .all:
                 // TODO: 삭제 로직 실행
                 vm.openAlertView()
@@ -369,7 +369,7 @@ private extension FolderDetailViewController {
             switch vm.select {
             case .none:
                 // TODO: 검색 로직 실행
-                print("검색 버튼 탭됨")
+                vm.pushSearch()
             case .all, .multiple:
                 // TODO: 이동 로직 실행
                 vm.presentMoveFolder { [weak self] name in

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -21,7 +21,13 @@ public final class FolderViewController: CollectionViewController {
         selectedItem: .init(title: " \(vm.category.title)", imageName: "chevron.left"),
         attributedString: Typography.title1.textAttributes
     )
-
+    
+    private lazy var searchButton: NavigationItemButton = .init(
+        normalItem: .init(imageName: "magnifyingglass"),
+        selectedItem: .init(imageName: "magnifyingglass"),
+        attributedString: Typography.title1.textAttributes
+    )
+    
     private lazy var addButton: NavigationItemButton = .init(
         normalItem: .init(imageName: "folder.badge.plus"),
         selectedItem: .init(imageName: "folder.badge.plus"),
@@ -144,15 +150,22 @@ public final class FolderViewController: CollectionViewController {
         let leftItem = UIBarButtonItem(customView: backButton)
         navigationItem.leftBarButtonItem = leftItem
 
+        searchButton.addAction(
+            UIAction { [weak self] _ in
+                self?.vm.pushSearch()
+            }, for: .touchUpInside
+        )
+        
         addButton.addAction(
             UIAction { [weak self] _ in
                 self?.vm.openTextField()
             }, for: .touchUpInside
         )
-        let rightItem = UIBarButtonItem(customView: addButton)
-        navigationItem.rightBarButtonItem = rightItem
+        let rightSearchItem = UIBarButtonItem(customView: searchButton)
+        let rightAddItem = UIBarButtonItem(customView: addButton)
+        navigationItem.rightBarButtonItems = [rightAddItem, rightSearchItem]
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
-        navigationItem.rightBarButtonItem?.hidesSharedBackground = true
+        navigationItem.rightBarButtonItems?.forEach { $0.hidesSharedBackground = true }
     }
 
     /// 오른쪽 Swipe 액션을 제어하는 함수

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -21,13 +21,13 @@ public final class FolderViewController: CollectionViewController {
         selectedItem: .init(title: " \(vm.category.title)", imageName: "chevron.left"),
         attributedString: Typography.title1.textAttributes
     )
-    
+
     private lazy var searchButton: NavigationItemButton = .init(
         normalItem: .init(imageName: "magnifyingglass"),
         selectedItem: .init(imageName: "magnifyingglass"),
         attributedString: Typography.title1.textAttributes
     )
-    
+
     private lazy var addButton: NavigationItemButton = .init(
         normalItem: .init(imageName: "folder.badge.plus"),
         selectedItem: .init(imageName: "folder.badge.plus"),
@@ -155,7 +155,7 @@ public final class FolderViewController: CollectionViewController {
                 self?.vm.pushSearch()
             }, for: .touchUpInside
         )
-        
+
         addButton.addAction(
             UIAction { [weak self] _ in
                 self?.vm.openTextField()

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -54,10 +54,15 @@ public final class MainViewController: ViewController {
     private lazy var termsofServiceAction: UIAction = UIAction(title: "약관 보기") { [weak self] _ in
     }
 
-    private let searchItem: UIBarButtonItem = .init(
-        image: UIImage(systemName: "magnifyingglass"),
-        menu: nil
-    )
+    private lazy var searchItem: UIBarButtonItem = {
+        let search = UIBarButtonItem()
+        search.image = UIImage(systemName: "magnifyingglass")
+        search.menu = nil
+        search.primaryAction = UIAction { [weak self] _ in
+            self?.vm.pushSearchView()
+        }
+        return search
+    }()
 
     private lazy var settingItem: UIBarButtonItem = .init(
         image: UIImage(systemName: "gearshape"),
@@ -241,7 +246,9 @@ public final class MainViewController: ViewController {
 
         let emptyRegistration = EmptyCellRegistration { cell, _, _ in
             cell.backgroundConfiguration = .clear()
-            cell.contentConfiguration = MainEmptyContentConfiguration()
+            cell.contentConfiguration = EmptyContentConfiguration(
+                message: "아직 녹음된 기록이 없습니다.\n녹음 버튼을 눌러 첫 기록을 시작해보세요."
+            )
         }
 
         let categoryHeaderRegistration = CategoryHeaderRegistration(

--- a/Presentation/Sources/View/Search/Cell/SearchHeader.swift
+++ b/Presentation/Sources/View/Search/Cell/SearchHeader.swift
@@ -1,20 +1,19 @@
 import UIKit
 
 final class SearchHeader: UICollectionReusableView {
-    
     static let elementKind: String = "SearchHeader"
-    
+
     // MARK: - Component
-    
+
     private let container: UIStackView = {
         let search = UIStackView()
         search.translatesAutoresizingMaskIntoConstraints = false
         search.axis = .horizontal
         search.spacing = 2
-        
+
         return search
     }()
-    
+
     private let keywordLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -22,37 +21,37 @@ final class SearchHeader: UICollectionReusableView {
 
         return label
     }()
-    
+
     private let searchResultLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.setTypography(text: "검색 결과", style: .title3)
         label.textColor = .gray800
-        
+
         return label
     }()
-    
+
     private let resultCountLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = .point700
-        
+
         return label
     }()
-    
+
     // MARK: - Initialize
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
     }
-    
+
     required init?(coder: NSCoder) {
         nil
     }
-    
+
     // MARK: - Setup
-    
+
     private func setup() {
         let spacer = UIView()
         container.addArrangedSubview(keywordLabel)
@@ -60,7 +59,7 @@ final class SearchHeader: UICollectionReusableView {
         container.addArrangedSubview(resultCountLabel)
         container.addArrangedSubview(UIView())
         addSubview(container)
-        
+
         NSLayoutConstraint.activate([
             container.topAnchor.constraint(equalTo: topAnchor, constant: 24),
             container.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -68,9 +67,9 @@ final class SearchHeader: UICollectionReusableView {
             container.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
     }
-    
+
     // MARK: - Configure
-    
+
     func configure(
         keyword: String,
         resultCount: Int

--- a/Presentation/Sources/View/Search/Cell/SearchHeader.swift
+++ b/Presentation/Sources/View/Search/Cell/SearchHeader.swift
@@ -14,6 +14,14 @@ final class SearchHeader: UICollectionReusableView {
         return search
     }()
 
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .point700
+
+        return label
+    }()
+    
     private let searchResultLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -46,6 +54,7 @@ final class SearchHeader: UICollectionReusableView {
 
     private func setup() {
         let spacer = UIView()
+        container.addArrangedSubview(titleLabel)
         container.addArrangedSubview(searchResultLabel)
         container.addArrangedSubview(resultCountLabel)
         container.addArrangedSubview(spacer)
@@ -62,8 +71,10 @@ final class SearchHeader: UICollectionReusableView {
     // MARK: - Configure
 
     func configure(
+        title: String,
         resultCount: Int
     ) {
+        titleLabel.setTypography(text: title, style: .title3)
         resultCountLabel.setTypography(text: String(resultCount), style: .title3)
     }
 }

--- a/Presentation/Sources/View/Search/Cell/SearchHeader.swift
+++ b/Presentation/Sources/View/Search/Cell/SearchHeader.swift
@@ -21,7 +21,7 @@ final class SearchHeader: UICollectionReusableView {
 
         return label
     }()
-    
+
     private let searchResultLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/Presentation/Sources/View/Search/Cell/SearchHeader.swift
+++ b/Presentation/Sources/View/Search/Cell/SearchHeader.swift
@@ -14,14 +14,6 @@ final class SearchHeader: UICollectionReusableView {
         return search
     }()
 
-    private let keywordLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = .point700
-
-        return label
-    }()
-
     private let searchResultLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -54,10 +46,9 @@ final class SearchHeader: UICollectionReusableView {
 
     private func setup() {
         let spacer = UIView()
-        container.addArrangedSubview(keywordLabel)
         container.addArrangedSubview(searchResultLabel)
         container.addArrangedSubview(resultCountLabel)
-        container.addArrangedSubview(UIView())
+        container.addArrangedSubview(spacer)
         addSubview(container)
 
         NSLayoutConstraint.activate([
@@ -71,10 +62,8 @@ final class SearchHeader: UICollectionReusableView {
     // MARK: - Configure
 
     func configure(
-        keyword: String,
         resultCount: Int
     ) {
-        keywordLabel.setTypography(text: keyword, style: .title3)
         resultCountLabel.setTypography(text: String(resultCount), style: .title3)
     }
 }

--- a/Presentation/Sources/View/Search/Cell/SearchHeader.swift
+++ b/Presentation/Sources/View/Search/Cell/SearchHeader.swift
@@ -1,0 +1,81 @@
+import UIKit
+
+final class SearchHeader: UICollectionReusableView {
+    
+    static let elementKind: String = "SearchHeader"
+    
+    // MARK: - Component
+    
+    private let container: UIStackView = {
+        let search = UIStackView()
+        search.translatesAutoresizingMaskIntoConstraints = false
+        search.axis = .horizontal
+        search.spacing = 2
+        
+        return search
+    }()
+    
+    private let keywordLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .point700
+
+        return label
+    }()
+    
+    private let searchResultLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setTypography(text: "검색 결과", style: .title3)
+        label.textColor = .gray800
+        
+        return label
+    }()
+    
+    private let resultCountLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .point700
+        
+        return label
+    }()
+    
+    // MARK: - Initialize
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        nil
+    }
+    
+    // MARK: - Setup
+    
+    private func setup() {
+        let spacer = UIView()
+        container.addArrangedSubview(keywordLabel)
+        container.addArrangedSubview(searchResultLabel)
+        container.addArrangedSubview(resultCountLabel)
+        container.addArrangedSubview(UIView())
+        addSubview(container)
+        
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: topAnchor, constant: 24),
+            container.leadingAnchor.constraint(equalTo: leadingAnchor),
+            container.trailingAnchor.constraint(equalTo: trailingAnchor),
+            container.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+    
+    // MARK: - Configure
+    
+    func configure(
+        keyword: String,
+        resultCount: Int
+    ) {
+        keywordLabel.setTypography(text: keyword, style: .title3)
+        resultCountLabel.setTypography(text: String(resultCount), style: .title3)
+    }
+}

--- a/Presentation/Sources/View/Search/SearchViewController.swift
+++ b/Presentation/Sources/View/Search/SearchViewController.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import Domain
 
 public final class SearchViewController: ViewController {
     // MARK: - Type
@@ -13,7 +14,7 @@ public final class SearchViewController: ViewController {
     enum Item: Hashable {
         case empty
         case emptyResult
-        case result(LibraryItem)
+        case result(ContentItem)
     }
 
     typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
@@ -105,16 +106,16 @@ public final class SearchViewController: ViewController {
         }
 
         let resultCellRegistration = CellRegistration { cell, _, item in
-            guard case .result(let libraryItem) = item else { return }
+            guard case .result(let item) = item else { return }
             cell.backgroundConfiguration = .clear()
             cell.contentConfiguration = UIHostingConfiguration {
-                switch libraryItem {
+                switch item {
                 case .folder(let folder):
                     SearchFolderCardView(
                         fullText: folder.name,
                         keyword: self.vm.query,
                         createdAt: folder.createdAt.description,
-                        voiceNoteCount: folder.content.count
+                        voiceNoteCount: folder.voiceNoteIDs.count
                     ) { [weak self] in
                         self?.vm.pushFolder(folder)
                     }

--- a/Presentation/Sources/View/Search/SearchViewController.swift
+++ b/Presentation/Sources/View/Search/SearchViewController.swift
@@ -1,0 +1,290 @@
+import SwiftUI
+import UIKit
+
+public final class SearchViewController: ViewController {
+
+    // MARK: - Type
+
+    enum Section: Hashable {
+        case empty
+        case emptyResult
+        case result
+    }
+
+    enum Item: Hashable {
+        case empty
+        case emptyResult
+        case result(LibraryItem)
+    }
+
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
+    typealias SnapShot = NSDiffableDataSourceSnapshot<Section, Item>
+    typealias CellRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item>
+    typealias HeaderRegistration = UICollectionView.SupplementaryRegistration<SearchHeader>
+
+    // MARK: - Component
+
+    private let searchBar: ChagokSearchBar = .init()
+    private lazy var collectionView: CollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        let view = CollectionView(frame: .zero, collectionViewLayout: layout)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .clear
+        return view
+    }()
+
+    private var dataSource: DataSource!
+    private let vm: SearchViewModel
+
+    // MARK: - Initialize
+
+    public init(vm: SearchViewModel) {
+        self.vm = vm
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    // MARK: - LifeCycle
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+        setupSearchBar()
+        setupCollectionView()
+    }
+
+    public override func updateProperties() {
+        super.updateProperties()
+        updateNavigationBarAppearance(isTransparent: false)
+        updateDataSource()
+        updateVisibleHeader()
+    }
+
+    // MARK: - SetUp
+
+    private func setup() {
+        navigationItem.titleView = searchBar
+    }
+
+    private func setupSearchBar() {
+        searchBar.textField.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            vm.search(searchBar.textField.text ?? "")
+        }, for: .editingChanged)
+
+        searchBar.textField.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            vm.search(searchBar.textField.text ?? "")
+        }, for: .editingDidEndOnExit)
+
+        searchBar.closeButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            searchBar.textField.text = nil
+            vm.clearSearch()
+        }, for: .touchUpInside)
+    }
+
+    private func setupCollectionView() {
+        view.addSubview(collectionView)
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        collectionView.setCollectionViewLayout(createLayout(), animated: false)
+
+        // 셀 등록
+        let emptyCellRegistration = CellRegistration { cell, _, _ in
+            cell.backgroundConfiguration = .clear()
+            cell.contentConfiguration = EmptyContentConfiguration(
+                message: "검색 가능한 문서가 없습니다.\n지금 첫 기록을 시작해보세요."
+            )
+        }
+
+        let emptyResultCellRegistration = CellRegistration { cell, _, _ in
+            cell.backgroundConfiguration = .clear()
+            cell.contentConfiguration = EmptyContentConfiguration(
+                message: "검색 결과가 없습니다.\n다른 검색어로 검색해보세요."
+            )
+        }
+
+        let resultCellRegistration = CellRegistration { cell, _, item in
+            guard case .result(let libraryItem) = item else { return }
+            cell.backgroundConfiguration = .clear()
+            cell.contentConfiguration = UIHostingConfiguration {
+                switch libraryItem {
+                case .folder(let folder):
+                    FolderCardView(folder: folder)
+                case .voiceNote(let voiceNote):
+                    VoiceNoteCardView(voiceNote: voiceNote)
+                }
+            }
+            .margins(.all, 0)
+        }
+
+        // DataSource 설정
+        dataSource = DataSource(collectionView: collectionView) { collectionView, indexPath, item in
+            switch item {
+            case .empty:
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: emptyCellRegistration, for: indexPath, item: item
+                )
+            case .emptyResult:
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: emptyResultCellRegistration, for: indexPath, item: item
+                )
+            case .result:
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: resultCellRegistration, for: indexPath, item: item
+                )
+            }
+        }
+        
+        // 전역 Header
+        let headerRegistration = HeaderRegistration.init(elementKind: SearchHeader.elementKind) { [weak self] header, _, _ in
+            guard let self else { return }
+            header.configure(
+                keyword: vm.query,
+                resultCount: vm.filteredItems.count
+            )
+        }
+        
+        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
+            if kind == SearchHeader.elementKind {
+                return collectionView.dequeueConfiguredReusableSupplementary(using: headerRegistration, for: indexPath)
+            }
+            return nil
+        }
+
+        updateDataSource()
+    }
+}
+
+// MARK: - Update Method
+
+extension SearchViewController {
+    
+    private func updateDataSource() {
+        var snapshot = SnapShot()
+
+        switch vm.searchState {
+        case .empty:
+            snapshot.appendSections([.empty])
+            snapshot.appendItems([.empty], toSection: .empty)
+
+        case .emptyResult:
+            snapshot.appendSections([.emptyResult])
+            snapshot.appendItems([.emptyResult], toSection: .emptyResult)
+
+        case .result:
+            snapshot.appendSections([.result])
+            let resultItems = vm.filteredItems.map(Item.result)
+            snapshot.appendItems(resultItems, toSection: .result)
+        }
+
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+    
+    private func updateVisibleHeader() {
+        guard let header = collectionView
+            .visibleSupplementaryViews(ofKind: SearchHeader.elementKind)
+            .first as? SearchHeader
+        else { return }
+
+        header.configure(
+            keyword: vm.query,
+            resultCount: vm.filteredItems.count
+        )
+    }
+}
+
+// MARK: - Layout
+
+extension SearchViewController {
+    private func createLayout() -> UICollectionViewCompositionalLayout {
+        let sectionProvider: UICollectionViewCompositionalLayoutSectionProvider = { [weak self] sectionIndex, _ in
+            guard let self,
+                  let section = dataSource.sectionIdentifier(for: sectionIndex)
+            else {
+                return self?.emptySection()
+            }
+
+            switch section {
+            case .empty, .emptyResult:
+                return createSection(
+                    itemWidth: .fractionalWidth(1.0),
+                    itemHeight: .estimated(300),
+                    groupWidth: .fractionalWidth(1.0),
+                    groupHeight: .estimated(300)
+                )
+            case .result:
+                return createSection(
+                    itemWidth: .fractionalWidth(1.0),
+                    itemHeight: .estimated(120),
+                    groupWidth: .fractionalWidth(1.0),
+                    groupHeight: .estimated(120),
+                    interGroupSpacing: 8,
+                    contentInsets: .init(top: 16, leading: 20, bottom: 0, trailing: 20)
+                )
+            }
+        }
+
+        let configuration = UICollectionViewCompositionalLayoutConfiguration()
+        let globalHeader = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .estimated(44)
+            ),
+            elementKind: SearchHeader.elementKind,
+            alignment: .top
+        )
+        globalHeader.contentInsets = .init(top: 0, leading: 20, bottom: 0, trailing: 20)
+        globalHeader.pinToVisibleBounds = true
+        globalHeader.zIndex = 10
+        configuration.boundarySupplementaryItems = [globalHeader]
+
+        return UICollectionViewCompositionalLayout(
+            sectionProvider: sectionProvider,
+            configuration: configuration
+        )
+    }
+
+    private func createSection(
+        itemWidth: NSCollectionLayoutDimension,
+        itemHeight: NSCollectionLayoutDimension,
+        groupWidth: NSCollectionLayoutDimension,
+        groupHeight: NSCollectionLayoutDimension,
+        interGroupSpacing: CGFloat = 0.0,
+        contentInsets: NSDirectionalEdgeInsets = .zero
+    ) -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: itemWidth, heightDimension: itemHeight)
+        let groupSize = NSCollectionLayoutSize(widthDimension: groupWidth, heightDimension: groupHeight)
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = interGroupSpacing
+        section.contentInsets = contentInsets
+        return section
+    }
+
+    private func emptySection() -> NSCollectionLayoutSection {
+        createSection(
+            itemWidth: .fractionalWidth(0),
+            itemHeight: .fractionalHeight(0),
+            groupWidth: .fractionalWidth(0),
+            groupHeight: .fractionalHeight(0)
+        )
+    }
+}
+
+#Preview {
+    UINavigationController(
+        rootViewController: SearchViewController(vm: SearchViewModel())
+    )
+}

--- a/Presentation/Sources/View/Search/SearchViewController.swift
+++ b/Presentation/Sources/View/Search/SearchViewController.swift
@@ -71,11 +71,6 @@ public final class SearchViewController: ViewController {
     }
 
     private func setupSearchBar() {
-        searchBar.textField.addAction(UIAction { [weak self] _ in
-            guard let self else { return }
-            vm.search(searchBar.textField.text ?? "")
-        }, for: .editingChanged)
-
         searchBar.textField.delegate = self
 
         searchBar.closeButton.addAction(UIAction { [weak self] _ in
@@ -99,9 +94,7 @@ public final class SearchViewController: ViewController {
         // 셀 등록
         let emptyCellRegistration = CellRegistration { cell, _, _ in
             cell.backgroundConfiguration = .clear()
-            cell.contentConfiguration = EmptyContentConfiguration(
-                message: "검색 가능한 문서가 없습니다.\n지금 첫 기록을 시작해보세요."
-            )
+            cell.contentConfiguration = nil
         }
 
         let emptyResultCellRegistration = CellRegistration { cell, _, _ in
@@ -117,9 +110,26 @@ public final class SearchViewController: ViewController {
             cell.contentConfiguration = UIHostingConfiguration {
                 switch libraryItem {
                 case .folder(let folder):
-                    FolderCardView(folder: folder)
+                    SearchFolderCardView(
+                        fullText: folder.name,
+                        keyword: self.vm.query,
+                        createdAt: folder.createdAt.description,
+                        voiceNoteCount: folder.content.count
+                    ) { [weak self] in
+                        self?.vm.pushFolder(folder)
+                    }
                 case .voiceNote(let voiceNote):
-                    VoiceNoteCardView(voiceNote: voiceNote)
+                    SearchVoiceNoteCardView(
+                        title: voiceNote.title,
+                        keyword: self.vm.query,
+                        timeline: Date.now.voiceNoteDay(
+                            createdAt: voiceNote.createdAt,
+                            updatedAt: voiceNote.updatedAt,
+                            duration: voiceNote.voiceRecord.duration
+                        )
+                    ) { [weak self] in
+                        self?.vm.pushVoiceNote(voiceNote)
+                    }
                 }
             }
             .margins(.all, 0)
@@ -147,7 +157,7 @@ public final class SearchViewController: ViewController {
         let headerRegistration = HeaderRegistration(elementKind: SearchHeader.elementKind) { [weak self] header, _, _ in
             guard let self else { return }
             header.configure(
-                keyword: vm.query,
+                title: vm.type.title,
                 resultCount: vm.filteredItems.count
             )
         }
@@ -194,7 +204,7 @@ extension SearchViewController {
         else { return }
 
         header.configure(
-            keyword: vm.query,
+            title: vm.type.title,
             resultCount: vm.filteredItems.count
         )
     }
@@ -284,12 +294,19 @@ extension SearchViewController {
 extension SearchViewController: UITextFieldDelegate {
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
+        vm.search(searchBar.textField.text ?? "")
         return true
     }
 }
 
 #Preview {
+    
     UINavigationController(
-        rootViewController: SearchViewController(vm: SearchViewModel())
+        rootViewController: SearchViewController(
+            vm: SearchViewModel(
+                type: .main,
+                items: []
+            )
+        )
     )
 }

--- a/Presentation/Sources/View/Search/SearchViewController.swift
+++ b/Presentation/Sources/View/Search/SearchViewController.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import UIKit
 
 public final class SearchViewController: ViewController {
-
     // MARK: - Type
 
     enum Section: Hashable {
@@ -57,7 +56,7 @@ public final class SearchViewController: ViewController {
         setupCollectionView()
     }
 
-    public override func updateProperties() {
+    override public func updateProperties() {
         super.updateProperties()
         updateNavigationBarAppearance(isTransparent: false)
         updateDataSource()
@@ -145,16 +144,16 @@ public final class SearchViewController: ViewController {
                 )
             }
         }
-        
+
         // 전역 Header
-        let headerRegistration = HeaderRegistration.init(elementKind: SearchHeader.elementKind) { [weak self] header, _, _ in
+        let headerRegistration = HeaderRegistration(elementKind: SearchHeader.elementKind) { [weak self] header, _, _ in
             guard let self else { return }
             header.configure(
                 keyword: vm.query,
                 resultCount: vm.filteredItems.count
             )
         }
-        
+
         dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
             if kind == SearchHeader.elementKind {
                 return collectionView.dequeueConfiguredReusableSupplementary(using: headerRegistration, for: indexPath)
@@ -169,7 +168,6 @@ public final class SearchViewController: ViewController {
 // MARK: - Update Method
 
 extension SearchViewController {
-    
     private func updateDataSource() {
         var snapshot = SnapShot()
 
@@ -190,7 +188,7 @@ extension SearchViewController {
 
         dataSource.apply(snapshot, animatingDifferences: true)
     }
-    
+
     private func updateVisibleHeader() {
         guard let header = collectionView
             .visibleSupplementaryViews(ofKind: SearchHeader.elementKind)

--- a/Presentation/Sources/View/Search/SearchViewController.swift
+++ b/Presentation/Sources/View/Search/SearchViewController.swift
@@ -1,6 +1,6 @@
+import Domain
 import SwiftUI
 import UIKit
-import Domain
 
 public final class SearchViewController: ViewController {
     // MARK: - Type
@@ -276,7 +276,7 @@ extension SearchViewController {
             alignment: .top
         )
         header.pinToVisibleBounds = true
-        header.zIndex = 1_000
+        header.zIndex = 1000
         return header
     }
 
@@ -301,7 +301,6 @@ extension SearchViewController: UITextFieldDelegate {
 }
 
 #Preview {
-    
     UINavigationController(
         rootViewController: SearchViewController(
             vm: SearchViewModel(

--- a/Presentation/Sources/View/Search/SearchViewController.swift
+++ b/Presentation/Sources/View/Search/SearchViewController.swift
@@ -67,6 +67,7 @@ public final class SearchViewController: ViewController {
 
     private func setup() {
         navigationItem.titleView = searchBar
+        navigationItem.hidesBackButton = true
     }
 
     private func setupSearchBar() {
@@ -75,10 +76,7 @@ public final class SearchViewController: ViewController {
             vm.search(searchBar.textField.text ?? "")
         }, for: .editingChanged)
 
-        searchBar.textField.addAction(UIAction { [weak self] _ in
-            guard let self else { return }
-            vm.search(searchBar.textField.text ?? "")
-        }, for: .editingDidEndOnExit)
+        searchBar.textField.delegate = self
 
         searchBar.closeButton.addAction(UIAction { [weak self] _ in
             guard let self else { return }
@@ -228,29 +226,13 @@ extension SearchViewController {
                     groupWidth: .fractionalWidth(1.0),
                     groupHeight: .estimated(120),
                     interGroupSpacing: 8,
-                    contentInsets: .init(top: 16, leading: 20, bottom: 0, trailing: 20)
+                    contentInsets: .init(top: 16, leading: 20, bottom: 0, trailing: 20),
+                    boundarySupplementaryItems: [searchHeaderItem()]
                 )
             }
         }
 
-        let configuration = UICollectionViewCompositionalLayoutConfiguration()
-        let globalHeader = NSCollectionLayoutBoundarySupplementaryItem(
-            layoutSize: NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .estimated(44)
-            ),
-            elementKind: SearchHeader.elementKind,
-            alignment: .top
-        )
-        globalHeader.contentInsets = .init(top: 0, leading: 20, bottom: 0, trailing: 20)
-        globalHeader.pinToVisibleBounds = true
-        globalHeader.zIndex = 10
-        configuration.boundarySupplementaryItems = [globalHeader]
-
-        return UICollectionViewCompositionalLayout(
-            sectionProvider: sectionProvider,
-            configuration: configuration
-        )
+        return UICollectionViewCompositionalLayout(sectionProvider: sectionProvider)
     }
 
     private func createSection(
@@ -259,7 +241,8 @@ extension SearchViewController {
         groupWidth: NSCollectionLayoutDimension,
         groupHeight: NSCollectionLayoutDimension,
         interGroupSpacing: CGFloat = 0.0,
-        contentInsets: NSDirectionalEdgeInsets = .zero
+        contentInsets: NSDirectionalEdgeInsets = .zero,
+        boundarySupplementaryItems: [NSCollectionLayoutBoundarySupplementaryItem] = []
     ) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(widthDimension: itemWidth, heightDimension: itemHeight)
         let groupSize = NSCollectionLayoutSize(widthDimension: groupWidth, heightDimension: groupHeight)
@@ -268,7 +251,22 @@ extension SearchViewController {
         let section = NSCollectionLayoutSection(group: group)
         section.interGroupSpacing = interGroupSpacing
         section.contentInsets = contentInsets
+        section.boundarySupplementaryItems = boundarySupplementaryItems
         return section
+    }
+
+    private func searchHeaderItem() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .estimated(44)
+            ),
+            elementKind: SearchHeader.elementKind,
+            alignment: .top
+        )
+        header.pinToVisibleBounds = true
+        header.zIndex = 1_000
+        return header
     }
 
     private func emptySection() -> NSCollectionLayoutSection {
@@ -278,6 +276,15 @@ extension SearchViewController {
             groupWidth: .fractionalWidth(0),
             groupHeight: .fractionalHeight(0)
         )
+    }
+}
+
+// MARK: 검색 Delegate
+
+extension SearchViewController: UITextFieldDelegate {
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
     }
 }
 

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -344,7 +344,7 @@ private extension TrashViewController {
             guard let self else { return }
             switch vm.select {
             case .none:
-                print("검색 버튼 탭됨")
+                vm.pushSearch()
             case .multiple, .all:
                 guard let selectedItems = selectedItemsForBulkAction() else {
                     return

--- a/Presentation/Sources/ViewModel/CoordinatorDelegate/MainCoordinatorDelegate.swift
+++ b/Presentation/Sources/ViewModel/CoordinatorDelegate/MainCoordinatorDelegate.swift
@@ -15,4 +15,6 @@ public protocol MainCoordinatorDelegate: AnyObject {
     func presentRecodingView()
     /// 공용 Pop함수
     func pop()
+    /// 검색 화면 Push함수
+    func pushSearchView()
 }

--- a/Presentation/Sources/ViewModel/CoordinatorDelegate/MainCoordinatorDelegate.swift
+++ b/Presentation/Sources/ViewModel/CoordinatorDelegate/MainCoordinatorDelegate.swift
@@ -16,5 +16,5 @@ public protocol MainCoordinatorDelegate: AnyObject {
     /// 공용 Pop함수
     func pop()
     /// 검색 화면 Push함수
-    func pushSearchView()
+    func pushSearchView(type: SearchViewModel.SearchType, items: [LibraryItem])
 }

--- a/Presentation/Sources/ViewModel/CoordinatorDelegate/MainCoordinatorDelegate.swift
+++ b/Presentation/Sources/ViewModel/CoordinatorDelegate/MainCoordinatorDelegate.swift
@@ -16,5 +16,5 @@ public protocol MainCoordinatorDelegate: AnyObject {
     /// 공용 Pop함수
     func pop()
     /// 검색 화면 Push함수
-    func pushSearchView(type: SearchViewModel.SearchType, items: [LibraryItem])
+    func pushSearchView(type: SearchViewModel.SearchType, items: [ContentItem])
 }

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -101,7 +101,7 @@ extension FolderDetailViewModel {
         guard !selectedItems.isEmpty else { return }
         coordinator?.presentFolderList(with: selectedItems, onComplete: dismiss)
     }
-    
+
     /// 검색화면 이동
     func pushSearch() {
         coordinator?.pushSearchView(type: .myDetailFolder(title), items: items)

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -4,9 +4,14 @@ import Foundation
 
 @MainActor
 public protocol FolderDetailCoordinatorDelegate: AnyObject {
+    /// 뒤로 가기
     func pop()
+    /// 음성 노트 가기
     func pushVoiceNoteView(voiceNote: VoiceNote)
+    /// 폴더 이동 Sheet
     func presentFolderList(with voiceNotes: [VoiceNote], onComplete: ((String) -> Void)?)
+    /// 검색 화면 Push함수
+    func pushSearchView(type: SearchViewModel.SearchType, items: [ContentItem])
 }
 
 @MainActor
@@ -95,6 +100,11 @@ extension FolderDetailViewModel {
     func presentMoveFolder(dismiss: @escaping (String) -> Void) {
         guard !selectedItems.isEmpty else { return }
         coordinator?.presentFolderList(with: selectedItems, onComplete: dismiss)
+    }
+    
+    /// 검색화면 이동
+    func pushSearch() {
+        coordinator?.pushSearchView(type: .myDetailFolder(title), items: items)
     }
 
     /// 전체 선택

--- a/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
@@ -4,8 +4,12 @@ import Foundation
 
 @MainActor
 public protocol FolderCoordinatorDelegate: AnyObject {
+    /// 뒤로 가기
     func pop()
+    /// 폴더 상세 Push
     func pushMyFolderDetailView(_ folder: Folder)
+    /// 검색 화면 Push함수
+    func pushSearchView(type: SearchViewModel.SearchType, items: [ContentItem])
 }
 
 @MainActor
@@ -66,6 +70,10 @@ extension FolderViewModel {
 
     func pushDetail(_ folder: Folder) {
         coordinator?.pushMyFolderDetailView(folder)
+    }
+    
+    func pushSearch() {
+        coordinator?.pushSearchView(type: .myFolder, items: category.items)
     }
 }
 

--- a/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
@@ -71,7 +71,7 @@ extension FolderViewModel {
     func pushDetail(_ folder: Folder) {
         coordinator?.pushMyFolderDetailView(folder)
     }
-    
+
     func pushSearch() {
         coordinator?.pushSearchView(type: .myFolder, items: category.items)
     }

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -147,6 +147,10 @@ extension MainViewModel {
     func presentRecodingView() {
         mainCoordinator?.presentRecodingView()
     }
+    
+    func pushSearchView() {
+        mainCoordinator?.pushSearchView()
+    }
 }
 
 // MARK: - Update CategoryData

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -149,7 +149,7 @@ extension MainViewModel {
     }
 
     func pushSearchView() {
-        var uniqueItems: [LibraryItem] = []
+        var uniqueItems: [ContentItem] = []
         var seenIDs: Set<UUID> = []
 
         let searchableCategories = categoryData.prefix(3)

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -147,7 +147,7 @@ extension MainViewModel {
     func presentRecodingView() {
         mainCoordinator?.presentRecodingView()
     }
-    
+
     func pushSearchView() {
         mainCoordinator?.pushSearchView()
     }

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -149,7 +149,22 @@ extension MainViewModel {
     }
 
     func pushSearchView() {
-        mainCoordinator?.pushSearchView()
+        var uniqueItems: [LibraryItem] = []
+        var seenIDs: Set<UUID> = []
+
+        let searchableCategories = categoryData.prefix(3)
+
+        for item in searchableCategories.flatMap(\.items) {
+            if !seenIDs.contains(item.id) {
+                seenIDs.insert(item.id)
+                uniqueItems.append(item)
+            }
+        }
+
+        mainCoordinator?.pushSearchView(
+            type: .main,
+            items: uniqueItems
+        )
     }
 }
 

--- a/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
+++ b/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
@@ -1,18 +1,21 @@
-import Foundation
 import Domain
+import Foundation
 
-public protocol SearchCoordinatorDelegate: BaseCoordinatorDelegate {}
+@MainActor
+public protocol SearchCoordinatorDelegate: AnyObject {
+    /// 뒤로 가기
+    func pop()
+}
 
 @MainActor
 @Observable
 public final class SearchViewModel {
-
     // MARK: - Search State
 
     enum SearchState {
-        case empty        // 검색 전
-        case emptyResult  // 검색 결과 없음
-        case result       // 검색 결과 있음
+        case empty // 검색 전
+        case emptyResult // 검색 결과 없음
+        case result // 검색 결과 있음
     }
 
     // MARK: - State
@@ -20,19 +23,17 @@ public final class SearchViewModel {
     private(set) var searchState: SearchState = .empty
     private(set) var filteredItems: [LibraryItem] = []
     private(set) var query: String = ""
-    private weak var coordinator: SearchCoordinatorDelegate?
-    
+    public weak var coordinator: SearchCoordinatorDelegate?
+
     // MARK: Initialize
-    
-    public init() {
-        
-    }
-    
+
+    public init() {}
+
     // MARK: - Data (더미)
 
     let items: [LibraryItem] = [
         .folder(Folder(name: "여행 계획", createdAt: .now.addingTimeInterval(-86400), content: [], isDeletable: true)),
-        .folder(Folder(name: "업무 미팅", createdAt: .now.addingTimeInterval(-172800), content: [], isDeletable: true)),
+        .folder(Folder(name: "업무 미팅", createdAt: .now.addingTimeInterval(-172_800), content: [], isDeletable: true)),
         .voiceNote(VoiceNote(
             title: "아이디어 스케치",
             createdAt: .now.addingTimeInterval(-3600),
@@ -49,7 +50,7 @@ public final class SearchViewModel {
             voiceRecord: VoiceRecord(createdAt: .now.addingTimeInterval(-7200), audioFilePath: "", duration: 300),
             analysisState: .completed
         )),
-        .folder(Folder(name: "개인 프로젝트", createdAt: .now.addingTimeInterval(-259200), content: [], isDeletable: true)),
+        .folder(Folder(name: "개인 프로젝트", createdAt: .now.addingTimeInterval(-259_200), content: [], isDeletable: true)),
         .voiceNote(VoiceNote(
             title: "장보기 리스트",
             createdAt: .now.addingTimeInterval(-10800),

--- a/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
+++ b/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
@@ -45,17 +45,17 @@ public final class SearchViewModel {
     // MARK: - State
 
     @ObservationIgnored
-    private(set) var items: [LibraryItem]
+    private(set) var items: [ContentItem]
     @ObservationIgnored
     let type: SearchType
     private(set) var searchState: SearchState = .empty
-    private(set) var filteredItems: [LibraryItem] = []
+    private(set) var filteredItems: [ContentItem] = []
     private(set) var query: String = ""
     public weak var coordinator: SearchCoordinatorDelegate?
 
     // MARK: Initialize
 
-    public init(type: SearchType, items: [LibraryItem]) {
+    public init(type: SearchType, items: [ContentItem]) {
         self.type = type
         self.items = items
     }

--- a/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
+++ b/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
@@ -22,7 +22,7 @@ public final class SearchViewModel {
         case result                     // 검색 결과 있음
     }
     
-    public enum SearchType {
+    public enum SearchType: Equatable {
         case main                       // 메인
         case myFolder                   // 폴더 목록
         case myDetailFolder(String)     // 상세 폴더

--- a/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
+++ b/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Domain
+
+public protocol SearchCoordinatorDelegate: BaseCoordinatorDelegate {}
+
+@MainActor
+@Observable
+public final class SearchViewModel {
+
+    // MARK: - Search State
+
+    enum SearchState {
+        case empty        // 검색 전
+        case emptyResult  // 검색 결과 없음
+        case result       // 검색 결과 있음
+    }
+
+    // MARK: - State
+
+    private(set) var searchState: SearchState = .empty
+    private(set) var filteredItems: [LibraryItem] = []
+    private(set) var query: String = ""
+    private weak var coordinator: SearchCoordinatorDelegate?
+    
+    // MARK: Initialize
+    
+    public init() {
+        
+    }
+    
+    // MARK: - Data (더미)
+
+    let items: [LibraryItem] = [
+        .folder(Folder(name: "여행 계획", createdAt: .now.addingTimeInterval(-86400), content: [], isDeletable: true)),
+        .folder(Folder(name: "업무 미팅", createdAt: .now.addingTimeInterval(-172800), content: [], isDeletable: true)),
+        .voiceNote(VoiceNote(
+            title: "아이디어 스케치",
+            createdAt: .now.addingTimeInterval(-3600),
+            updatedAt: .now.addingTimeInterval(-3600),
+            folderID: UUID(),
+            voiceRecord: VoiceRecord(createdAt: .now.addingTimeInterval(-3600), audioFilePath: "", duration: 120),
+            analysisState: .completed
+        )),
+        .voiceNote(VoiceNote(
+            title: "주간 회의록",
+            createdAt: .now.addingTimeInterval(-7200),
+            updatedAt: .now.addingTimeInterval(-7200),
+            folderID: UUID(),
+            voiceRecord: VoiceRecord(createdAt: .now.addingTimeInterval(-7200), audioFilePath: "", duration: 300),
+            analysisState: .completed
+        )),
+        .folder(Folder(name: "개인 프로젝트", createdAt: .now.addingTimeInterval(-259200), content: [], isDeletable: true)),
+        .voiceNote(VoiceNote(
+            title: "장보기 리스트",
+            createdAt: .now.addingTimeInterval(-10800),
+            updatedAt: .now.addingTimeInterval(-10800),
+            folderID: UUID(),
+            voiceRecord: VoiceRecord(createdAt: .now.addingTimeInterval(-10800), audioFilePath: "", duration: 45),
+            analysisState: .completed
+        ))
+    ]
+
+    // MARK: - Action
+
+    func search(_ query: String) {
+        self.query = query
+
+        guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
+            searchState = .empty
+            filteredItems = []
+            return
+        }
+
+        let results = items.filter { item in
+            switch item {
+            case .folder(let folder):
+                return folder.name.localizedCaseInsensitiveContains(query)
+            case .voiceNote(let voiceNote):
+                return voiceNote.title.localizedCaseInsensitiveContains(query)
+            }
+        }
+
+        filteredItems = results
+        searchState = results.isEmpty ? .emptyResult : .result
+    }
+
+    func clearSearch() {
+        coordinator?.pop()
+    }
+}

--- a/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
+++ b/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
@@ -17,17 +17,17 @@ public final class SearchViewModel {
     // MARK: - Search State
 
     enum SearchState {
-        case empty                      // 검색 전
-        case emptyResult                // 검색 결과 없음
-        case result                     // 검색 결과 있음
+        case empty // 검색 전
+        case emptyResult // 검색 결과 없음
+        case result // 검색 결과 있음
     }
-    
+
     public enum SearchType: Equatable {
-        case main                       // 메인
-        case myFolder                   // 폴더 목록
-        case myDetailFolder(String)     // 상세 폴더
-        case trash                      // 휴지통
-        
+        case main // 메인
+        case myFolder // 폴더 목록
+        case myDetailFolder(String) // 상세 폴더
+        case trash // 휴지통
+
         var title: String {
             switch self {
             case .main:
@@ -87,13 +87,13 @@ public final class SearchViewModel {
     func clearSearch() {
         coordinator?.pop()
     }
-    
+
     // MARK: - Coordinator
-    
+
     func pushFolder(_ folder: Folder) {
         coordinator?.pushMyFolderDetailView(folder)
     }
-    
+
     func pushVoiceNote(_ voiceNote: VoiceNote) {
         coordinator?.pushVoiceNoteView(voiceNote: voiceNote)
     }

--- a/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
+++ b/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
@@ -5,6 +5,10 @@ import Foundation
 public protocol SearchCoordinatorDelegate: AnyObject {
     /// 뒤로 가기
     func pop()
+    /// 폴더 Push
+    func pushMyFolderDetailView(_ folder: Folder)
+    /// 음성 노트 Push
+    func pushVoiceNoteView(voiceNote: VoiceNote)
 }
 
 @MainActor
@@ -13,13 +17,37 @@ public final class SearchViewModel {
     // MARK: - Search State
 
     enum SearchState {
-        case empty // 검색 전
-        case emptyResult // 검색 결과 없음
-        case result // 검색 결과 있음
+        case empty                      // 검색 전
+        case emptyResult                // 검색 결과 없음
+        case result                     // 검색 결과 있음
+    }
+    
+    public enum SearchType {
+        case main                       // 메인
+        case myFolder                   // 폴더 목록
+        case myDetailFolder(String)     // 상세 폴더
+        case trash                      // 휴지통
+        
+        var title: String {
+            switch self {
+            case .main:
+                "전체"
+            case .myFolder:
+                "폴더 목록"
+            case .myDetailFolder(let name):
+                name
+            case .trash:
+                "휴지통"
+            }
+        }
     }
 
     // MARK: - State
 
+    @ObservationIgnored
+    private(set) var items: [LibraryItem]
+    @ObservationIgnored
+    let type: SearchType
     private(set) var searchState: SearchState = .empty
     private(set) var filteredItems: [LibraryItem] = []
     private(set) var query: String = ""
@@ -27,39 +55,10 @@ public final class SearchViewModel {
 
     // MARK: Initialize
 
-    public init() {}
-
-    // MARK: - Data (더미)
-
-    let items: [LibraryItem] = [
-        .folder(Folder(name: "여행 계획", createdAt: .now.addingTimeInterval(-86400), content: [], isDeletable: true)),
-        .folder(Folder(name: "업무 미팅", createdAt: .now.addingTimeInterval(-172_800), content: [], isDeletable: true)),
-        .voiceNote(VoiceNote(
-            title: "아이디어 스케치",
-            createdAt: .now.addingTimeInterval(-3600),
-            updatedAt: .now.addingTimeInterval(-3600),
-            folderID: UUID(),
-            voiceRecord: VoiceRecord(createdAt: .now.addingTimeInterval(-3600), audioFilePath: "", duration: 120),
-            analysisState: .completed
-        )),
-        .voiceNote(VoiceNote(
-            title: "주간 회의록",
-            createdAt: .now.addingTimeInterval(-7200),
-            updatedAt: .now.addingTimeInterval(-7200),
-            folderID: UUID(),
-            voiceRecord: VoiceRecord(createdAt: .now.addingTimeInterval(-7200), audioFilePath: "", duration: 300),
-            analysisState: .completed
-        )),
-        .folder(Folder(name: "개인 프로젝트", createdAt: .now.addingTimeInterval(-259_200), content: [], isDeletable: true)),
-        .voiceNote(VoiceNote(
-            title: "장보기 리스트",
-            createdAt: .now.addingTimeInterval(-10800),
-            updatedAt: .now.addingTimeInterval(-10800),
-            folderID: UUID(),
-            voiceRecord: VoiceRecord(createdAt: .now.addingTimeInterval(-10800), audioFilePath: "", duration: 45),
-            analysisState: .completed
-        ))
-    ]
+    public init(type: SearchType, items: [LibraryItem]) {
+        self.type = type
+        self.items = items
+    }
 
     // MARK: - Action
 
@@ -87,5 +86,15 @@ public final class SearchViewModel {
 
     func clearSearch() {
         coordinator?.pop()
+    }
+    
+    // MARK: - Coordinator
+    
+    func pushFolder(_ folder: Folder) {
+        coordinator?.pushMyFolderDetailView(folder)
+    }
+    
+    func pushVoiceNote(_ voiceNote: VoiceNote) {
+        coordinator?.pushVoiceNoteView(voiceNote: voiceNote)
     }
 }

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -4,9 +4,14 @@ import Foundation
 
 @MainActor
 public protocol TrashCoordinatorDelegate: AnyObject {
+    /// 뒤로가기
     func pop()
+    /// 음성 노트 Push
     func pushVoiceNoteView(voiceNote: VoiceNote)
+    /// 상세 폴더 Push
     func pushMyFolderDetailView(_ folder: Folder)
+    /// 검색 화면 Push함수
+    func pushSearchView(type: SearchViewModel.SearchType, items: [ContentItem])
 }
 
 @MainActor
@@ -97,6 +102,10 @@ extension TrashViewModel {
 
     func pushDetailFolder(_ folder: Folder) {
         coordinator?.pushMyFolderDetailView(folder)
+    }
+    
+    func pushSearch() {
+        coordinator?.pushSearchView(type: .trash, items: items)
     }
 
     func selectItem(_ item: ContentItem) {

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -103,7 +103,7 @@ extension TrashViewModel {
     func pushDetailFolder(_ folder: Folder) {
         coordinator?.pushMyFolderDetailView(folder)
     }
-    
+
     func pushSearch() {
         coordinator?.pushSearchView(type: .trash, items: items)
     }

--- a/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
@@ -7,6 +7,9 @@ import XCTest
 final class MockFolderDetailCoordinatorDelegate: FolderDetailCoordinatorDelegate {
     var popCalled = false
     var pushedVoiceNote: VoiceNote?
+    var pushSearchViewCalled = false
+    var pushedSearchType: SearchViewModel.SearchType?
+    var pushedSearchItems: [ContentItem] = []
 
     var presentFolderListCalled = false
 
@@ -20,6 +23,12 @@ final class MockFolderDetailCoordinatorDelegate: FolderDetailCoordinatorDelegate
 
     func presentFolderList(with voiceNotes: [VoiceNote], onComplete: ((String) -> Void)?) {
         presentFolderListCalled = true
+    }
+
+    func pushSearchView(type: SearchViewModel.SearchType, items: [ContentItem]) {
+        pushSearchViewCalled = true
+        pushedSearchType = type
+        pushedSearchItems = items
     }
 }
 
@@ -96,6 +105,25 @@ final class FolderDetailViewModelTests: XCTestCase {
         sut.viewModel.pushVoiceNote(voiceNote: note)
 
         XCTAssertEqual(sut.mockCoordinator.pushedVoiceNote?.id, note.id)
+    }
+
+    func test_pushSearch_호출시_화면전환() async {
+        let sut = makeSUT(title: "상세 폴더")
+        let note = VoiceNote.stub(title: "검색용 노트")
+
+        sut.mockVoiceNoteRepo.setObserveFolderResult(.success(makeStream([note])))
+        sut.viewModel.onAppear()
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        sut.viewModel.pushSearch()
+
+        XCTAssertTrue(sut.mockCoordinator.pushSearchViewCalled)
+        if case .myDetailFolder(let title) = sut.mockCoordinator.pushedSearchType {
+            XCTAssertEqual(title, "상세 폴더")
+        } else {
+            XCTFail("Wrong search type")
+        }
+        XCTAssertEqual(sut.mockCoordinator.pushedSearchItems.count, 1)
     }
 
     func test_presentMoveFolder_버튼탭시_선택항목존재하면_시트오픈() {

--- a/Presentation/Tests/Folder/FolderViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderViewModelTests.swift
@@ -7,6 +7,9 @@ import XCTest
 final class MockFolderCoordinatorDelegate: FolderCoordinatorDelegate {
     var popCalled = false
     var pushedFolder: Folder?
+    var pushSearchViewCalled = false
+    var pushedSearchType: SearchViewModel.SearchType?
+    var pushedSearchItems: [ContentItem] = []
 
     func pop() {
         popCalled = true
@@ -14,6 +17,12 @@ final class MockFolderCoordinatorDelegate: FolderCoordinatorDelegate {
 
     func pushMyFolderDetailView(_ folder: Folder) {
         pushedFolder = folder
+    }
+
+    func pushSearchView(type: SearchViewModel.SearchType, items: [ContentItem]) {
+        pushSearchViewCalled = true
+        pushedSearchType = type
+        pushedSearchItems = items
     }
 }
 
@@ -77,6 +86,17 @@ final class FolderViewModelTests: XCTestCase {
         sut.viewModel.pushDetail(folder)
 
         XCTAssertEqual(sut.mockCoordinator.pushedFolder?.id, folder.id)
+    }
+
+    func test_pushSearch_호출시_화면전환() {
+        let folder = Folder(name: "개인 폴더")
+        let sut = makeSUT(initialItems: [.folder(folder)])
+
+        sut.viewModel.pushSearch()
+
+        XCTAssertTrue(sut.mockCoordinator.pushSearchViewCalled)
+        XCTAssertEqual(sut.mockCoordinator.pushedSearchType, .myFolder)
+        XCTAssertEqual(sut.mockCoordinator.pushedSearchItems.count, 1)
     }
 
     func test_openTextFieldView_호출시_상태변경() {

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -34,7 +34,7 @@ final class MockMainCoordinatorDelegate: MainCoordinatorDelegate {
     func presentRecodingView() {
         presentRecodingViewCalled = true
     }
-    
+
     func pushSearchView(type: Presentation.SearchViewModel.SearchType, items: [Domain.ContentItem]) {
         pushSearchViewCalled = true
         pushedSearchType = type

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -8,11 +8,14 @@ final class MockMainCoordinatorDelegate: MainCoordinatorDelegate {
     var pushTrashViewCalled = false
     var pushMyFolderViewCalled = false
     var pushVoiceNoteViewCalled = false
+    var pushSearchViewCalled = false
     var presentRecodingViewCalled = false
     var popCalled = false
 
     var pushedCategory: CategoryToggle?
     var pushedVoiceNote: VoiceNote?
+    var pushedSearchType: SearchViewModel.SearchType?
+    var pushedSearchItems: [ContentItem] = []
 
     func pushTrashView() {
         pushTrashViewCalled = true
@@ -30,6 +33,12 @@ final class MockMainCoordinatorDelegate: MainCoordinatorDelegate {
 
     func presentRecodingView() {
         presentRecodingViewCalled = true
+    }
+    
+    func pushSearchView(type: Presentation.SearchViewModel.SearchType, items: [Domain.ContentItem]) {
+        pushSearchViewCalled = true
+        pushedSearchType = type
+        pushedSearchItems = items
     }
 
     func pop() {
@@ -134,6 +143,44 @@ final class MainViewModelTests: XCTestCase {
 
         XCTAssertTrue(sut.mockCoordinator.pushVoiceNoteViewCalled)
         XCTAssertEqual(sut.mockCoordinator.pushedVoiceNote?.id, note.id)
+    }
+
+    func test_pushSearchView_호출시_화면전환() async {
+        // Given
+        let sut = makeSUT()
+        let note = VoiceNote.stub(title: "검색용 노트")
+        let folder = Folder(name: "검색용 폴더", kind: .custom)
+
+        // Mock 데이터 설정
+        sut.mockVoiceNoteRepo.setObserveRecentResult(.success(makeStream([note])))
+        sut.mockFolderRepo.setObserveByKindResult(.custom, result: .success(makeStream([folder])))
+
+        // ViewModel 데이터 업데이트
+        sut.viewModel.updateRecentCategory()
+        sut.viewModel.updateMyFolderCategory()
+
+        // 비동기 업데이트 대기
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        // When
+        sut.viewModel.pushSearchView()
+
+        // Then
+        XCTAssertTrue(sut.mockCoordinator.pushSearchViewCalled)
+        XCTAssertEqual(sut.mockCoordinator.pushedSearchType, .main)
+        XCTAssertEqual(sut.mockCoordinator.pushedSearchItems.count, 2)
+
+        let hasNote = sut.mockCoordinator.pushedSearchItems.contains { item in
+            if case .voiceNote(let n) = item { return n.id == note.id }
+            return false
+        }
+        let hasFolder = sut.mockCoordinator.pushedSearchItems.contains { item in
+            if case .folder(let f) = item { return f.id == folder.id }
+            return false
+        }
+
+        XCTAssertTrue(hasNote)
+        XCTAssertTrue(hasFolder)
     }
 
     func test_didScroll_상태변경() {

--- a/Presentation/Tests/Trash/TrashViewModelTests.swift
+++ b/Presentation/Tests/Trash/TrashViewModelTests.swift
@@ -8,6 +8,9 @@ final class MockTrashCoordinatorDelegate: TrashCoordinatorDelegate {
     var popCalled = false
     var pushedVoiceNote: VoiceNote?
     var pushedFolder: Folder?
+    var pushSearchViewCalled = false
+    var pushedSearchType: SearchViewModel.SearchType?
+    var pushedSearchItems: [ContentItem] = []
 
     func pop() {
         popCalled = true
@@ -19,6 +22,12 @@ final class MockTrashCoordinatorDelegate: TrashCoordinatorDelegate {
 
     func pushMyFolderDetailView(_ folder: Folder) {
         pushedFolder = folder
+    }
+
+    func pushSearchView(type: SearchViewModel.SearchType, items: [ContentItem]) {
+        pushSearchViewCalled = true
+        pushedSearchType = type
+        pushedSearchItems = items
     }
 }
 
@@ -105,6 +114,21 @@ final class TrashViewModelTests: XCTestCase {
         sut.viewModel.didTapBack()
 
         XCTAssertTrue(sut.mockCoordinator.popCalled, "뒤로가기 시 pop이 정상 호출되어야 합니다.")
+    }
+
+    func test_pushSearch_호출시_화면전환() async {
+        let sut = makeSUT()
+        let folder = Folder(name: "삭제된 폴더")
+        setTrashStreams(sut, items: [.folder(folder)])
+
+        sut.viewModel.onAppear()
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        sut.viewModel.pushSearch()
+
+        XCTAssertTrue(sut.mockCoordinator.pushSearchViewCalled)
+        XCTAssertEqual(sut.mockCoordinator.pushedSearchType, .trash)
+        XCTAssertEqual(sut.mockCoordinator.pushedSearchItems.count, 1)
     }
 
     // MARK: - Update & Fetch Tests


### PR DESCRIPTION
---

## ✨ 작업 요약
검색 화면(SearchView) 구현 및 주요 화면 연동과 뷰모델 검증 테스트 추가

## 📋 구체적인 내용
- **추가/변경된 동작**:
    - 검색 기능을 전담하는 `SearchViewController` 및 `SearchViewModel` 구현
    - 메인, 폴더, 상세 폴더, 휴지통 화면에서 검색 진입(`pushSearch`) 로직 및 Coordinator 연동 추가
    - 검색 화면 진입 시 현재 화면의 데이터(Items)를 검색 대상으로 주입하여 즉각적인 필터링 가능하도록 구현
    - 네비게이션 바 전환 애니메이션 중 검색바가 잘리는 현상을 해결하기 위해 `ChagokSearchBar` 높이를 46pt에서 표준인 44pt로 최적화
- **영향 받는 화면/모듈**:
    - `Presentation`: 메인, 폴더, 폴더 상세, 휴지통, 검색 화면 전체

---

## 🔗 연관 이슈

- closed #224

---

## 🧩 설계·구현 노트

- **선택한 방식**
    - **Data Injection**: 검색 화면이 서버나 로컬 DB를 다시 조회하는 대신, 진입 시점의 데이터를 주입받는 방식을 선택했습니다. 이는 사용자에게 훨씬 빠른 검색 경험을 제공하며, 현재 보고 있는 데이터 맥락을 유지하기에 적합합니다.
    - **State-Driven UI**: `UICollectionViewDiffableDataSource`를 활용하여 검색 결과 유무에 따른 상태(empty, emptyResult, result)를 선언적으로 관리합니다.
- **고려했다가 제외한 방식**
    - 검색 바의 높이를 46pt로 유지하고 `clipsToBounds = false`를 주는 방식도 고려했으나, 시스템 네비게이션 바의 표준 가이드라인(44pt)을 따르는 것이 OS 버전별 레이아웃 대응 및 전환 애니메이션에서 가장 안정적이라고 판단하여 높이를 수정했습니다.

---

## ✅ 확인 사항

- [x] 정상 플로우 동작 확인 (각 화면에서 검색 진입 및 필터링)
- [x] 엣지 케이스 / 빈 값·에러 처리 확인 (검색 결과 없을 시 전용 UI 노출)
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [x] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [x] **설계·구조 적절성**: `SearchType`을 통해 각 진입점(메인/폴더 등)마다 다른 헤더 타이틀을 보여주는 구조가 적절한지 확인 부탁드립니다.
- [x] **로직·엣지 케이스**: `MainViewModel`에서 검색 데이터를 만들 때 중복 아이템이 제거(`seenIDs`)되는 로직을 중점적으로 봐주세요.
- [x] **UI/UX**: 화면 전환 도중 검색바 위쪽이 미세하게 가려지던 렌더링 이슈가 해결되었는지 확인이 필요합니다.

**특히 봐줬으면 하는 부분**

- `MainViewModelTests`, `FolderViewModelTests`, `TrashViewModelTests` 등 각 뷰모델 테스트에 추가된 코디네이터 호출 검증 로직이 충분한지 검토 부탁드립니다.

---

## 📚 참고