### PR TITLE
UX 1차 리펙토링입니다.

### DIFF
--- a/Core/Sources/Extensions/Date+Formatting.swift
+++ b/Core/Sources/Extensions/Date+Formatting.swift
@@ -24,7 +24,7 @@ public extension Date {
     }
 
     func voiceNoteDay(createdAt: Date, updatedAt: Date, duration: Double) -> String {
-        let dateText = voiceNoteDateText(createdAt: createdAt, updatedAt: createdAt)
+        let dateText = voiceNoteDateText(createdAt: createdAt, updatedAt: updatedAt)
         let durationText = duration.koreanDurationString
 
         if Int(createdAt.timeIntervalSince1970) != Int(updatedAt.timeIntervalSince1970) {

--- a/Core/Sources/Extensions/Date+Formatting.swift
+++ b/Core/Sources/Extensions/Date+Formatting.swift
@@ -24,8 +24,14 @@ public extension Date {
     }
 
     func voiceNoteDay(createdAt: Date, updatedAt: Date, duration: Double) -> String {
-        let dateText = voiceNoteDateText(createdAt: createdAt, updatedAt: updatedAt)
+        let dateText = voiceNoteDateText(createdAt: createdAt, updatedAt: createdAt)
         let durationText = duration.koreanDurationString
+
+        if Int(createdAt.timeIntervalSince1970) != Int(updatedAt.timeIntervalSince1970) {
+            let updateText = updatedAt.toString(format: "M월 d일")
+            return "\(dateText) · \(durationText) (\(updateText) 수정됨)"
+        }
+
         return "\(dateText) · \(durationText)"
     }
 }

--- a/Core/Tests/Extensions/DateFormattingTests.swift
+++ b/Core/Tests/Extensions/DateFormattingTests.swift
@@ -31,7 +31,7 @@ extension DateFormattingTests {
         let result = now.voiceNoteDay(createdAt: createdAt, updatedAt: updatedAt, duration: 720)
 
         // Then
-        XCTAssertEqual(result, "방금 전 · 12분")
+        XCTAssertEqual(result, "방금 전 · 12분 (4월 13일 수정됨)")
     }
 
     func test_5분전_음성메모일자문구생성시_분전으로표시된다() {
@@ -44,7 +44,7 @@ extension DateFormattingTests {
         let result = now.voiceNoteDay(createdAt: createdAt, updatedAt: updatedAt, duration: 150)
 
         // Then
-        XCTAssertEqual(result, "5분 전 · 2분 30초")
+        XCTAssertEqual(result, "5분 전 · 2분 30초 (4월 13일 수정됨)")
     }
 
     func test_1시간전_상세날짜문구생성시_수정일기준시간전으로표시된다() {

--- a/Data/Sources/Repositories/Folders/DefaultFolderRepository.swift
+++ b/Data/Sources/Repositories/Folders/DefaultFolderRepository.swift
@@ -37,18 +37,22 @@ public struct DefaultFolderRepository: FolderRepository {
     }
 
     public func fetch(by id: UUID) throws(FolderRepositoryError) -> Folder {
+        let request = FolderEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        request.fetchLimit = 1
+
+        let result: [FolderEntity]
         do {
-            let request = FolderEntity.fetchRequest()
-            request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-            request.fetchLimit = 1
-            guard let entity = try context.fetch(request).first else {
-                throw FolderRepositoryError.notFound
-            }
-            return entity.toModel()
+            result = try context.fetch(request)
         } catch {
             AppLogger.error(error)
             throw .fetchFailed
         }
+
+        guard let entity = result.first else {
+            throw .notFound
+        }
+        return entity.toModel()
     }
 
     public func fetch(by kind: FolderKind) throws(FolderRepositoryError) -> [Folder] {

--- a/Domain/Sources/Entities/VoiceNote.swift
+++ b/Domain/Sources/Entities/VoiceNote.swift
@@ -9,6 +9,34 @@ public enum AnalysisState: String, Sendable, Hashable {
     case regenerating
     case completed
     case summarizationFailed
+
+    public enum BindingKey {
+        case progress
+        case success
+        case failed
+
+        public var currentText: String {
+            switch self {
+            case .progress:
+                "진행 중"
+            case .success:
+                "요약 완료"
+            case .failed:
+                "요약 실패"
+            }
+        }
+    }
+
+    public var bindingValue: BindingKey {
+        switch self {
+        case .pending, .transcribing, .transcribed, .regenerating, .summarizing:
+            .progress
+        case .completed:
+            .success
+        case .transcriptionFailed, .summarizationFailed:
+            .failed
+        }
+    }
 }
 
 public struct VoiceNote: Sendable, Identifiable, Hashable {

--- a/Domain/Sources/Entities/VoiceNote.swift
+++ b/Domain/Sources/Entities/VoiceNote.swift
@@ -14,17 +14,6 @@ public enum AnalysisState: String, Sendable, Hashable {
         case progress
         case success
         case failed
-
-        public var currentText: String {
-            switch self {
-            case .progress:
-                "진행 중"
-            case .success:
-                "요약 완료"
-            case .failed:
-                "요약 실패"
-            }
-        }
     }
 
     public var bindingValue: BindingKey {

--- a/Presentation/Sources/Component/Folder/FolderCardView.swift
+++ b/Presentation/Sources/Component/Folder/FolderCardView.swift
@@ -62,10 +62,10 @@ struct FolderCardView: View {
             Group {
                 Image(systemName: "folder")
                 Text(folder.name)
-                    .font(Font.custom("Pretendard", size: 16))
+                    .typography(.body2)
                 Spacer()
                 Text(String(folder.voiceNoteIDs.count))
-                    .font(Font.custom("Pretendard", size: 16))
+                    .typography(.body2)
                     .multilineTextAlignment(.trailing)
             }
             .foregroundColor(.gray800)

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
@@ -67,19 +67,37 @@ struct VoiceNoteCardView: View {
         )
         Group {
             Text(voiceNote.title)
+                .typography(.title2)
                 .foregroundStyle(.gray950)
-                .font(.system(size: 18))
-                .lineSpacing(1.3)
             Text(time)
+                .typography(.body2)
                 .foregroundStyle(.gray800)
-                .font(.body)
-                .font(.system(size: 16))
-                .lineSpacing(1.5)
-                .tracking(-0.03)
-            Text("요약 필요")
-                .font(.system(size: 15))
-                .lineSpacing(1.3)
-                .tracking(-0.03)
+            analysisText(binding: voiceNote.analysisState.bindingValue)
+        }
+    }
+}
+
+// MARK: - Helper
+
+extension VoiceNoteCardView {
+    /// 분석 상태에 따른 텍스트 뷰 (요약 중, 요약 실패, 요약 완료
+    @ViewBuilder
+    func analysisText(binding: AnalysisState.BindingKey) -> some View {
+        switch binding {
+        case .progress, .failed:
+            Text(binding.currentText)
+                .typography(.label)
+                .padding(.vertical, 4)
+                .padding(.horizontal, 12)
+                .overlay(
+                    Capsule()
+                        .stroke(Color.gray500, lineWidth: 1)
+                )
+                .background(.gray200, in: .capsule)
+                .foregroundStyle(.gray750)
+        case .success:
+            Text(binding.currentText)
+                .typography(.label)
                 .padding(.vertical, 4)
                 .padding(.horizontal, 12)
                 .overlay(
@@ -92,6 +110,7 @@ struct VoiceNoteCardView: View {
     }
 }
 
+/// ViewModifier 확장
 extension View {
     func editVoiceNoteCardStyle(isSelected: Bool) -> some View {
         modifier(
@@ -102,8 +121,14 @@ extension View {
     }
 }
 
+/// 음성 노트 선택 모드 스타일 정의
 struct EditVoiceNoteCardModifier: ViewModifier {
     let isSelected: Bool
+    private let cornerRadius: CGFloat = 20
+
+    private var borderColor: Color {
+        isSelected ? .point900 : .gray500
+    }
 
     func body(content: Content) -> some View {
         content

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteCardView.swift
@@ -83,9 +83,20 @@ extension VoiceNoteCardView {
     /// 분석 상태에 따른 텍스트 뷰 (요약 중, 요약 실패, 요약 완료
     @ViewBuilder
     func analysisText(binding: AnalysisState.BindingKey) -> some View {
+        var currentText: String {
+            switch binding {
+            case .progress:
+                "요약 중"
+            case .success:
+                "요약 성공"
+            case .failed:
+                "요약 실패"
+            }
+        }
+
         switch binding {
         case .progress, .failed:
-            Text(binding.currentText)
+            Text(currentText)
                 .typography(.label)
                 .padding(.vertical, 4)
                 .padding(.horizontal, 12)
@@ -96,7 +107,7 @@ extension VoiceNoteCardView {
                 .background(.gray200, in: .capsule)
                 .foregroundStyle(.gray750)
         case .success:
-            Text(binding.currentText)
+            Text(currentText)
                 .typography(.label)
                 .padding(.vertical, 4)
                 .padding(.horizontal, 12)

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -9,8 +9,8 @@ public final class FolderDetailViewController: CollectionViewController {
 
     typealias DataSource = UICollectionViewDiffableDataSource<Section, ContentItem>
     typealias SnapShot = NSDiffableDataSourceSnapshot<Section, ContentItem>
-
-    private var dataSource: DataSource?
+    private var listConfiguration: UICollectionLayoutListConfiguration = .init(appearance: .plain)
+    private var dataSource: DataSource!
 
     // MARK: - Component
 
@@ -81,20 +81,9 @@ public final class FolderDetailViewController: CollectionViewController {
 
     public init(vm: FolderDetailViewModel) {
         self.vm = vm
-        let layout = UICollectionViewCompositionalLayout { sectionIndex, layoutEnvironment in
-            var listConfiguration = UICollectionLayoutListConfiguration(appearance: .plain)
-            listConfiguration.headerMode = .none
-            listConfiguration.showsSeparators = false
-            listConfiguration.backgroundColor = .clear
-            let section = NSCollectionLayoutSection.list(
-                using: listConfiguration,
-                layoutEnvironment: layoutEnvironment
-            )
-            section.contentInsets = .init(top: 12, leading: 20, bottom: 20, trailing: 20)
-            section.interGroupSpacing = 8
-            return section
-        }
-
+        listConfiguration.backgroundColor = .clear
+        listConfiguration.showsSeparators = false
+        let layout = UICollectionViewCompositionalLayout.list(using: listConfiguration)
         super.init(collectionViewLayout: layout)
     }
 
@@ -108,6 +97,7 @@ public final class FolderDetailViewController: CollectionViewController {
         super.viewDidLoad()
         collectionView.allowsSelection = false
         setupNavigation()
+        setupSwipeAction()
         setupRemoveAlert()
         setupDataSource()
         updateDataSource()
@@ -154,6 +144,25 @@ public final class FolderDetailViewController: CollectionViewController {
         navigationItem.rightBarButtonItems?.forEach {
             $0.hidesSharedBackground = true
         }
+    }
+    
+    private func setupSwipeAction() {
+        
+        listConfiguration.trailingSwipeActionsConfigurationProvider = { [weak self] indexPath in
+            self?.trailingAction(indexPath: indexPath)
+        }
+
+        // List 레이아웃을 사용하되, 섹션 설정을 통해 간격을 조정합니다.
+        let layout = UICollectionViewCompositionalLayout { [weak self] sectionIndex, layoutEnvironment in
+            guard let self else { return nil }
+            let config = listConfiguration
+            // 개별 셀의 높이가 카드에 딱 맞게 설정되도록 여백 제거
+            let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: layoutEnvironment)
+            section.interGroupSpacing = 8
+            section.contentInsets = .init(top: 12, leading: 20, bottom: 20, trailing: 20)
+            return section
+        }
+        collectionView.setCollectionViewLayout(layout, animated: false)
     }
 
     private func setupRightBarButtonMenu() {
@@ -388,6 +397,29 @@ private extension FolderDetailViewController {
         backButton.isUserInteractionEnabled = !isPresented
         moreAndActionButton.isUserInteractionEnabled = !isPresented
         searchAndMoveButton.isUserInteractionEnabled = !isPresented
+    }
+}
+
+// MARK: - Swipe Action Delegate
+
+public extension FolderDetailViewController {
+    private func trailingAction(indexPath: IndexPath) -> UISwipeActionsConfiguration {
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return .init() }
+
+        let deleteAction = UIContextualAction(style: .destructive, title: nil) {
+            [weak self] _, _, completion in
+            if case .voiceNote(let voiceNote) = item {
+                self?.vm.move(id: voiceNote.id)
+                // Swipe 종료 애니메이션과 목록 갱신 타이밍이 어긋나면 셀이 튕겨 보일 수 있어 즉시 반영합니다.
+                self?.updateDataSource(reconfigure: true)
+            }
+            completion(true)
+        }
+        deleteAction.image = UIImage(systemName: "trash.fill")
+
+        let configuration = UISwipeActionsConfiguration(actions: [deleteAction])
+        configuration.performsFirstActionWithFullSwipe = false
+        return configuration
     }
 }
 

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -145,9 +145,8 @@ public final class FolderDetailViewController: CollectionViewController {
             $0.hidesSharedBackground = true
         }
     }
-    
+
     private func setupSwipeAction() {
-        
         listConfiguration.trailingSwipeActionsConfigurationProvider = { [weak self] indexPath in
             self?.trailingAction(indexPath: indexPath)
         }

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -410,7 +410,7 @@ public extension FolderDetailViewController {
             if case .voiceNote(let voiceNote) = item {
                 self?.vm.move(id: voiceNote.id)
                 // Swipe 종료 애니메이션과 목록 갱신 타이밍이 어긋나면 셀이 튕겨 보일 수 있어 즉시 반영합니다.
-                self?.updateDataSource(reconfigure: true)
+                self?.updateDataSource()
             }
             completion(true)
         }

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -315,7 +315,7 @@ public extension FolderViewController {
             if case .folder(let folder) = item {
                 self?.vm.move(folder: folder)
                 // Swipe 종료 애니메이션과 목록 갱신 타이밍이 어긋나면 셀이 튕겨 보일 수 있어 즉시 반영합니다.
-                self?.updateDataSource(animated: false)
+                self?.updateDataSource(animated: true)
             }
             completion(true)
         }

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -310,7 +310,7 @@ public extension FolderViewController {
     private func trailingAction(indexPath: IndexPath) -> UISwipeActionsConfiguration {
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return .init() }
 
-        let deleteAction = UIContextualAction(style: .destructive, title: "삭제") {
+        let deleteAction = UIContextualAction(style: .destructive, title: nil) {
             [weak self] _, _, completion in
             if case .folder(let folder) = item {
                 self?.vm.move(folder: folder)
@@ -321,7 +321,7 @@ public extension FolderViewController {
         }
         deleteAction.image = UIImage(systemName: "trash.fill")
 
-        let editAction = UIContextualAction(style: .normal, title: "수정") {
+        let editAction = UIContextualAction(style: .normal, title: nil) {
             [weak self] _, _, completion in
             if case .folder(let folder) = item {
                 self?.vm.openTextField(for: folder)

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -202,6 +202,18 @@ extension FolderDetailViewModel {
             errorMessage = error.errorDescription
         }
     }
+    
+    func move(id: VoiceNote.ID) {
+        do {
+            try voiceNoteUseCase.moveToTrash(noteID: id)
+            items.removeAll {
+                if case .voiceNote(let obj) = $0 { return obj.id == id }
+                return false
+            }
+        } catch {
+            AppLogger.error(error)
+        }
+    }
 }
 
 // MARK: - Restore (휴지통 이동 복구)

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -202,7 +202,7 @@ extension FolderDetailViewModel {
             errorMessage = error.errorDescription
         }
     }
-    
+
     func move(id: VoiceNote.ID) {
         do {
             try voiceNoteUseCase.moveToTrash(noteID: id)


### PR DESCRIPTION
## ✨ 작업 요약
> 음성 메모 카드 스타일 최적화, 폴더 복구 에러 핸들링 정상화 및 날짜 표기 로직 개선

## 📋 구체적인 내용
- **추가/변경된 동작**:
  - **에러 핸들링**: `DefaultFolderRepository`의 `fetch(by id:)`에서 발생하던 에러 가로채기 문제를 해결하여, 폴더가 없을 때 `.notFound`가 정확히 전파되도록 수정했습니다.
  - **복구 로직**: `VoiceNoteUseCase`에서 원래 폴더가 영구 삭제된 경우, '기본 폴더'로 안전하게 복구(Fallback)되는 로직을 정상화했습니다.
  - **날짜 표기**: `voiceNoteDay`가 `updatedAt`(최신 활동)을 기준으로 상대 시간(방금 전, 5분 전 등)을 표시하도록 개선하고, 수정된 경우 `(M월 d일 수정됨)` 접미사를 추가했습니다.
  - **UI 최적화**: `VoiceNoteCardView`의 선택 시 스타일을 디자인 시스템에 맞춰 `glassEffect`와 테두리 스타일로 정돈했습니다.
- **영향 받는 화면/모듈**:
  - `Core`: 날짜 포맷팅 확장 및 테스트 코드
  - `Domain/Data`: 음성 메모 복구 유즈케이스 및 폴더 리포지토리
  - `Presentation`: 휴지통 화면(복구 동작) 및 음성 메모 카드 컴포넌트

---

## 🔗 연관 이슈
- closed #225 

---

## 🧩 설계·구현 노트
- **선택한 방식: 에러 전파 구조 개선**
  - 기존에는 리포지토리의 `do-catch` 블록이 직접 던진 `.notFound` 에러까지 모두 잡아서 `.fetchFailed`로 변환하고 있었습니다. 이를 해결하기 위해 `do-catch` 범위를 시스템 호출(`context.fetch`)로만 좁혀 비즈니스 에러(`.notFound`)가 UseCase까지 오염되지 않고 전달되도록 수정했습니다.
  - 날짜 표기의 경우, "방금 전" 같은 상대 시간 정보는 사용자가 가장 마지막으로 수정한 시점을 기준으로 보여주는 것이 UX 측면에서 더 유용하다고 판단하여 `updatedAt`을 기준점으로 변경했습니다.

---

## ✅ 확인 사항
- [x] 휴지통 내 아이템 복구 시 원래 폴더가 없으면 '기본 폴더'로 정상 이동 확인
- [x] 음성 메모 수정 시 날짜 표기에 '수정됨' 문구 및 최신 시간 반영 확인
- [x] `DateFormattingTests` 유닛 테스트 통과 확인 (로직 변경 반영)

---

## 👀 리뷰 포인트
- [x] **로직·엣지 케이스**: 폴더 영구 삭제 후 내부 아이템 복구 시의 에러 전파 흐름이 적절한지
- [x] **UI/UX**: 변경된 날짜 표기 방식(`상대 시간 + 수정 날짜`)이 가독성 측면에서 적절한지

**특히 봐줬으면 하는 부분**
- `DefaultFolderRepository`에서 에러 타입을 구분하여 던지는 방식이 다른 리포지토리에도 적용할 만한 표준인지 확인 부탁드립니다.

---

## 📚 참고
- Swift 6 Typed Throws에서의 에러 타입 추론 방식 관련 수정 내역 포함