### PR TITLE
v2.0 UI / UX 리펙토링 합니다

### DIFF
--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -130,8 +130,11 @@ public final class AppDIContainer {
         return NewFolderViewModel(folderUseCase: folderUseCase)
     }
 
-    public func makeSearchViewModel(type: SearchViewModel.SearchType, items: [ContentItem]) -> SearchViewModel {
-        return SearchViewModel(type: type, items: items)
+    public func makeSearchViewModel(
+        type: SearchViewModel.SearchType,
+        items: [ContentItem]
+    ) -> SearchViewModel {
+        return SearchViewModel(type: type, items: items, folderRepository: folderRepository)
     }
 
     #if DEBUG

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -106,10 +106,11 @@ public final class AppDIContainer {
         )
     }
 
-    public func makeMyFolderDetailViewModel(_ folder: Folder) -> FolderDetailViewModel {
+    public func makeMyFolderDetailViewModel(_ folder: Folder, isTrashMode: Bool = false) -> FolderDetailViewModel {
         return FolderDetailViewModel(
             title: folder.name,
             folderID: folder.id,
+            isTrashMode: isTrashMode,
             voiceNoteUseCase: voiceNoteUseCase
         )
     }
@@ -132,9 +133,15 @@ public final class AppDIContainer {
 
     public func makeSearchViewModel(
         type: SearchViewModel.SearchType,
-        items: [ContentItem]
+        items: [ContentItem],
+        isTrashMode: Bool = false
     ) -> SearchViewModel {
-        return SearchViewModel(type: type, items: items, folderRepository: folderRepository)
+        return SearchViewModel(
+            type: type,
+            items: items,
+            isTrashMode: isTrashMode,
+            folderRepository: folderRepository
+        )
     }
 
     public func makeChaGokAlertViewModel(environment: ChaGokAlertViewModel.AlertEnvironment) -> ChaGokAlertViewModel {

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -137,6 +137,10 @@ public final class AppDIContainer {
         return SearchViewModel(type: type, items: items, folderRepository: folderRepository)
     }
 
+    public func makeChaGokAlertViewModel(environment: ChaGokAlertViewModel.AlertEnvironment) -> ChaGokAlertViewModel {
+        return ChaGokAlertViewModel(environment: environment)
+    }
+
     #if DEBUG
         public func seedDebugDataIfNeeded() {
             DebugSeeder(

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -51,6 +51,7 @@ extension MainCoordinator: MainCoordinatorDelegate {
     func pushTrashView() {
         let trashVM = dependencyContainer.makeTrashViewModel()
         trashVM.coordinator = self
+        trashVM.alertCoordinator = self
         let trashVC = TrashViewController(vm: trashVM)
         presenter.pushViewController(trashVC, animated: true)
     }

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -102,6 +102,7 @@ extension MainCoordinator: FolderCoordinatorDelegate {
     func pushMyFolderDetailView(_ folder: Folder) {
         let myFolderDetailVM = dependencyContainer.makeMyFolderDetailViewModel(folder)
         myFolderDetailVM.coordinator = self
+        myFolderDetailVM.alertCoordinator = self
         let myFolderDetailVC = FolderDetailViewController(vm: myFolderDetailVM)
         presenter.pushViewController(myFolderDetailVC, animated: true)
     }

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -19,6 +19,7 @@ final class MainCoordinator: BaseCoordinator<UINavigationController> {
         let mainVM = dependencyContainer.makeMainViewModel()
         let mainVC = MainViewController(vm: mainVM)
         mainVM.mainCoordinator = self
+        mainVM.alertCoordinator = self
         presenter.isNavigationBarHidden = false
         presenter.setViewControllers([mainVC], animated: false)
     }
@@ -127,6 +128,21 @@ extension MainCoordinator: VoiceNoteCoordinatorDelegate {
 // MARK: - SearchCoordinatorDelegate
 
 extension MainCoordinator: SearchCoordinatorDelegate {}
+
+// MARK: - ChaGokAlertCoordinatorDelegate
+
+extension MainCoordinator: ChaGokAlertCoordinatorDelegate {
+    func presentAlert(
+        environment: ChaGokAlertViewModel.AlertEnvironment,
+        delegate: ChaGokAlertButtonTappedDelegate?
+    ) {
+        let viewModel = dependencyContainer.makeChaGokAlertViewModel(environment: environment)
+        viewModel.coordinator = self
+        let alertVC = ChaGokAlertViewController(vm: viewModel)
+        alertVC.delegate = delegate
+        presenter.present(alertVC, animated: true)
+    }
+}
 
 // MARK: - Helpers
 

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -58,6 +58,7 @@ extension MainCoordinator: MainCoordinatorDelegate {
     func pushMyFolderView(category: CategoryToggle) {
         let myFolderVM = dependencyContainer.makeMyFolderViewModel(category)
         myFolderVM.coordinator = self
+        myFolderVM.alertCoordinator = self
         let myFolderVC = FolderViewController(vm: myFolderVM)
         presenter.pushViewController(myFolderVC, animated: true)
     }

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -119,7 +119,27 @@ extension MainCoordinator: FolderDetailCoordinatorDelegate {
 
 // MARK: - TrashCoordinatorDelegate
 
-extension MainCoordinator: TrashCoordinatorDelegate {}
+extension MainCoordinator: TrashCoordinatorDelegate {
+    
+    func pushMyFolderDetailView(_ folder: Folder, isHidden: Bool) {
+        let myFolderDetailVM = dependencyContainer.makeMyFolderDetailViewModel(folder, isTrashMode: isHidden)
+        myFolderDetailVM.coordinator = self
+        myFolderDetailVM.alertCoordinator = self
+        let myFolderDetailVC = FolderDetailViewController(vm: myFolderDetailVM)
+        presenter.pushViewController(myFolderDetailVC, animated: true)
+    }
+    
+    func pushSearchView(
+        type: Presentation.SearchViewModel.SearchType,
+        items: [ContentItem],
+        isHidden: Bool
+    ) {
+        let searchVM = dependencyContainer.makeSearchViewModel(type: type, items: items, isTrashMode: isHidden)
+        searchVM.coordinator = self
+        let searchVC = SearchViewController(vm: searchVM)
+        presenter.pushViewController(searchVC, animated: true)
+    }
+}
 
 // MARK: - VoiceNoteCoordinatorDelegate
 
@@ -131,7 +151,15 @@ extension MainCoordinator: VoiceNoteCoordinatorDelegate {
 
 // MARK: - SearchCoordinatorDelegate
 
-extension MainCoordinator: SearchCoordinatorDelegate {}
+extension MainCoordinator: SearchCoordinatorDelegate {
+    func pushMyFolderDetailView(_ folder: Folder, isTrashMode: Bool) {
+        let myFolderDetailVM = dependencyContainer.makeMyFolderDetailViewModel(folder, isTrashMode: isTrashMode)
+        myFolderDetailVM.coordinator = self
+        myFolderDetailVM.alertCoordinator = self
+        let myFolderDetailVC = FolderDetailViewController(vm: myFolderDetailVM)
+        presenter.pushViewController(myFolderDetailVC, animated: true)
+    }
+}
 
 // MARK: - ChaGokAlertCoordinatorDelegate
 

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -83,6 +83,7 @@ extension MainCoordinator: MainCoordinatorDelegate {
         let navController = UINavigationController()
         let viewModel = dependencyContainer.makeRecordingViewModel()
         viewModel.coordinator = self
+        viewModel.alertCoordinator = self
         let recordingVC = RecordingViewController(viewModel: viewModel)
         navController.modalPresentationStyle = .fullScreen
         navController.setViewControllers([recordingVC], animated: false)
@@ -140,7 +141,11 @@ extension MainCoordinator: ChaGokAlertCoordinatorDelegate {
         viewModel.coordinator = self
         let alertVC = ChaGokAlertViewController(vm: viewModel)
         alertVC.delegate = delegate
-        presenter.present(alertVC, animated: true)
+        var topVC: UIViewController = presenter
+        while let presented = topVC.presentedViewController {
+            topVC = presented
+        }
+        topVC.present(alertVC, animated: true)
     }
 }
 

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -120,7 +120,6 @@ extension MainCoordinator: FolderDetailCoordinatorDelegate {
 // MARK: - TrashCoordinatorDelegate
 
 extension MainCoordinator: TrashCoordinatorDelegate {
-    
     func pushMyFolderDetailView(_ folder: Folder, isHidden: Bool) {
         let myFolderDetailVM = dependencyContainer.makeMyFolderDetailViewModel(folder, isTrashMode: isHidden)
         myFolderDetailVM.coordinator = self
@@ -128,7 +127,7 @@ extension MainCoordinator: TrashCoordinatorDelegate {
         let myFolderDetailVC = FolderDetailViewController(vm: myFolderDetailVM)
         presenter.pushViewController(myFolderDetailVC, animated: true)
     }
-    
+
     func pushSearchView(
         type: Presentation.SearchViewModel.SearchType,
         items: [ContentItem],

--- a/Core/Sources/Extensions/Date+Folder.swift
+++ b/Core/Sources/Extensions/Date+Folder.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public extension Date {
+    func trashFolderText(deletedAt: Date?, count: Int) -> String {
+        var deletedText: String
+        guard let deletedAt else {
+            return ""
+        }
+        deletedText = Self.relativeDateText(referenceDate: deletedAt, now: self)
+
+        if count == 0 {
+            return "항목 없음 · \(deletedText) 삭제"
+        } else {
+            return "\(count)개 항목 · \(deletedText) 삭제"
+        }
+    }
+
+    func searchFolderText() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        return formatter.string(from: self)
+    }
+}

--- a/Core/Sources/Extensions/Date+Folder.swift
+++ b/Core/Sources/Extensions/Date+Folder.swift
@@ -7,12 +7,7 @@ public extension Date {
             return ""
         }
         deletedText = Self.relativeDateText(referenceDate: deletedAt, now: self)
-
-        if count == 0 {
-            return "항목 없음 · \(deletedText) 삭제"
-        } else {
-            return "\(count)개 항목 · \(deletedText) 삭제"
-        }
+        return "\(count)개 항목 · \(deletedText) 삭제됨"
     }
 
     func searchFolderText() -> String {

--- a/Core/Sources/Extensions/Date+Formatting.swift
+++ b/Core/Sources/Extensions/Date+Formatting.swift
@@ -2,18 +2,23 @@ import Foundation
 
 public extension Date {
     var yyyyMMddHHmmssString: String {
-        formatted(
-            Date.VerbatimFormatStyle(
-                format: "\(year: .defaultDigits)\(month: .twoDigits)\(day: .twoDigits)\(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased))\(minute: .twoDigits)\(second: .twoDigits)",
-                timeZone: .current,
-                calendar: .current
-            )
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: self)
+        return String(
+            format: "%04d%02d%02d%02d%02d%02d",
+            components.year ?? 0,
+            components.month ?? 0,
+            components.day ?? 0,
+            components.hour ?? 0,
+            components.minute ?? 0,
+            components.second ?? 0
         )
     }
 
     func toString(format: String, localeIdentifier: String = "ko_KR") -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: localeIdentifier)
+        formatter.timeZone = TimeZone.autoupdatingCurrent
         formatter.dateFormat = format
         return formatter.string(from: self)
     }

--- a/Core/Sources/Extensions/Date+Formatting.swift
+++ b/Core/Sources/Extensions/Date+Formatting.swift
@@ -18,43 +18,18 @@ public extension Date {
         return formatter.string(from: self)
     }
 
-    func voiceNoteDateText(createdAt: Date, updatedAt: Date) -> String {
-        let referenceDate = max(createdAt, updatedAt)
-        return Self.voiceNoteDateText(referenceDate: referenceDate, now: self)
-    }
-
-    func voiceNoteDay(createdAt: Date, updatedAt: Date, duration: Double) -> String {
-        let dateText = voiceNoteDateText(createdAt: createdAt, updatedAt: updatedAt)
-        let durationText = duration.koreanDurationString
-
-        if Int(createdAt.timeIntervalSince1970) != Int(updatedAt.timeIntervalSince1970) {
-            let updateText = updatedAt.toString(format: "M월 d일")
-            return "\(dateText) · \(durationText) (\(updateText) 수정됨)"
-        }
-
-        return "\(dateText) · \(durationText)"
-    }
-}
-
-// MARK: VoiceNote 시간 표기 확장
-
-private extension Date {
-    static func voiceNoteDateText(referenceDate: Date, now: Date) -> String {
-        var calendar = Calendar.current
-        calendar.locale = Locale(identifier: "ko_KR")
-
+    static func relativeDateText(referenceDate: Date, now: Date) -> String {
         let elapsed = now.timeIntervalSince(referenceDate)
-        if elapsed >= 0, calendar.isDate(referenceDate, equalTo: now, toGranularity: .day) {
-            if elapsed < 60 { return "방금 전" }
-            if elapsed < 3600 { return "\(Int(elapsed / 60))분 전" }
-            return "\(Int(elapsed / 3600))시간 전"
+        if elapsed < 0 {
+            return referenceDate.toString(format: "M월 d일 a h:mm")
         }
 
-        let oneYearAgo = calendar.date(byAdding: .year, value: -1, to: now) ?? now.addingTimeInterval(-31_536_000)
-        if referenceDate < oneYearAgo {
-            return referenceDate.toString(format: "yyyy.MM.dd")
-        }
+        if elapsed < 60 { return "방금 전" }
+        if elapsed < 3600 { return "\(Int(elapsed / 60))분 전" }
+        if elapsed < 86400 { return "\(Int(elapsed / 3600))시간 전" }
+        if elapsed < 2_592_000 { return "\(Int(elapsed / 86400))일 전" }
+        if elapsed < 31_536_000 { return "\(Int(elapsed / 2_592_000))개월 전" }
 
-        return referenceDate.toString(format: "M월 d일 a h:mm")
+        return referenceDate.toString(format: "yyyy.MM.dd")
     }
 }

--- a/Core/Sources/Extensions/Date+Formatting.swift
+++ b/Core/Sources/Extensions/Date+Formatting.swift
@@ -24,11 +24,18 @@ public extension Date {
             return referenceDate.toString(format: "M월 d일 a h:mm")
         }
 
-        if elapsed < 60 { return "방금 전" }
-        if elapsed < 3600 { return "\(Int(elapsed / 60))분 전" }
-        if elapsed < 86400 { return "\(Int(elapsed / 3600))시간 전" }
-        if elapsed < 2_592_000 { return "\(Int(elapsed / 86400))일 전" }
-        if elapsed < 31_536_000 { return "\(Int(elapsed / 2_592_000))개월 전" }
+        let calendar = Calendar.current
+        if calendar.isDate(referenceDate, inSameDayAs: now) {
+            return "오늘"
+        }
+
+        let startOfReference = calendar.startOfDay(for: referenceDate)
+        let startOfNow = calendar.startOfDay(for: now)
+        let components = calendar.dateComponents([.day], from: startOfReference, to: startOfNow)
+
+        if let day = components.day, day > 0, day <= 7 {
+            return "\(day)일 전"
+        }
 
         return referenceDate.toString(format: "yyyy.MM.dd")
     }

--- a/Core/Sources/Extensions/Date+Formatting.swift
+++ b/Core/Sources/Extensions/Date+Formatting.swift
@@ -18,7 +18,7 @@ public extension Date {
     func toString(format: String, localeIdentifier: String = "ko_KR") -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: localeIdentifier)
-        formatter.timeZone = TimeZone.autoupdatingCurrent
+        formatter.timeZone = Calendar.current.timeZone
         formatter.dateFormat = format
         return formatter.string(from: self)
     }

--- a/Core/Sources/Extensions/Date+VoiceNote.swift
+++ b/Core/Sources/Extensions/Date+VoiceNote.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+// MARK: - VoiceNote 관련 Date 확장
+
+public extension Date {
+    func voiceNoteDay(createdAt: Date, updatedAt: Date, duration: Double) -> String {
+        let dateText = voiceNoteDateText(createdAt: createdAt, updatedAt: updatedAt)
+        let durationText = duration.koreanDurationString
+
+        if Int(createdAt.timeIntervalSince1970) != Int(updatedAt.timeIntervalSince1970) {
+            let updateText = Self.updatedDateText(updatedAt: updatedAt, now: self)
+            return "\(dateText) (\(updateText)) · \(durationText)"
+        }
+
+        return "\(dateText) · \(durationText)"
+    }
+
+    func trashVoiceNoteDay(createdAt: Date, updatedAt: Date, deletedAt: Date?) -> String {
+        let referenceDate = max(createdAt, updatedAt)
+        let createdTimeText = referenceDate.toString(format: "a h:mm")
+
+        guard let deletedAt else {
+            return createdTimeText
+        }
+
+        let deletedText = Self.relativeDateText(referenceDate: deletedAt, now: self)
+        return "\(createdTimeText) · \(deletedText) 삭제"
+    }
+
+    func searchVoiceNoteDay(createdAt: Date, updatedAt: Date, duration: Double, folderName: String) -> String {
+        let frontText = voiceNoteDay(createdAt: createdAt, updatedAt: updatedAt, duration: duration)
+        return frontText + " · " + folderName
+    }
+
+    internal func voiceNoteDateText(createdAt: Date, updatedAt: Date) -> String {
+        let referenceDate = max(createdAt, updatedAt)
+        return Self.voiceNoteMainDateText(referenceDate: referenceDate, now: self)
+    }
+
+    private static func voiceNoteMainDateText(referenceDate: Date, now: Date) -> String {
+        var calendar = Calendar.current
+        calendar.locale = Locale(identifier: "ko_KR")
+
+        let elapsed = now.timeIntervalSince(referenceDate)
+        if elapsed >= 0, calendar.isDate(referenceDate, equalTo: now, toGranularity: .day) {
+            if elapsed < 60 { return "방금 전" }
+            if elapsed < 3600 { return "\(Int(elapsed / 60))분 전" }
+            return referenceDate.toString(format: "a h:mm")
+        }
+
+        let oneYearAgo = calendar.date(byAdding: .year, value: -1, to: now) ?? now.addingTimeInterval(-31_536_000)
+        if referenceDate < oneYearAgo {
+            return referenceDate.toString(format: "yyyy.MM.dd")
+        }
+
+        return referenceDate.toString(format: "M월 d일 a h:mm")
+    }
+
+    private static func updatedDateText(updatedAt: Date, now: Date) -> String {
+        var calendar = Calendar.current
+        calendar.locale = Locale(identifier: "ko_KR")
+
+        if calendar.isDate(updatedAt, equalTo: now, toGranularity: .day) {
+            return "오늘 수정됨"
+        }
+
+        let oneYearAgo = calendar.date(byAdding: .year, value: -1, to: now) ?? now.addingTimeInterval(-31_536_000)
+        if updatedAt < oneYearAgo {
+            return "\(updatedAt.toString(format: "yyyy.MM.dd")) 수정됨"
+        }
+
+        return "\(updatedAt.toString(format: "M월 d일")) 수정됨"
+    }
+}

--- a/Core/Sources/Extensions/Date+VoiceNote.swift
+++ b/Core/Sources/Extensions/Date+VoiceNote.swift
@@ -24,7 +24,7 @@ public extension Date {
         }
 
         let deletedText = Self.relativeDateText(referenceDate: deletedAt, now: self)
-        return "\(createdTimeText) · \(deletedText) 삭제"
+        return "\(createdTimeText) · \(deletedText) 삭제됨"
     }
 
     func searchVoiceNoteDay(createdAt: Date, updatedAt: Date, duration: Double, folderName: String) -> String {

--- a/Core/Tests/Extensions/DateFormattingTests.swift
+++ b/Core/Tests/Extensions/DateFormattingTests.swift
@@ -219,7 +219,7 @@ extension DateFormattingTests {
         let now = makeDate(2026, 4, 13, 15, 30, 0)
         let yesterday = makeDate(2026, 4, 12, 23, 59, 59)
         let sevenDaysAgo = makeDate(2026, 4, 6, 0, 1, 0)
-        
+
         XCTAssertEqual(Date.relativeDateText(referenceDate: yesterday, now: now), "1일 전")
         XCTAssertEqual(Date.relativeDateText(referenceDate: sevenDaysAgo, now: now), "7일 전")
     }
@@ -227,7 +227,7 @@ extension DateFormattingTests {
     func test_상대시간_7일초과_경계값테스트() {
         let now = makeDate(2026, 4, 13, 15, 30, 0)
         let eightDaysAgo = makeDate(2026, 4, 5, 23, 59, 59)
-        
+
         XCTAssertEqual(Date.relativeDateText(referenceDate: eightDaysAgo, now: now), "2026.04.05")
     }
 }

--- a/Core/Tests/Extensions/DateFormattingTests.swift
+++ b/Core/Tests/Extensions/DateFormattingTests.swift
@@ -31,7 +31,7 @@ extension DateFormattingTests {
         let result = now.voiceNoteDay(createdAt: createdAt, updatedAt: updatedAt, duration: 720)
 
         // Then
-        XCTAssertEqual(result, "방금 전 · 12분 (4월 13일 수정됨)")
+        XCTAssertEqual(result, "방금 전 (오늘 수정됨) · 12분")
     }
 
     func test_5분전_음성메모일자문구생성시_분전으로표시된다() {
@@ -44,10 +44,10 @@ extension DateFormattingTests {
         let result = now.voiceNoteDay(createdAt: createdAt, updatedAt: updatedAt, duration: 150)
 
         // Then
-        XCTAssertEqual(result, "5분 전 · 2분 30초 (4월 13일 수정됨)")
+        XCTAssertEqual(result, "5분 전 (오늘 수정됨) · 2분 30초")
     }
 
-    func test_1시간전_상세날짜문구생성시_수정일기준시간전으로표시된다() {
+    func test_당일1시간초과_상세날짜문구생성시_오전오후시각으로표시된다() {
         // Given
         let now = makeDate(2026, 4, 13, 15, 30, 0)
         let createdAt = makeDate(2026, 3, 15, 15, 23, 0)
@@ -57,7 +57,7 @@ extension DateFormattingTests {
         let result = now.voiceNoteDateText(createdAt: createdAt, updatedAt: updatedAt)
 
         // Then
-        XCTAssertEqual(result, "1시간 전")
+        XCTAssertEqual(result, "오후 2:20")
     }
 }
 
@@ -86,6 +86,177 @@ extension DateFormattingTests {
 
         // Then
         XCTAssertEqual(result, "2025.03.15 · 12분")
+    }
+}
+
+// MARK: - 휴지통 삭제 시각
+
+extension DateFormattingTests {
+    func test_휴지통_삭제3일전_타임라인문구생성시_일전삭제로표시된다() {
+        // Given
+        let now = makeDate(2026, 4, 13, 15, 30, 0)
+        let createdAt = makeDate(2026, 4, 13, 15, 23, 0)
+        let deletedAt = makeDate(2026, 4, 10, 10, 0, 0)
+
+        // When
+        let result = now.trashVoiceNoteDay(createdAt: createdAt, updatedAt: createdAt, deletedAt: deletedAt)
+
+        // Then
+        XCTAssertEqual(result, "오후 3:23 · 3일 전 삭제")
+    }
+
+    func test_휴지통_삭제2개월전_타임라인문구생성시_개월전삭제로표시된다() {
+        // Given
+        let now = makeDate(2026, 4, 13, 15, 30, 0)
+        let createdAt = makeDate(2026, 4, 13, 15, 23, 0)
+        let deletedAt = makeDate(2026, 2, 10, 10, 0, 0)
+
+        // When
+        let result = now.trashVoiceNoteDay(createdAt: createdAt, updatedAt: createdAt, deletedAt: deletedAt)
+
+        // Then
+        XCTAssertEqual(result, "오후 3:23 · 2개월 전 삭제")
+    }
+
+    func test_휴지통_삭제1년초과_타임라인문구생성시_yyyyMMdd삭제로표시된다() {
+        // Given
+        let now = makeDate(2026, 4, 13, 15, 30, 0)
+        let createdAt = makeDate(2026, 4, 13, 15, 23, 0)
+        let deletedAt = makeDate(2025, 3, 15, 15, 23, 0)
+
+        // When
+        let result = now.trashVoiceNoteDay(createdAt: createdAt, updatedAt: createdAt, deletedAt: deletedAt)
+
+        // Then
+        XCTAssertEqual(result, "오후 3:23 · 2025.03.15 삭제")
+    }
+}
+
+// MARK: - 폴더 상대 시각
+
+extension DateFormattingTests {
+    func test_폴더_3개항목_1개월전_문구생성시_요청형식으로표시된다() {
+        // Given
+        let now = makeDate(2026, 4, 13, 15, 30, 0)
+        let deletedAt = makeDate(2026, 3, 10, 10, 0, 0)
+
+        // When
+        let result = now.trashFolderText(deletedAt: deletedAt, count: 3)
+
+        // Then
+        XCTAssertEqual(result, "3개 항목 · 1개월 전 삭제")
+    }
+
+    func test_폴더_0개항목_삭제문구생성시_항목없음으로표시된다() {
+        // Given
+        let now = makeDate(2026, 4, 13, 15, 30, 0)
+        let deletedAt = makeDate(2026, 4, 13, 15, 20, 0)
+
+        // When
+        let result = now.trashFolderText(deletedAt: deletedAt, count: 0)
+
+        // Then
+        XCTAssertEqual(result, "항목 없음 · 10분 전 삭제")
+    }
+}
+
+// MARK: - 검색 결과 시각
+
+extension DateFormattingTests {
+    func test_검색결과_폴더날짜생성시_yyyyMMdd형식으로표시된다() {
+        // Given
+        let date = makeDate(2026, 4, 13, 15, 30, 0)
+
+        // When
+        let result = date.searchFolderText()
+
+        // Then
+        XCTAssertEqual(result, "2026.04.13")
+    }
+
+    func test_검색결과_음성메모생성시_폴더명이포함되어표시된다() {
+        // Given
+        let now = makeDate(2026, 4, 13, 15, 30, 0)
+        let createdAt = makeDate(2026, 4, 13, 15, 20, 0)
+
+        // When
+        let result = now.searchVoiceNoteDay(
+            createdAt: createdAt,
+            updatedAt: createdAt,
+            duration: 125,
+            folderName: "아이디어"
+        )
+
+        // Then
+        XCTAssertEqual(result, "10분 전 · 2분 5초 · 아이디어")
+    }
+}
+
+// MARK: - 문자열 변환
+
+extension DateFormattingTests {
+    func test_yyyyMMddHHmmssString_호출시_지정된형식으로반환된다() {
+        // Given
+        let date = makeDate(2026, 4, 13, 15, 30, 45)
+
+        // When
+        let result = date.yyyyMMddHHmmssString
+
+        // Then
+        XCTAssertEqual(result, "20260413153045")
+    }
+
+    func test_toString_호출시_지정된포맷의문자열을반환한다() {
+        // Given
+        let date = makeDate(2026, 4, 13, 15, 30, 0)
+
+        // When
+        let result = date.toString(format: "yyyy-MM-dd HH:mm")
+
+        // Then
+        XCTAssertEqual(result, "2026-04-13 15:30")
+    }
+}
+
+// MARK: - 상대 시간 임계값 테스트
+
+extension DateFormattingTests {
+    func test_상대시간_방금전_경계값테스트() {
+        let now = makeDate(2026, 4, 13, 15, 30, 0)
+
+        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-59), now: now), "방금 전")
+        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-60), now: now), "1분 전")
+    }
+
+    func test_상대시간_분전_경계값테스트() {
+        let now = makeDate(2026, 4, 13, 15, 30, 0)
+
+        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-3599), now: now), "59분 전")
+        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-3600), now: now), "1시간 전")
+    }
+
+    func test_상대시간_시간전_경계값테스트() {
+        let now = makeDate(2026, 4, 13, 15, 30, 0)
+
+        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-86399), now: now), "23시간 전")
+        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-86400), now: now), "1일 전")
+    }
+
+    func test_상대시간_일전_경계값테스트() {
+        let now = makeDate(2026, 4, 13, 15, 30, 0)
+
+        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-2_591_999), now: now), "29일 전")
+        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-2_592_000), now: now), "1개월 전")
+    }
+
+    func test_상대시간_개월전_경계값테스트() {
+        let now = makeDate(2026, 4, 13, 15, 30, 0)
+
+        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-31_535_999), now: now), "12개월 전")
+        XCTAssertEqual(
+            Date.relativeDateText(referenceDate: now.addingTimeInterval(-31_536_000), now: now),
+            "2025.04.13"
+        )
     }
 }
 

--- a/Core/Tests/Extensions/DateFormattingTests.swift
+++ b/Core/Tests/Extensions/DateFormattingTests.swift
@@ -102,7 +102,7 @@ extension DateFormattingTests {
         let result = now.trashVoiceNoteDay(createdAt: createdAt, updatedAt: createdAt, deletedAt: deletedAt)
 
         // Then
-        XCTAssertEqual(result, "오후 3:23 · 3일 전 삭제")
+        XCTAssertEqual(result, "오후 3:23 · 3일 전 삭제됨")
     }
 
     func test_휴지통_삭제2개월전_타임라인문구생성시_개월전삭제로표시된다() {
@@ -115,7 +115,7 @@ extension DateFormattingTests {
         let result = now.trashVoiceNoteDay(createdAt: createdAt, updatedAt: createdAt, deletedAt: deletedAt)
 
         // Then
-        XCTAssertEqual(result, "오후 3:23 · 2개월 전 삭제")
+        XCTAssertEqual(result, "오후 3:23 · 2026.02.10 삭제됨")
     }
 
     func test_휴지통_삭제1년초과_타임라인문구생성시_yyyyMMdd삭제로표시된다() {
@@ -128,7 +128,7 @@ extension DateFormattingTests {
         let result = now.trashVoiceNoteDay(createdAt: createdAt, updatedAt: createdAt, deletedAt: deletedAt)
 
         // Then
-        XCTAssertEqual(result, "오후 3:23 · 2025.03.15 삭제")
+        XCTAssertEqual(result, "오후 3:23 · 2025.03.15 삭제됨")
     }
 }
 
@@ -144,19 +144,7 @@ extension DateFormattingTests {
         let result = now.trashFolderText(deletedAt: deletedAt, count: 3)
 
         // Then
-        XCTAssertEqual(result, "3개 항목 · 1개월 전 삭제")
-    }
-
-    func test_폴더_0개항목_삭제문구생성시_항목없음으로표시된다() {
-        // Given
-        let now = makeDate(2026, 4, 13, 15, 30, 0)
-        let deletedAt = makeDate(2026, 4, 13, 15, 20, 0)
-
-        // When
-        let result = now.trashFolderText(deletedAt: deletedAt, count: 0)
-
-        // Then
-        XCTAssertEqual(result, "항목 없음 · 10분 전 삭제")
+        XCTAssertEqual(result, "3개 항목 · 2026.03.10 삭제됨")
     }
 }
 
@@ -221,42 +209,26 @@ extension DateFormattingTests {
 // MARK: - 상대 시간 임계값 테스트
 
 extension DateFormattingTests {
-    func test_상대시간_방금전_경계값테스트() {
+    func test_상대시간_당일_경계값테스트() {
         let now = makeDate(2026, 4, 13, 15, 30, 0)
-
-        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-59), now: now), "방금 전")
-        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-60), now: now), "1분 전")
+        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-60), now: now), "오늘")
+        XCTAssertEqual(Date.relativeDateText(referenceDate: makeDate(2026, 4, 13, 0, 1, 0), now: now), "오늘")
     }
 
-    func test_상대시간_분전_경계값테스트() {
+    func test_상대시간_7일이내_경계값테스트() {
         let now = makeDate(2026, 4, 13, 15, 30, 0)
-
-        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-3599), now: now), "59분 전")
-        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-3600), now: now), "1시간 전")
+        let yesterday = makeDate(2026, 4, 12, 23, 59, 59)
+        let sevenDaysAgo = makeDate(2026, 4, 6, 0, 1, 0)
+        
+        XCTAssertEqual(Date.relativeDateText(referenceDate: yesterday, now: now), "1일 전")
+        XCTAssertEqual(Date.relativeDateText(referenceDate: sevenDaysAgo, now: now), "7일 전")
     }
 
-    func test_상대시간_시간전_경계값테스트() {
+    func test_상대시간_7일초과_경계값테스트() {
         let now = makeDate(2026, 4, 13, 15, 30, 0)
-
-        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-86399), now: now), "23시간 전")
-        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-86400), now: now), "1일 전")
-    }
-
-    func test_상대시간_일전_경계값테스트() {
-        let now = makeDate(2026, 4, 13, 15, 30, 0)
-
-        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-2_591_999), now: now), "29일 전")
-        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-2_592_000), now: now), "1개월 전")
-    }
-
-    func test_상대시간_개월전_경계값테스트() {
-        let now = makeDate(2026, 4, 13, 15, 30, 0)
-
-        XCTAssertEqual(Date.relativeDateText(referenceDate: now.addingTimeInterval(-31_535_999), now: now), "12개월 전")
-        XCTAssertEqual(
-            Date.relativeDateText(referenceDate: now.addingTimeInterval(-31_536_000), now: now),
-            "2025.04.13"
-        )
+        let eightDaysAgo = makeDate(2026, 4, 5, 23, 59, 59)
+        
+        XCTAssertEqual(Date.relativeDateText(referenceDate: eightDaysAgo, now: now), "2026.04.05")
     }
 }
 

--- a/Presentation/Sources/Component/Common/AlertView.swift
+++ b/Presentation/Sources/Component/Common/AlertView.swift
@@ -1,12 +1,11 @@
 import UIKit
 
 final class AlertView: UIView {
-    let closeButton: GlassButton
+    var closeButton: GlassButton
 
-    let primaryButton: GlassButton
+    var primaryButton: GlassButton
 
     private let title: String
-
     private let subTitle: String
     private var widthConstraint: NSLayoutConstraint?
 
@@ -163,5 +162,21 @@ extension AlertView {
                 constant: -Constant.alertLeftAndRightValueForBottomContent
             )
         ])
+    }
+}
+
+// MARK: - Configure
+
+extension AlertView {
+    func configure(
+        title: String,
+        subtitle: String,
+        closeButton: GlassButton,
+        primaryButton: GlassButton
+    ) {
+        header.setTypography(text: title, style: .title2)
+        body.setTypography(text: subTitle, style: .body1)
+        self.closeButton = closeButton
+        self.primaryButton = primaryButton
     }
 }

--- a/Presentation/Sources/Component/Common/GlassButton.swift
+++ b/Presentation/Sources/Component/Common/GlassButton.swift
@@ -359,3 +359,41 @@ private final class UnifiedGradientView: UIView {
         }
     }
 }
+
+// MARK: Alert Apply Factory
+
+extension GlassButton {
+    func apply(_ style: ChaGokAlertViewModel.ButtonStyle) {
+        switch style.type {
+        case .close:
+            configure(
+                style.text,
+                typography: .body1,
+                backgroundColor: .color(.gray300),
+                foregroundColor: .gray750
+            )
+        case .default:
+            configure(
+                style.text,
+                typography: .subtitle1,
+                border: Border(color: .color(.gray600), width: Constant.borderWidth),
+                backgroundColor: .color(.point200.withAlphaComponent(Constant.backgroundOpacity)),
+                foregroundColor: .gray900
+            )
+        case .primary:
+            configure(
+                style.text,
+                typography: .subtitle1,
+                backgroundColor: .color(.point600),
+                foregroundColor: .white
+            )
+        case .danger:
+            configure(
+                style.text,
+                typography: .subtitle1,
+                backgroundColor: .color(.danger),
+                foregroundColor: .white
+            )
+        }
+    }
+}

--- a/Presentation/Sources/Component/Common/LanguagePicker.swift
+++ b/Presentation/Sources/Component/Common/LanguagePicker.swift
@@ -3,7 +3,7 @@ import Domain
 import UIKit
 
 /// 언어 선택을 위한 라디오 버튼 스타일의 피커 컴포넌트입니다.
-final class LanguagePicker: UIStackView {
+public final class LanguagePicker: UIStackView {
     // MARK: - State
 
     private(set) var selectedLanguage: Language
@@ -14,7 +14,7 @@ final class LanguagePicker: UIStackView {
 
     // MARK: - LifeCycle
 
-    init(selected: Language, axis: NSLayoutConstraint.Axis = .vertical, showAlert: Bool = false) {
+    public init(selected: Language, axis: NSLayoutConstraint.Axis = .vertical, showAlert: Bool = false) {
         selectedLanguage = selected
         self.showAlert = showAlert
         super.init(frame: .zero)

--- a/Presentation/Sources/Component/Common/TextFieldView.swift
+++ b/Presentation/Sources/Component/Common/TextFieldView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class TextFieldView: UIView {
+public final class TextFieldView: UIView {
     // MARK: - Properties
 
     var field: Field
@@ -105,7 +105,7 @@ final class TextFieldView: UIView {
 
     // MARK: - LifeCycle
 
-    override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
         layer.shadowColor = UIColor.black.cgColor
         layer.shadowOpacity = Constant.shadowOpacity
@@ -118,7 +118,7 @@ final class TextFieldView: UIView {
             ).cgPath
     }
 
-    override func updateProperties() {
+    override public func updateProperties() {
         super.updateProperties()
         titleLabel.setTypography(text: field.title, style: .title2, textAlignment: .center)
         subTitleLabel.setTypography(text: field.subTitle, style: .body2, textAlignment: .center)
@@ -218,7 +218,7 @@ extension TextFieldView {
 
 extension TextFieldView {
     @Observable
-    final class Field {
+    public final class Field: Sendable {
         var mode: Mode
         var title: String
         var subTitle: String
@@ -238,7 +238,7 @@ extension TextFieldView {
             text.count > 50
         }
 
-        init(
+        public init(
             mode: Mode,
             title: String,
             subTitle: String,
@@ -255,7 +255,7 @@ extension TextFieldView {
         }
     }
 
-    enum Mode {
+    public enum Mode {
         case create
         case edit
     }
@@ -264,12 +264,12 @@ extension TextFieldView {
 // MARK: TextField Delegate
 
 extension TextFieldView: UITextFieldDelegate {
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
     }
 
-    func textField(
+    public func textField(
         _ textField: UITextField,
         shouldChangeCharactersIn range: NSRange,
         replacementString string: String

--- a/Presentation/Sources/Component/Common/TextFieldView.swift
+++ b/Presentation/Sources/Component/Common/TextFieldView.swift
@@ -216,9 +216,9 @@ extension TextFieldView {
 
 // MARK: - Observable 구조
 
-extension TextFieldView {
+public extension TextFieldView {
     @Observable
-    public final class Field: Sendable {
+    final class Field {
         var mode: Mode
         var title: String
         var subTitle: String
@@ -255,7 +255,7 @@ extension TextFieldView {
         }
     }
 
-    public enum Mode {
+    enum Mode {
         case create
         case edit
     }

--- a/Presentation/Sources/Component/Common/TextFieldView.swift
+++ b/Presentation/Sources/Component/Common/TextFieldView.swift
@@ -134,7 +134,6 @@ public final class TextFieldView: UIView {
         case .edit:
             primaryButton.configuration?.title = "수정하기"
         }
-        primaryButton.isEnabled = field.isSubmitEnabled
         updatePlaceholderVisibility()
         // error Message
         updateErrorMessageLabel()
@@ -212,6 +211,11 @@ extension TextFieldView {
             textCount.textColor = field.text.count >= 50 ? .danger : .gray750
         }
     }
+
+    public func setErrorMessage(_ message: String?) {
+        field.errorMessage = message
+        updateErrorMessageLabel()
+    }
 }
 
 // MARK: - Observable 구조
@@ -225,10 +229,6 @@ public extension TextFieldView {
         var placeHolder: String
         var text: String
         var errorMessage: String?
-
-        var isSubmitEnabled: Bool {
-            !text.isEmpty
-        }
 
         var textCountLabel: String {
             "\(text.count)/\(50)"

--- a/Presentation/Sources/Component/Trash/TrashFolderCardView.swift
+++ b/Presentation/Sources/Component/Trash/TrashFolderCardView.swift
@@ -57,15 +57,23 @@ struct TrashFolderCardView: View {
         .padding(.trailing)
     }
 
+    @ViewBuilder
     private var cardContent: some View {
-        HStack(spacing: 8) {
-            Group {
-                Image(systemName: "folder")
+        let time: String = Date.now.trashFolderText(
+            deletedAt: folder.deletedAt,
+            count: folder.voiceNoteIDs.count
+        )
+
+        HStack(spacing: 16) {
+            Image(systemName: "folder")
+                .frame(width: 20, height: 20)
+            VStack(alignment: .leading, spacing: 6) {
                 Text(folder.name)
-                    .font(Font.custom("Pretendard", size: 16))
-                Spacer()
+                    .typography(.title2)
+                    .foregroundStyle(.gray900)
+                Text(time)
+                    .foregroundColor(.gray800)
             }
-            .foregroundColor(.gray800)
         }
     }
 }

--- a/Presentation/Sources/Component/Trash/TrashVoiceNoteCardView.swift
+++ b/Presentation/Sources/Component/Trash/TrashVoiceNoteCardView.swift
@@ -57,15 +57,23 @@ struct TrashVoiceNoteCardView: View {
         .padding(.trailing)
     }
 
+    @ViewBuilder
     private var cardContent: some View {
-        HStack(spacing: 8) {
-            Group {
-                Image(systemName: "microphone")
+        let time: String = Date.now.trashVoiceNoteDay(
+            createdAt: voiceNote.createdAt,
+            updatedAt: voiceNote.updatedAt,
+            deletedAt: voiceNote.deletedAt
+        )
+        HStack(spacing: 16) {
+            Image(systemName: "microphone")
+                .frame(width: 20, height: 20)
+            VStack(alignment: .leading, spacing: 6) {
                 Text(voiceNote.title)
-                    .font(Font.custom("Pretendard", size: 16))
-                Spacer()
+                    .typography(.title2)
+                    .foregroundStyle(.gray900)
+                Text(time)
+                    .foregroundColor(.gray800)
             }
-            .foregroundColor(.gray800)
         }
     }
 }

--- a/Presentation/Sources/DesignSystem/Text+HighlightedMultipleText.swift
+++ b/Presentation/Sources/DesignSystem/Text+HighlightedMultipleText.swift
@@ -21,7 +21,6 @@ extension Text {
         while let range = attributedString[searchRange].range(of: keyword, options: .caseInsensitive) {
             // 스타일 적용
             attributedString[range].foregroundColor = .point900
-            attributedString[range].font = .body.weight(.bold)
 
             // 찾은 부분 다음부터 다시 검색하도록 범위를 업데이트
             searchRange = range.upperBound ..< attributedString.endIndex

--- a/Presentation/Sources/View/Alert/ChaGokAlertViewController.swift
+++ b/Presentation/Sources/View/Alert/ChaGokAlertViewController.swift
@@ -12,6 +12,9 @@ public final class ChaGokAlertViewController: UIViewController {
     public var selectedLanguage: Language? {
         vm.selectedLanguage
     }
+    public var inputText: String? {
+        textFieldView?.field.text
+    }
 
     // MARK: - Initialize
 

--- a/Presentation/Sources/View/Alert/ChaGokAlertViewController.swift
+++ b/Presentation/Sources/View/Alert/ChaGokAlertViewController.swift
@@ -112,18 +112,42 @@ public final class ChaGokAlertViewController: UIViewController {
             primaryButton: primaryButton
         )
         self.textFieldView = textFieldView
-        attachContentView(textFieldView, needsWidthConstraint: true)
+        attachContentView(textFieldView, needsWidthConstraint: true, respectKeyboard: true)
     }
 
-    private func attachContentView(_ contentView: UIView, needsWidthConstraint: Bool = false) {
+    private func attachContentView(
+        _ contentView: UIView,
+        needsWidthConstraint: Bool = false,
+        respectKeyboard: Bool = false
+    ) {
         contentView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(contentView)
         currentContentView = contentView
 
-        var constraints: [NSLayoutConstraint] = [
-            contentView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            contentView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
-        ]
+        var constraints: [NSLayoutConstraint] = []
+
+        if respectKeyboard {
+            let containerGuide = UILayoutGuide()
+            view.addLayoutGuide(containerGuide)
+
+            constraints.append(contentsOf: [
+                containerGuide.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                containerGuide.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                containerGuide.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                containerGuide.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
+
+                contentView.centerXAnchor.constraint(equalTo: containerGuide.centerXAnchor),
+                contentView.centerYAnchor.constraint(equalTo: containerGuide.centerYAnchor),
+                contentView.topAnchor.constraint(greaterThanOrEqualTo: containerGuide.topAnchor, constant: 20),
+                contentView.bottomAnchor.constraint(lessThanOrEqualTo: containerGuide.bottomAnchor, constant: -20)
+            ])
+        } else {
+            constraints.append(contentsOf: [
+                contentView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                contentView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+            ])
+        }
+
         if needsWidthConstraint {
             constraints.append(contentView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8))
         }

--- a/Presentation/Sources/View/Alert/ChaGokAlertViewController.swift
+++ b/Presentation/Sources/View/Alert/ChaGokAlertViewController.swift
@@ -1,3 +1,4 @@
+import Domain
 import UIKit
 
 public final class ChaGokAlertViewController: UIViewController {
@@ -8,32 +9,37 @@ public final class ChaGokAlertViewController: UIViewController {
     private var languagePickerAlert: LanguagePickerAlert?
     private weak var currentContentView: UIView?
     public weak var delegate: ChaGokAlertButtonTappedDelegate?
-    
+    public var selectedLanguage: Language? {
+        vm.selectedLanguage
+    }
+
     // MARK: - Initialize
-    
+
     private let vm: ChaGokAlertViewModel
-    
+
     public init(vm: ChaGokAlertViewModel) {
         self.vm = vm
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .overFullScreen
         modalTransitionStyle = .crossDissolve
+        isModalInPresentation = true
     }
-    
+
     required init?(coder: NSCoder) {
         nil
     }
-    
+
     // MARK: - LifeCycle
-    
+
     override public func viewDidLoad() {
         super.viewDidLoad()
         setup()
         setupActions()
         render(vm.state)
     }
-    
+
     // MARK: - setup
+
     private func setup() {
         view.backgroundColor = UIColor.black.withAlphaComponent(0.6)
     }
@@ -55,47 +61,58 @@ public final class ChaGokAlertViewController: UIViewController {
             for: .touchUpInside
         )
     }
-}
 
-// MARK: Component 초기화
+    /// Componenet 중 AlertView를 초기화 합니다.
+    private func setAlertView(state: ChaGokAlertViewModel.AlertState, subTitle: String) {
+        let alertView = AlertView(
+            title: state.header.title,
+            subTitle: subTitle,
+            closeButton: cancelButton,
+            primaryButton: primaryButton
+        )
+        self.alertView = alertView
+        attachContentView(alertView)
+    }
 
-extension ChaGokAlertViewController {
-    private func render(_ state: ChaGokAlertViewModel.AlertState) {
-        cancelButton.apply(state.cancelButtonStyle)
-        primaryButton.apply(state.primaryButtonStyle)
-
-        currentContentView?.removeFromSuperview()
-
-        switch state.bodyStyle {
-        case .basic(let subTitle):
-            let alertView = AlertView(
-                title: state.header.title,
-                subTitle: subTitle,
-                closeButton: cancelButton,
-                primaryButton: primaryButton
-            )
-            self.alertView = alertView
-            attachContentView(alertView)
-        case .languagePicker(let picker):
-            let languagePickerAlert = LanguagePickerAlert(
-                title: state.header.title,
-                languagePicker: picker,
-                closeButton: cancelButton,
-                primaryButton: primaryButton
-            )
-            self.languagePickerAlert = languagePickerAlert
-            attachContentView(languagePickerAlert)
-        case .textField(let field, let subTitle):
-            field.title = state.header.title
-            field.subTitle = subTitle
-            let textFieldView = TextFieldView(
-                field: field,
-                cancelButton: cancelButton,
-                primaryButton: primaryButton
-            )
-            self.textFieldView = textFieldView
-            attachContentView(textFieldView, needsWidthConstraint: true)
+    /// Componenet 중 LanguagePickerAlert 를 초기화 합니다.
+    private func setLanguagePickerAlertView(
+        state: ChaGokAlertViewModel.AlertState,
+        language: Language
+    ) {
+        let languagePicker = LanguagePicker(
+            selected: language,
+            axis: .horizontal,
+            showAlert: true
+        )
+        vm.setSelectedLanguage(language)
+        languagePicker.onLanguageChanged = { [weak self] updatedLanguage in
+            self?.vm.setSelectedLanguage(updatedLanguage)
         }
+        let languagePickerAlert = LanguagePickerAlert(
+            title: state.header.title,
+            languagePicker: languagePicker,
+            closeButton: cancelButton,
+            primaryButton: primaryButton
+        )
+        self.languagePickerAlert = languagePickerAlert
+        attachContentView(languagePickerAlert)
+    }
+
+    /// Componenet 중 TextFieldView 를 초기화 합니다.
+    private func setTextFieldAlertView(
+        state: ChaGokAlertViewModel.AlertState,
+        field: TextFieldView.Field,
+        subTitle: String
+    ) {
+        field.title = state.header.title
+        field.subTitle = subTitle
+        let textFieldView = TextFieldView(
+            field: field,
+            cancelButton: cancelButton,
+            primaryButton: primaryButton
+        )
+        self.textFieldView = textFieldView
+        attachContentView(textFieldView, needsWidthConstraint: true)
     }
 
     private func attachContentView(_ contentView: UIView, needsWidthConstraint: Bool = false) {
@@ -111,5 +128,25 @@ extension ChaGokAlertViewController {
             constraints.append(contentView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8))
         }
         NSLayoutConstraint.activate(constraints)
+    }
+}
+
+// MARK: Component 초기화
+
+extension ChaGokAlertViewController {
+    private func render(_ state: ChaGokAlertViewModel.AlertState) {
+        cancelButton.apply(state.cancelButtonStyle)
+        primaryButton.apply(state.primaryButtonStyle)
+
+        currentContentView?.removeFromSuperview()
+
+        switch state.bodyStyle {
+        case .basic(let subTitle):
+            setAlertView(state: state, subTitle: subTitle)
+        case .languagePicker(let language):
+            setLanguagePickerAlertView(state: state, language: language)
+        case .textField(let field, let subTitle):
+            setTextFieldAlertView(state: state, field: field, subTitle: subTitle)
+        }
     }
 }

--- a/Presentation/Sources/View/Alert/ChaGokAlertViewController.swift
+++ b/Presentation/Sources/View/Alert/ChaGokAlertViewController.swift
@@ -1,0 +1,115 @@
+import UIKit
+
+public final class ChaGokAlertViewController: UIViewController {
+    private var cancelButton: GlassButton = .init()
+    private let primaryButton: GlassButton = .init()
+    private var alertView: AlertView?
+    private var textFieldView: TextFieldView?
+    private var languagePickerAlert: LanguagePickerAlert?
+    private weak var currentContentView: UIView?
+    public weak var delegate: ChaGokAlertButtonTappedDelegate?
+    
+    // MARK: - Initialize
+    
+    private let vm: ChaGokAlertViewModel
+    
+    public init(vm: ChaGokAlertViewModel) {
+        self.vm = vm
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+    
+    required init?(coder: NSCoder) {
+        nil
+    }
+    
+    // MARK: - LifeCycle
+    
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+        setupActions()
+        render(vm.state)
+    }
+    
+    // MARK: - setup
+    private func setup() {
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+    }
+
+    private func setupActions() {
+        cancelButton.addAction(
+            UIAction { [weak self] _ in
+                guard let self else { return }
+                vm.didTapCancel(delegate: delegate, alertVC: self)
+            },
+            for: .touchUpInside
+        )
+
+        primaryButton.addAction(
+            UIAction { [weak self] _ in
+                guard let self else { return }
+                vm.didTapPrimary(delegate: delegate, alertVC: self)
+            },
+            for: .touchUpInside
+        )
+    }
+}
+
+// MARK: Component 초기화
+
+extension ChaGokAlertViewController {
+    private func render(_ state: ChaGokAlertViewModel.AlertState) {
+        cancelButton.apply(state.cancelButtonStyle)
+        primaryButton.apply(state.primaryButtonStyle)
+
+        currentContentView?.removeFromSuperview()
+
+        switch state.bodyStyle {
+        case .basic(let subTitle):
+            let alertView = AlertView(
+                title: state.header.title,
+                subTitle: subTitle,
+                closeButton: cancelButton,
+                primaryButton: primaryButton
+            )
+            self.alertView = alertView
+            attachContentView(alertView)
+        case .languagePicker(let picker):
+            let languagePickerAlert = LanguagePickerAlert(
+                title: state.header.title,
+                languagePicker: picker,
+                closeButton: cancelButton,
+                primaryButton: primaryButton
+            )
+            self.languagePickerAlert = languagePickerAlert
+            attachContentView(languagePickerAlert)
+        case .textField(let field, let subTitle):
+            field.title = state.header.title
+            field.subTitle = subTitle
+            let textFieldView = TextFieldView(
+                field: field,
+                cancelButton: cancelButton,
+                primaryButton: primaryButton
+            )
+            self.textFieldView = textFieldView
+            attachContentView(textFieldView, needsWidthConstraint: true)
+        }
+    }
+
+    private func attachContentView(_ contentView: UIView, needsWidthConstraint: Bool = false) {
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(contentView)
+        currentContentView = contentView
+
+        var constraints: [NSLayoutConstraint] = [
+            contentView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            contentView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ]
+        if needsWidthConstraint {
+            constraints.append(contentView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8))
+        }
+        NSLayoutConstraint.activate(constraints)
+    }
+}

--- a/Presentation/Sources/View/Alert/ChaGokAlertViewController.swift
+++ b/Presentation/Sources/View/Alert/ChaGokAlertViewController.swift
@@ -12,10 +12,11 @@ public final class ChaGokAlertViewController: UIViewController {
     public var selectedLanguage: Language? {
         vm.selectedLanguage
     }
+
     public var inputText: String? {
         textFieldView?.field.text
     }
-    
+
     public func setErrorMessage(_ message: String?) {
         textFieldView?.setErrorMessage(message)
     }

--- a/Presentation/Sources/View/Alert/ChaGokAlertViewController.swift
+++ b/Presentation/Sources/View/Alert/ChaGokAlertViewController.swift
@@ -15,6 +15,10 @@ public final class ChaGokAlertViewController: UIViewController {
     public var inputText: String? {
         textFieldView?.field.text
     }
+    
+    public func setErrorMessage(_ message: String?) {
+        textFieldView?.setErrorMessage(message)
+    }
 
     // MARK: - Initialize
 

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -59,24 +59,6 @@ public final class FolderDetailViewController: CollectionViewController {
         self?.vm.setSelectionMode(.all)
     }
 
-    private let cancelAlertButton: GlassButton = .close("취소")
-    private let primaryAlertButton: GlassButton = .danger("삭제")
-    private let removeAlertOverlayView: UIView = {
-        let overlay = UIView()
-        overlay.translatesAutoresizingMaskIntoConstraints = false
-        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.6)
-        overlay.isHidden = true
-        return overlay
-    }()
-
-    private lazy var removeAlertView: AlertView = .init(
-        title: "기록을 삭제할까요?",
-        subTitle: "휴지통으로 이동되며,\n직접 비우기 전까지 보관돼요.",
-        closeButton: cancelAlertButton,
-        primaryButton: primaryAlertButton,
-        tintColor: .gray200.withAlphaComponent(0.2)
-    )
-
     private let vm: FolderDetailViewModel
 
     public init(vm: FolderDetailViewModel) {
@@ -96,12 +78,11 @@ public final class FolderDetailViewController: CollectionViewController {
     override public func viewDidLoad() {
         super.viewDidLoad()
         collectionView.allowsSelection = false
+        updateNavigationBarAppearance(isTransparent: false)
         setupNavigation()
         setupSwipeAction()
-        setupRemoveAlert()
         setupDataSource()
         updateDataSource()
-        updateNavigationBarAppearance(isTransparent: vm.showAlert)
     }
 
     override public func viewWillAppear(_ animated: Bool) {
@@ -123,8 +104,6 @@ public final class FolderDetailViewController: CollectionViewController {
         updateNavigationItems(vm.select)
         // dataSource
         updateDataSource(reconfigure: true)
-        // Remove Alert
-        updateRemoveAlert()
     }
 
     private func setupNavigation() {
@@ -181,34 +160,6 @@ public final class FolderDetailViewController: CollectionViewController {
             children: [dateSection, selectSection]
         )
         moreAndActionButton.menu = menu
-    }
-
-    private func setupRemoveAlert() {
-        cancelAlertButton.addAction(UIAction { [weak self] _ in
-            guard let self else { return }
-            vm.closeAlertView()
-        }, for: .touchUpInside)
-
-        primaryAlertButton.addAction(UIAction { [weak self] _ in
-            guard let self else { return }
-            let restoreItems: [VoiceNote] = vm.selectedItems
-            vm.move()
-            vm.closeAlertView()
-            chagokBackgroundView.makeToast("휴지통으로 이동되었어요.") { [weak self] in
-                self?.vm.restore(items: restoreItems)
-            }
-        }, for: .touchUpInside)
-
-        view.addSubview(removeAlertOverlayView)
-        removeAlertOverlayView.addSubview(removeAlertView)
-        NSLayoutConstraint.activate([
-            removeAlertOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
-            removeAlertOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            removeAlertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            removeAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            removeAlertView.centerXAnchor.constraint(equalTo: removeAlertOverlayView.centerXAnchor),
-            removeAlertView.centerYAnchor.constraint(equalTo: removeAlertOverlayView.centerYAnchor)
-        ])
     }
 
     private func setupDataSource() {
@@ -330,16 +281,6 @@ extension FolderDetailViewController {
         }
         dataSource?.apply(snapshot, animatingDifferences: true)
     }
-
-    private func updateRemoveAlert() {
-        let shouldShowAlert = vm.showAlert
-        removeAlertOverlayView.isHidden = !shouldShowAlert
-        updateInteractionForAlert(isPresented: shouldShowAlert)
-        if shouldShowAlert {
-            view.bringSubviewToFront(removeAlertOverlayView)
-        }
-        updateNavigationBarAppearance(isTransparent: shouldShowAlert)
-    }
 }
 
 // MARK: - Helper Method
@@ -366,7 +307,14 @@ private extension FolderDetailViewController {
                 break
             case .multiple, .all:
                 // TODO: 삭제 로직 실행
-                vm.openAlertView()
+                vm.deleteButtonTapped(
+                    alertAction: {
+                        vm.alertCoordinator?.presentAlert(
+                            environment: .moveTrash,
+                            delegate: self
+                        )
+                    }
+                )
             }
         }
     }
@@ -390,13 +338,6 @@ private extension FolderDetailViewController {
             }
         }
     }
-
-    func updateInteractionForAlert(isPresented: Bool) {
-        collectionView.isUserInteractionEnabled = !isPresented
-        backButton.isUserInteractionEnabled = !isPresented
-        moreAndActionButton.isUserInteractionEnabled = !isPresented
-        searchAndMoveButton.isUserInteractionEnabled = !isPresented
-    }
 }
 
 // MARK: - Swipe Action Delegate
@@ -409,7 +350,6 @@ public extension FolderDetailViewController {
             [weak self] _, _, completion in
             if case .voiceNote(let voiceNote) = item {
                 self?.vm.move(id: voiceNote.id)
-                // Swipe 종료 애니메이션과 목록 갱신 타이밍이 어긋나면 셀이 튕겨 보일 수 있어 즉시 반영합니다.
                 self?.updateDataSource()
             }
             completion(true)
@@ -419,6 +359,21 @@ public extension FolderDetailViewController {
         let configuration = UISwipeActionsConfiguration(actions: [deleteAction])
         configuration.performsFirstActionWithFullSwipe = false
         return configuration
+    }
+}
+
+// MARK: Delegate
+
+extension FolderDetailViewController: ChaGokAlertButtonTappedDelegate {
+    public func moveTrashCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true)
+    }
+
+    public func moveTrashPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true) { [weak self] in
+            guard let self else { return }
+            vm.move()
+        }
     }
 }
 

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -111,14 +111,19 @@ public final class FolderDetailViewController: CollectionViewController {
         navigationItem.leftBarButtonItem = leftItem
 
         backButton.addAction(backButtonAction(), for: .touchUpInside)
-        navigationItem.rightBarButtonItems = [
-            UIBarButtonItem(customView: moreAndActionButton),
-            UIBarButtonItem(customView: searchAndMoveButton)
-        ]
-        moreAndActionButton.addAction(moreAndActionButtonAction(), for: .touchUpInside)
-        searchAndMoveButton.addAction(searchAndMoveButtonAction(), for: .touchUpInside)
 
-        setupRightBarButtonMenu()
+        if !vm.isTrashMode {
+            navigationItem.rightBarButtonItems = [
+                UIBarButtonItem(customView: moreAndActionButton),
+                UIBarButtonItem(customView: searchAndMoveButton)
+            ]
+            moreAndActionButton.addAction(moreAndActionButtonAction(), for: .touchUpInside)
+            searchAndMoveButton.addAction(searchAndMoveButtonAction(), for: .touchUpInside)
+            setupRightBarButtonMenu()
+        } else {
+            navigationItem.rightBarButtonItems = []
+        }
+
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
         navigationItem.rightBarButtonItems?.forEach {
             $0.hidesSharedBackground = true
@@ -127,7 +132,9 @@ public final class FolderDetailViewController: CollectionViewController {
 
     private func setupSwipeAction() {
         listConfiguration.trailingSwipeActionsConfigurationProvider = { [weak self] indexPath in
-            self?.trailingAction(indexPath: indexPath)
+            guard let self else { return nil }
+            if vm.isTrashMode { return UISwipeActionsConfiguration(actions: []) }
+            return self.trailingAction(indexPath: indexPath)
         }
 
         // List 레이아웃을 사용하되, 섹션 설정을 통해 간격을 조정합니다.

--- a/Presentation/Sources/View/Folder/FolderDetailViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderDetailViewController.swift
@@ -134,7 +134,7 @@ public final class FolderDetailViewController: CollectionViewController {
         listConfiguration.trailingSwipeActionsConfigurationProvider = { [weak self] indexPath in
             guard let self else { return nil }
             if vm.isTrashMode { return UISwipeActionsConfiguration(actions: []) }
-            return self.trailingAction(indexPath: indexPath)
+            return trailingAction(indexPath: indexPath)
         }
 
         // List 레이아웃을 사용하되, 섹션 설정을 통해 간격을 조정합니다.

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -243,7 +243,7 @@ extension FolderViewController: ChaGokAlertButtonTappedDelegate {
     public func createFolderPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
         guard let name = alertVC.inputText, !name.isEmpty else { return }
         vm.create(name: name)
-        
+
         if let errorMessage = vm.errorMessage {
             alertVC.setErrorMessage(errorMessage)
         } else {
@@ -252,17 +252,17 @@ extension FolderViewController: ChaGokAlertButtonTappedDelegate {
             }
         }
     }
-    
+
     public func updateFolderCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true) { [weak self] in
             self?.vm.closeTextField()
         }
     }
-    
+
     public func updateFolderPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
         guard let name = alertVC.inputText, !name.isEmpty else { return }
         vm.update(name: name)
-        
+
         if let errorMessage = vm.errorMessage {
             alertVC.setErrorMessage(errorMessage)
         } else {

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -242,21 +242,33 @@ extension FolderViewController: ChaGokAlertButtonTappedDelegate {
 
     public func createFolderPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
         guard let name = alertVC.inputText, !name.isEmpty else { return }
-        alertVC.dismiss(animated: true) { [weak self] in
-            self?.vm.create(name: name)
+        vm.create(name: name)
+        
+        if let errorMessage = vm.errorMessage {
+            alertVC.setErrorMessage(errorMessage)
+        } else {
+            alertVC.dismiss(animated: true) { [weak self] in
+                self?.vm.closeTextField()
+            }
         }
     }
-
+    
     public func updateFolderCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true) { [weak self] in
             self?.vm.closeTextField()
         }
     }
-
+    
     public func updateFolderPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
         guard let name = alertVC.inputText, !name.isEmpty else { return }
-        alertVC.dismiss(animated: true) { [weak self] in
-            self?.vm.update(name: name)
+        vm.update(name: name)
+        
+        if let errorMessage = vm.errorMessage {
+            alertVC.setErrorMessage(errorMessage)
+        } else {
+            alertVC.dismiss(animated: true) { [weak self] in
+                self?.vm.closeTextField()
+            }
         }
     }
 }

--- a/Presentation/Sources/View/Folder/FolderViewController.swift
+++ b/Presentation/Sources/View/Folder/FolderViewController.swift
@@ -34,29 +34,6 @@ public final class FolderViewController: CollectionViewController {
         attributedString: Typography.title1.textAttributes
     )
 
-    private var cancelButton: GlassButton = .close("취소")
-    private var primaryButton: GlassButton = .primary("만들기")
-
-    private let textFieldAlertOverlayView: UIView = {
-        let overlay = UIView()
-        overlay.translatesAutoresizingMaskIntoConstraints = false
-        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.6)
-        overlay.isHidden = true
-        return overlay
-    }()
-
-    private lazy var textField = TextFieldView(
-        field: .init(
-            mode: .create,
-            title: "새 폴더",
-            subTitle: "새로 만들 폴더의 이름을\n입력해주세요.",
-            placeHolder: "폴더 이름을 적어주세요",
-            errorMessage: vm.errorMessage
-        ),
-        cancelButton: cancelButton,
-        primaryButton: primaryButton
-    )
-
     // MARK: - Initialize
 
     public init(vm: FolderViewModel) {
@@ -79,7 +56,6 @@ public final class FolderViewController: CollectionViewController {
         setup()
         setupNavigationBar()
         setupSwipeAction()
-        setupButtons()
         setupDataSource()
         updateDataSource(animated: false)
     }
@@ -95,11 +71,8 @@ public final class FolderViewController: CollectionViewController {
 
     override public func updateProperties() {
         super.updateProperties()
-        // textField
-        updateTextFieldAlert()
-        syncTextFieldField()
-        // error Message
-        updateErrorMessage()
+        // Naviagation
+        updateNavigationBarAppearance(isTransparent: false)
         // DataSource
         updateDataSource()
     }
@@ -108,40 +81,18 @@ public final class FolderViewController: CollectionViewController {
 
     private func setup() {
         collectionView.showsVerticalScrollIndicator = false
-
-        // 1. overlay — 화면 전체를 덮는 반투명 배경
-        view.addSubview(textFieldAlertOverlayView)
-
-        // 2. layoutGuide — 키보드 위 영역을 잡는 가이드 (overlay 위)
-        let containerGuide = UILayoutGuide()
-        textFieldAlertOverlayView.addLayoutGuide(containerGuide)
-
-        // 3. textField — containerGuide 중앙에 배치 (overlay 위)
-        textFieldAlertOverlayView.addSubview(textField)
-
-        NSLayoutConstraint.activate([
-            // overlay: 화면 전체
-            textFieldAlertOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
-            textFieldAlertOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            textFieldAlertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            textFieldAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-
-            // containerGuide: safeArea top ~ 키보드 top
-            containerGuide.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            containerGuide.leadingAnchor.constraint(equalTo: textFieldAlertOverlayView.leadingAnchor),
-            containerGuide.trailingAnchor.constraint(equalTo: textFieldAlertOverlayView.trailingAnchor),
-            containerGuide.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
-
-            // textField: containerGuide 중앙
-            textField.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8),
-            textField.centerYAnchor.constraint(equalTo: containerGuide.centerYAnchor),
-            textField.centerXAnchor.constraint(equalTo: containerGuide.centerXAnchor),
-            textField.topAnchor.constraint(greaterThanOrEqualTo: containerGuide.topAnchor, constant: 20),
-            textField.bottomAnchor.constraint(lessThanOrEqualTo: containerGuide.bottomAnchor, constant: -20)
-        ])
     }
 
     private func setupNavigationBar() {
+        vm.showFolderAlert = { [weak self] field in
+            guard let self else { return }
+            if field.mode == .create {
+                vm.alertCoordinator?.presentAlert(environment: .createFolder(field), delegate: self)
+            } else {
+                vm.alertCoordinator?.presentAlert(environment: .updateFolder(field), delegate: self)
+            }
+        }
+
         backButton.addAction(
             UIAction { [weak self] _ in
                 self?.vm.didTapBack()
@@ -185,80 +136,6 @@ public final class FolderViewController: CollectionViewController {
             return section
         }
         collectionView.setCollectionViewLayout(layout, animated: false)
-    }
-
-    private func setupButtons() {
-        cancelButton.addAction(
-            UIAction { [weak self] _ in
-                guard let self else { return }
-                textField.endEditing(true)
-                textField.field.text = ""
-                vm.closeTextField()
-            },
-            for: .touchUpInside
-        )
-
-        primaryButton.addAction(
-            UIAction { [weak self] _ in
-                guard let self else { return }
-                let name = textField.field.text
-
-                switch vm.mode {
-                case .create:
-                    vm.create(name: name)
-                case .edit:
-                    vm.update(name: name)
-                }
-                textField.endEditing(true)
-                textField.field.text = ""
-            },
-            for: .touchUpInside
-        )
-    }
-}
-
-// MARK: - Update Method
-
-extension FolderViewController {
-    private func updateErrorMessage() {
-        textField.field.errorMessage = vm.errorMessage
-    }
-
-    private func syncTextFieldField() {
-        textField.field.mode = vm.mode
-
-        switch vm.mode {
-        case .create:
-            textField.field.title = "새 폴더"
-            textField.field.subTitle = "새로 만들 폴더의 이름을\n입력해주세요."
-            textField.field.placeHolder = "폴더 이름을 적어주세요"
-            textField.field.errorMessage = vm.errorMessage
-            if !vm.showTextField {
-                textField.field.text = ""
-            }
-        case .edit:
-            textField.field.title = "폴더 이름 수정"
-            textField.field.subTitle = "수정할 폴더의 이름을\n입력해주세요."
-            textField.field.placeHolder = "폴더 이름을 적어주세요"
-            textField.field.errorMessage = vm.errorMessage
-            textField.field.text = vm.editFolder?.name ?? ""
-        }
-    }
-
-    private func updateTextFieldAlert() {
-        let shouldShowAlert = vm.showTextField
-        textFieldAlertOverlayView.isHidden = !shouldShowAlert
-        updateInteractionForAlert(isPresented: shouldShowAlert)
-        if shouldShowAlert {
-            view.bringSubviewToFront(textFieldAlertOverlayView)
-        }
-        updateNavigationBarAppearance(isTransparent: shouldShowAlert)
-    }
-
-    func updateInteractionForAlert(isPresented: Bool) {
-        collectionView.isUserInteractionEnabled = !isPresented
-        backButton.isUserInteractionEnabled = !isPresented
-        addButton.isUserInteractionEnabled = !isPresented
     }
 }
 
@@ -350,6 +227,36 @@ public extension FolderViewController {
         // ContentItem이 folder 모델일 경우 상세 화면으로 이동합니다.
         if case .folder(let folder) = item {
             vm.pushDetail(folder)
+        }
+    }
+}
+
+// MARK: - Delegate
+
+extension FolderViewController: ChaGokAlertButtonTappedDelegate {
+    public func createFolderCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true) { [weak self] in
+            self?.vm.closeTextField()
+        }
+    }
+
+    public func createFolderPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        guard let name = alertVC.inputText, !name.isEmpty else { return }
+        alertVC.dismiss(animated: true) { [weak self] in
+            self?.vm.create(name: name)
+        }
+    }
+
+    public func updateFolderCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true) { [weak self] in
+            self?.vm.closeTextField()
+        }
+    }
+
+    public func updateFolderPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        guard let name = alertVC.inputText, !name.isEmpty else { return }
+        alertVC.dismiss(animated: true) { [weak self] in
+            self?.vm.update(name: name)
         }
     }
 }

--- a/Presentation/Sources/View/Main/Cell/MainCategoryContentConfiguration.swift
+++ b/Presentation/Sources/View/Main/Cell/MainCategoryContentConfiguration.swift
@@ -128,7 +128,6 @@ final class MainCategoryContentView: UIView, UIContentView {
     func setSelectedState(_ isSelected: Bool, totalCount: Int) {
         UIView.animate(withDuration: 0.2) {
             self.container.layer.borderColor = isSelected ? UIColor.point900.cgColor : UIColor.gray600.cgColor
-            self.container.layer.borderWidth = isSelected ? 2.0 : 1.0
             self.countView.setTypography(text: String(totalCount), style: isSelected ? .title3 : .label)
             self.titleLabel.textColor = isSelected ? UIColor.gray950 : UIColor.gray600
             self.imageView.tintColor = isSelected ? UIColor.gray950 : UIColor.gray600

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -73,24 +73,6 @@ public final class MainViewController: ViewController {
         menu: UIMenu(title: "", children: [langAction, termsofServiceAction])
     )
 
-    // TODO: Permission Alert
-    private let cancelPermissionAlertButton: GlassButton = .close("나중에")
-    private let primaryPermissionAlertButton: GlassButton = .primary("설정으로 이동")
-    private let permissionAlertOverlayView: UIView = {
-        let overlay = UIView()
-        overlay.translatesAutoresizingMaskIntoConstraints = false
-        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.6)
-        overlay.isHidden = true
-        return overlay
-    }()
-
-    private lazy var permissionAlertView: AlertView = .init(
-        title: "마이크 권한이 필요해요",
-        subTitle: "설정에서 마이크 권한을 \n허용해주세요.",
-        closeButton: cancelPermissionAlertButton,
-        primaryButton: primaryPermissionAlertButton
-    )
-
     private let floatingButton: GlassButton = .floating(
         image: .init(imageName: "microphone", type: .system)
     )
@@ -104,7 +86,6 @@ public final class MainViewController: ViewController {
         setup()
         setupCollectionView()
         setupfloatingButton()
-        setupPermissionAlert()
     }
 
     override public func viewWillAppear(_ animated: Bool) {
@@ -122,16 +103,7 @@ public final class MainViewController: ViewController {
 
     override public func updateProperties() {
         super.updateProperties()
-        let shouldshowPermissionAlert = vm.showPermissionAlert
-
-        permissionAlertOverlayView.isHidden = !shouldshowPermissionAlert
-        updateInteractionForAlert(isPresented: shouldshowPermissionAlert)
-        if shouldshowPermissionAlert {
-            view.bringSubviewToFront(permissionAlertOverlayView)
-        }
-        updateNavigationBarAppearance(
-            isTransparent: shouldshowPermissionAlert
-        )
+        updateNavigationBarAppearance(isTransparent: false)
         updateDataSource()
     }
 
@@ -143,29 +115,6 @@ public final class MainViewController: ViewController {
         navigationItem.leftBarButtonItem?.hidesSharedBackground = true
         navigationItem.rightBarButtonItems?.forEach { $0.hidesSharedBackground = true
         }
-    }
-
-    private func setupPermissionAlert() {
-        cancelPermissionAlertButton.addAction(UIAction { [weak self] _ in
-            self?.vm.closePermissionAlert()
-        }, for: .touchUpInside)
-
-        primaryPermissionAlertButton.addAction(UIAction { [weak self] _ in
-            guard let self else { return }
-            vm.closePermissionAlert()
-            openAppSettings()
-        }, for: .touchUpInside)
-
-        view.addSubview(permissionAlertOverlayView)
-        permissionAlertOverlayView.addSubview(permissionAlertView)
-        NSLayoutConstraint.activate([
-            permissionAlertOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
-            permissionAlertOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            permissionAlertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            permissionAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            permissionAlertView.centerXAnchor.constraint(equalTo: permissionAlertOverlayView.centerXAnchor),
-            permissionAlertView.centerYAnchor.constraint(equalTo: permissionAlertOverlayView.centerYAnchor)
-        ])
     }
 
     private func setupCollectionView() {
@@ -235,7 +184,11 @@ public final class MainViewController: ViewController {
     private func setupfloatingButton() {
         floatingButton.addAction(UIAction { [weak self] _ in
             guard let self else { return }
-            vm.handleRecordButtonTap()
+            vm.handleRecordButtonTap(
+                alertAction: {
+                    vm.alertCoordinator?.presentAlert(environment: .micPermissionRequired, delegate: self)
+                }
+            )
         }, for: .touchUpInside)
 
         NSLayoutConstraint.activate([
@@ -518,6 +471,15 @@ extension MainViewController: UICollectionViewDelegate, ChaGokAlertButtonTappedD
         if let selectedLanguage = alertVC.selectedLanguage {
             vm.saveLanguage(selectedLanguage)
         }
+        alertVC.dismiss(animated: true)
+    }
+    
+    public func micPermissionCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true)
+    }
+    
+    public func micPermissionPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        openAppSettings()
         alertVC.dismiss(animated: true)
     }
 }

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -121,6 +121,8 @@ public final class MainViewController: ViewController {
         view.addSubview(collectionView)
         view.addSubview(floatingButton)
         collectionViewConstraint()
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.showsHorizontalScrollIndicator = false
         collectionView.delegate = self
         collectionView.setCollectionViewLayout(
             createLayout(),

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -48,7 +48,11 @@ public final class MainViewController: ViewController {
     }()
 
     private lazy var langAction: UIAction = UIAction(title: "녹음 언어 선택") { [weak self] _ in
-        self?.vm.openLanguageAlert()
+        guard let self else { return }
+        vm.alertCoordinator?.presentAlert(
+            environment: .languageSelect(vm.checkLanguage()),
+            delegate: self
+        )
     }
 
     private lazy var termsofServiceAction: UIAction = UIAction(title: "약관 보기") { [weak self] _ in
@@ -69,29 +73,6 @@ public final class MainViewController: ViewController {
         menu: UIMenu(title: "", children: [langAction, termsofServiceAction])
     )
 
-    // TODO: Language Picker Alert
-    private let cancelLanguageAlertButton: GlassButton = .close("취소")
-    private let primaryLanguageAlertButton: GlassButton = .primary("저장하기")
-    private let languageAlertOverlayView: UIView = {
-        let overlay = UIView()
-        overlay.translatesAutoresizingMaskIntoConstraints = false
-        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.6)
-        overlay.isHidden = true
-        return overlay
-    }()
-
-    private lazy var languagePicker: LanguagePicker = .init(
-        selected: vm.checkLanguage(),
-        axis: .horizontal,
-        showAlert: true
-    )
-
-    private lazy var languageAlertView: LanguagePickerAlert = .init(
-        title: "언어 선택",
-        languagePicker: languagePicker,
-        closeButton: cancelLanguageAlertButton,
-        primaryButton: primaryLanguageAlertButton
-    )
     // TODO: Permission Alert
     private let cancelPermissionAlertButton: GlassButton = .close("나중에")
     private let primaryPermissionAlertButton: GlassButton = .primary("설정으로 이동")
@@ -124,7 +105,6 @@ public final class MainViewController: ViewController {
         setupCollectionView()
         setupfloatingButton()
         setupPermissionAlert()
-        setupLanguageAlert()
     }
 
     override public func viewWillAppear(_ animated: Bool) {
@@ -142,20 +122,15 @@ public final class MainViewController: ViewController {
 
     override public func updateProperties() {
         super.updateProperties()
-        let shouldshowLanguageAlert = vm.showLanguageAlert
         let shouldshowPermissionAlert = vm.showPermissionAlert
-        languageAlertOverlayView.isHidden = !shouldshowLanguageAlert
+
         permissionAlertOverlayView.isHidden = !shouldshowPermissionAlert
-        updateInteractionForAlert(isPresented: shouldshowPermissionAlert || shouldshowLanguageAlert)
+        updateInteractionForAlert(isPresented: shouldshowPermissionAlert)
         if shouldshowPermissionAlert {
             view.bringSubviewToFront(permissionAlertOverlayView)
         }
-        if shouldshowLanguageAlert {
-            languagePicker.setLanguage(vm.checkLanguage())
-            view.bringSubviewToFront(languageAlertOverlayView)
-        }
         updateNavigationBarAppearance(
-            isTransparent: shouldshowLanguageAlert || shouldshowPermissionAlert
+            isTransparent: shouldshowPermissionAlert
         )
         updateDataSource()
     }
@@ -190,29 +165,6 @@ public final class MainViewController: ViewController {
             permissionAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             permissionAlertView.centerXAnchor.constraint(equalTo: permissionAlertOverlayView.centerXAnchor),
             permissionAlertView.centerYAnchor.constraint(equalTo: permissionAlertOverlayView.centerYAnchor)
-        ])
-    }
-
-    private func setupLanguageAlert() {
-        cancelLanguageAlertButton.addAction(UIAction { [weak self] _ in
-            self?.vm.closeLanguageAlert()
-        }, for: .touchUpInside)
-
-        primaryLanguageAlertButton.addAction(UIAction { [weak self] _ in
-            guard let self else { return }
-            vm.saveLanguage(languagePicker.selectedLanguage)
-            vm.closeLanguageAlert()
-        }, for: .touchUpInside)
-
-        view.addSubview(languageAlertOverlayView)
-        languageAlertOverlayView.addSubview(languageAlertView)
-        NSLayoutConstraint.activate([
-            languageAlertOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
-            languageAlertOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            languageAlertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            languageAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            languageAlertView.centerXAnchor.constraint(equalTo: languageAlertOverlayView.centerXAnchor),
-            languageAlertView.centerYAnchor.constraint(equalTo: languageAlertOverlayView.centerYAnchor)
         ])
     }
 
@@ -545,7 +497,7 @@ extension MainViewController {
 
 // MARK: - Delegate
 
-extension MainViewController: UICollectionViewDelegate {
+extension MainViewController: UICollectionViewDelegate, ChaGokAlertButtonTappedDelegate {
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y + scrollView.adjustedContentInset.top
         let didScroll = offsetY > 0
@@ -556,6 +508,17 @@ extension MainViewController: UICollectionViewDelegate {
             .first as? MainCategoryHeaderView else { return }
         header.updateScrollState(didScroll)
         collectionView.collectionViewLayout.invalidateLayout()
+    }
+
+    public func languageSelectCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true)
+    }
+
+    public func languageSelectPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        if let selectedLanguage = alertVC.selectedLanguage {
+            vm.saveLanguage(selectedLanguage)
+        }
+        alertVC.dismiss(animated: true)
     }
 }
 

--- a/Presentation/Sources/View/Main/MainViewController.swift
+++ b/Presentation/Sources/View/Main/MainViewController.swift
@@ -475,11 +475,11 @@ extension MainViewController: UICollectionViewDelegate, ChaGokAlertButtonTappedD
         }
         alertVC.dismiss(animated: true)
     }
-    
+
     public func micPermissionCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true)
     }
-    
+
     public func micPermissionPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
         openAppSettings()
         alertVC.dismiss(animated: true)

--- a/Presentation/Sources/View/Recoding/RecordingViewController.swift
+++ b/Presentation/Sources/View/Recoding/RecordingViewController.swift
@@ -78,23 +78,6 @@ public final class RecordingViewController: ViewController {
         return button
     }()
 
-    private let cancelAlertButton: GlassButton = .close("아니오")
-    private let primaryAlertButton: GlassButton = .primary("저장 후 종료")
-    private let completeAlertOverlayView: UIView = {
-        let overlay = UIView()
-        overlay.translatesAutoresizingMaskIntoConstraints = false
-        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.6)
-        overlay.isHidden = true
-        return overlay
-    }()
-
-    private lazy var completeAlertView: AlertView = .init(
-        title: "녹음을 종료하고 저장할까요?",
-        subTitle: "지금까지 녹음한 내용이\n기록됩니다",
-        closeButton: cancelAlertButton,
-        primaryButton: primaryAlertButton
-    )
-
     // MARK: - Initialization
 
     public init(viewModel: RecordingViewModel) {
@@ -112,7 +95,6 @@ public final class RecordingViewController: ViewController {
         super.viewDidLoad()
         setupNavigation()
         setupUI()
-        setupCompleteAlert()
     }
 
     override public func viewDidAppear(_ animated: Bool) {
@@ -128,13 +110,6 @@ public final class RecordingViewController: ViewController {
         timestampLabel.setTypography(text: viewModel.state.displayStartDate, style: .subtitle2)
         durationLabel.setTypography(text: viewModel.state.displayDuration, style: .header1)
         recordButton.setImage(UIImage(systemName: recordButtonSymbolName), for: .normal)
-        let shouldShowAlert = viewModel.state.showAlert
-        completeAlertOverlayView.isHidden = !shouldShowAlert
-        completeAlertView.isHidden = !shouldShowAlert
-        updateInteractionForAlert(isPresented: shouldShowAlert)
-        if shouldShowAlert {
-            view.bringSubviewToFront(completeAlertOverlayView)
-        }
     }
 
     // MARK: - Private Methods
@@ -162,7 +137,7 @@ public final class RecordingViewController: ViewController {
     }
 
     private func setupUI() {
-        for item in [titleLabel, durationLabel, recordButton, timestampLabel, completeAlertOverlayView] {
+        for item in [titleLabel, durationLabel, recordButton, timestampLabel] {
             item.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview(item)
         }
@@ -187,31 +162,6 @@ public final class RecordingViewController: ViewController {
             recordButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -40),
             recordButton.topAnchor.constraint(greaterThanOrEqualTo: durationLabel.bottomAnchor, constant: 48)
         ])
-    }
-
-    private func setupCompleteAlert() {
-        cancelAlertButton.addAction(UIAction { [weak self] _ in
-            self?.viewModel.send(.closeAlertButtonTapped)
-        }, for: .touchUpInside)
-
-        primaryAlertButton.addAction(UIAction { [weak self] _ in
-            self?.viewModel.send(.finishButtonTapped)
-        }, for: .touchUpInside)
-        completeAlertOverlayView.addSubview(completeAlertView)
-        NSLayoutConstraint.activate([
-            completeAlertOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
-            completeAlertOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            completeAlertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            completeAlertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            completeAlertView.centerXAnchor.constraint(equalTo: completeAlertOverlayView.centerXAnchor),
-            completeAlertView.centerYAnchor.constraint(equalTo: completeAlertOverlayView.centerYAnchor)
-        ])
-    }
-
-    private func updateInteractionForAlert(isPresented: Bool) {
-        navigationItem.leftBarButtonItem?.isEnabled = !isPresented
-        navigationItem.rightBarButtonItem?.isEnabled = !isPresented
-        navigationItem.rightBarButtonItems?.forEach { $0.isEnabled = !isPresented }
     }
 
     private var recordButtonSymbolName: String {

--- a/Presentation/Sources/View/Recoding/RecordingViewController.swift
+++ b/Presentation/Sources/View/Recoding/RecordingViewController.swift
@@ -140,8 +140,13 @@ public final class RecordingViewController: ViewController {
     // MARK: - Private Methods
 
     private func setupNavigation() {
+        viewModel.showCancelAlert = { [weak self] in
+            guard let self else { return }
+            viewModel.alertCoordinator?.presentAlert(environment: .recordingCancel, delegate: self)
+        }
+
         cancelButton.addAction(UIAction { [weak self] _ in
-            self?.viewModel.send(.cancelButtonTapped)
+            self?.viewModel.send(.openCancelAlertButtonTapped)
         }, for: .touchUpInside)
 
         completeButton.addAction(UIAction { [weak self] _ in
@@ -217,6 +222,21 @@ public final class RecordingViewController: ViewController {
             return "pause.fill"
         case .paused:
             return "play.fill"
+        }
+    }
+}
+
+
+// MARK: - Delegate
+
+extension RecordingViewController: ChaGokAlertButtonTappedDelegate {
+    public func recordingCancelCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true)
+    }
+    
+    public func recordingCancelPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true) { [weak self] in
+            self?.viewModel.send(.cancelButtonTapped)
         }
     }
 }

--- a/Presentation/Sources/View/Recoding/RecordingViewController.swift
+++ b/Presentation/Sources/View/Recoding/RecordingViewController.swift
@@ -119,7 +119,7 @@ public final class RecordingViewController: ViewController {
             guard let self else { return }
             viewModel.alertCoordinator?.presentAlert(environment: .recordingCancel, delegate: self)
         }
-        
+
         viewModel.showCompleteAlert = { [weak self] in
             guard let self else { return }
             viewModel.alertCoordinator?.presentAlert(environment: .recordingComplete, delegate: self)
@@ -181,24 +181,23 @@ public final class RecordingViewController: ViewController {
     }
 }
 
-
 // MARK: - Delegate
 
 extension RecordingViewController: ChaGokAlertButtonTappedDelegate {
     public func recordingCancelCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true)
     }
-    
+
     public func recordingCancelPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true) { [weak self] in
             self?.viewModel.send(.cancelButtonTapped)
         }
     }
-    
+
     public func recordingCompleteCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true)
     }
-    
+
     public func recordingCompletePrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true) { [weak self] in
             self?.viewModel.send(.finishButtonTapped)

--- a/Presentation/Sources/View/Recoding/RecordingViewController.swift
+++ b/Presentation/Sources/View/Recoding/RecordingViewController.swift
@@ -119,13 +119,18 @@ public final class RecordingViewController: ViewController {
             guard let self else { return }
             viewModel.alertCoordinator?.presentAlert(environment: .recordingCancel, delegate: self)
         }
+        
+        viewModel.showCompleteAlert = { [weak self] in
+            guard let self else { return }
+            viewModel.alertCoordinator?.presentAlert(environment: .recordingComplete, delegate: self)
+        }
 
         cancelButton.addAction(UIAction { [weak self] _ in
             self?.viewModel.send(.openCancelAlertButtonTapped)
         }, for: .touchUpInside)
 
         completeButton.addAction(UIAction { [weak self] _ in
-            self?.viewModel.send(.openAlertButtonTapped)
+            self?.viewModel.send(.openCompleteAlertButtonTapped)
         }, for: .touchUpInside)
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: cancelButton)
@@ -187,6 +192,16 @@ extension RecordingViewController: ChaGokAlertButtonTappedDelegate {
     public func recordingCancelPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true) { [weak self] in
             self?.viewModel.send(.cancelButtonTapped)
+        }
+    }
+    
+    public func recordingCompleteCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true)
+    }
+    
+    public func recordingCompletePrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true) { [weak self] in
+            self?.viewModel.send(.finishButtonTapped)
         }
     }
 }

--- a/Presentation/Sources/View/Search/SearchViewController.swift
+++ b/Presentation/Sources/View/Search/SearchViewController.swift
@@ -114,7 +114,7 @@ public final class SearchViewController: ViewController {
                     SearchFolderCardView(
                         fullText: folder.name,
                         keyword: self.vm.query,
-                        createdAt: folder.createdAt.description,
+                        createdAt: folder.createdAt.searchFolderText(),
                         voiceNoteCount: folder.voiceNoteIDs.count
                     ) { [weak self] in
                         self?.vm.pushFolder(folder)
@@ -123,10 +123,11 @@ public final class SearchViewController: ViewController {
                     SearchVoiceNoteCardView(
                         title: voiceNote.title,
                         keyword: self.vm.query,
-                        timeline: Date.now.voiceNoteDay(
+                        timeline: Date.now.searchVoiceNoteDay(
                             createdAt: voiceNote.createdAt,
                             updatedAt: voiceNote.updatedAt,
-                            duration: voiceNote.voiceRecord.duration
+                            duration: voiceNote.voiceRecord.duration,
+                            folderName: self.vm.parentFolder(id: voiceNote.folderID)
                         )
                     ) { [weak self] in
                         self?.vm.pushVoiceNote(voiceNote)
@@ -303,10 +304,7 @@ extension SearchViewController: UITextFieldDelegate {
 #Preview {
     UINavigationController(
         rootViewController: SearchViewController(
-            vm: SearchViewModel(
-                type: .main,
-                items: []
-            )
+            vm: .preview()
         )
     )
 }

--- a/Presentation/Sources/View/Search/SearchViewController.swift
+++ b/Presentation/Sources/View/Search/SearchViewController.swift
@@ -194,6 +194,7 @@ extension SearchViewController {
             snapshot.appendSections([.result])
             let resultItems = vm.filteredItems.map(Item.result)
             snapshot.appendItems(resultItems, toSection: .result)
+            snapshot.reconfigureItems(resultItems)
         }
 
         dataSource.apply(snapshot, animatingDifferences: true)

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -37,8 +37,11 @@ public final class TrashViewController: CollectionViewController {
         title: "휴지통 비우기",
         image: nil,
         attributes: .destructive // 강조(빨간색) 효과
-    ) { _ in
-        self.vm.openTrashAlert()
+    ) { [weak self] _ in
+        guard let self else { return }
+        vm.alertCoordinator?.presentAlert(
+            environment: .deleteAllTrash, delegate: self
+        )
     }
 
     private lazy var selectAction = UIAction(
@@ -268,14 +271,13 @@ private extension TrashViewController {
     func moreAndActionButtonAction() -> UIAction {
         UIAction { [weak self] _ in
             guard let self else { return }
-            guard let selectedItems = selectedItemsForBulkAction() else {
-                return
+            vm.deleteButtonTapped { [weak self] in
+                guard let self else { return }
+                vm.alertCoordinator?.presentAlert(
+                    environment: .deleteItemsTrash,
+                    delegate: self
+                )
             }
-            vm.delete(items: selectedItems)
-            chagokBackgroundView.makeToast(
-                type: .normal,
-                "영구 삭제 되었습니다"
-            )
         }
     }
 
@@ -294,6 +296,41 @@ private extension TrashViewController {
                     self?.vm.cancelRestore(items: selectedItems)
                 }
             }
+        }
+    }
+}
+
+// MARK: - Delegate
+
+extension TrashViewController: ChaGokAlertButtonTappedDelegate {
+    public func deleteAllTrashCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true)
+    }
+    
+    public func deleteAllTrashPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true) { [weak self] in
+            self?.vm.deleteAll()
+            self?.chagokBackgroundView.makeToast(
+                type: .normal,
+                "영구 삭제 되었습니다"
+            )
+        }
+    }
+    
+    public func deleteItemsTrashCloseButonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true)
+    }
+    
+    public func deleteItemsTrashPrimaryButonTapped(_ alertVC: ChaGokAlertViewController) {
+        alertVC.dismiss(animated: true) { [weak self] in
+            guard let selectedItems = self?.selectedItemsForBulkAction() else {
+                return
+            }
+            self?.vm.delete(items: selectedItems)
+            self?.chagokBackgroundView.makeToast(
+                type: .normal,
+                "영구 삭제 되었습니다"
+            )
         }
     }
 }

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -119,6 +119,7 @@ public final class TrashViewController: CollectionViewController {
     override public func viewDidLoad() {
         super.viewDidLoad()
         collectionView.allowsSelection = false
+        collectionView.showsVerticalScrollIndicator = false
         setupNavigation()
         setupDataSource()
         updateDataSource()

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -91,7 +91,6 @@ public final class TrashViewController: CollectionViewController {
         setupNavigation()
         setupDataSource()
         updateDataSource()
-        
     }
 
     override public func viewWillAppear(_ animated: Bool) {
@@ -306,7 +305,7 @@ extension TrashViewController: ChaGokAlertButtonTappedDelegate {
     public func deleteAllTrashCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true)
     }
-    
+
     public func deleteAllTrashPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true) { [weak self] in
             self?.vm.deleteAll()
@@ -316,11 +315,11 @@ extension TrashViewController: ChaGokAlertButtonTappedDelegate {
             )
         }
     }
-    
+
     public func deleteItemsTrashCloseButonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true)
     }
-    
+
     public func deleteItemsTrashPrimaryButonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true) { [weak self] in
             guard let selectedItems = self?.selectedItemsForBulkAction() else {

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -33,14 +33,6 @@ public final class TrashViewController: CollectionViewController {
         attributedString: Typography.title1.textAttributes
     )
 
-    private let alertOverlayView: UIView = {
-        let overlay = UIView()
-        overlay.translatesAutoresizingMaskIntoConstraints = false
-        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.6)
-        overlay.isHidden = true
-        return overlay
-    }()
-
     private lazy var emptyTrashAction = UIAction(
         title: "휴지통 비우기",
         image: nil,
@@ -62,34 +54,6 @@ public final class TrashViewController: CollectionViewController {
     ) { [weak self] _ in
         self?.vm.setSelectionMode(.all)
     }
-
-    private lazy var cancelButton: GlassButton = {
-        let cancel = GlassButton.close("취소")
-        cancel.addAction(UIAction { [weak self] _ in
-            self?.vm.closeTrashAlert()
-        }, for: .touchUpInside)
-        return cancel
-    }()
-
-    private lazy var primaryButton: GlassButton = {
-        let primary = GlassButton.danger("비우기")
-        primary.addAction(UIAction { [weak self] _ in
-            self?.vm.deleteAll()
-            self?.chagokBackgroundView.makeToast(
-                type: .normal,
-                "영구 삭제 되었습니다"
-            )
-            self?.vm.closeTrashAlert()
-        }, for: .touchUpInside)
-        return primary
-    }()
-
-    private lazy var alert: AlertView = .init(
-        title: "휴지통 비울까요?",
-        subTitle: "모든 파일이 영구 삭제되며\n되돌릴 수 없어요",
-        closeButton: cancelButton,
-        primaryButton: primaryButton
-    )
 
     private let vm: TrashViewModel
 
@@ -120,11 +84,11 @@ public final class TrashViewController: CollectionViewController {
         super.viewDidLoad()
         collectionView.allowsSelection = false
         collectionView.showsVerticalScrollIndicator = false
+        updateNavigationBarAppearance(isTransparent: false)
         setupNavigation()
         setupDataSource()
         updateDataSource()
-        setupAlertView()
-        updateNavigationBarAppearance(isTransparent: vm.showTrashAlert)
+        
     }
 
     override public func viewWillAppear(_ animated: Bool) {
@@ -144,8 +108,6 @@ public final class TrashViewController: CollectionViewController {
         updateRightBarButtonMenu(vm.select)
         // dataSource
         updateDataSource(reconfigure: true)
-        // alert
-        updateAlertState()
     }
 
     private func setupNavigation() {
@@ -235,19 +197,6 @@ public final class TrashViewController: CollectionViewController {
             return collectionView.dequeueConfiguredReusableSupplementary(using: headerRegistration, for: indexPath)
         }
     }
-
-    private func setupAlertView() {
-        view.addSubview(alertOverlayView)
-        alertOverlayView.addSubview(alert)
-        NSLayoutConstraint.activate([
-            alertOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
-            alertOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            alertOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            alertOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            alert.centerXAnchor.constraint(equalTo: alertOverlayView.centerXAnchor),
-            alert.centerYAnchor.constraint(equalTo: alertOverlayView.centerYAnchor)
-        ])
-    }
 }
 
 // MARK: - Update Method
@@ -268,16 +217,6 @@ extension TrashViewController {
             item.sizeToFit()
         }
         moreAndActionButton.showsMenuAsPrimaryAction = !isEditMode
-    }
-
-    private func updateAlertState() {
-        let shouldShowAlert = vm.showTrashAlert
-        alertOverlayView.isHidden = !shouldShowAlert
-        updateInteractionForAlert(isPresented: shouldShowAlert)
-        if shouldShowAlert {
-            view.bringSubviewToFront(alertOverlayView)
-        }
-        updateNavigationBarAppearance(isTransparent: shouldShowAlert)
     }
 
     private func updateDataSource(reconfigure: Bool = false) {

--- a/Presentation/Sources/View/Trash/TrashViewController.swift
+++ b/Presentation/Sources/View/Trash/TrashViewController.swift
@@ -316,11 +316,11 @@ extension TrashViewController: ChaGokAlertButtonTappedDelegate {
         }
     }
 
-    public func deleteItemsTrashCloseButonTapped(_ alertVC: ChaGokAlertViewController) {
+    public func deleteItemsTrashCloseButtonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true)
     }
 
-    public func deleteItemsTrashPrimaryButonTapped(_ alertVC: ChaGokAlertViewController) {
+    public func deleteItemsTrashPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController) {
         alertVC.dismiss(animated: true) { [weak self] in
             guard let selectedItems = self?.selectedItemsForBulkAction() else {
                 return

--- a/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
+++ b/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
@@ -59,7 +59,17 @@ public protocol ChaGokAlertButtonTappedDelegate: AnyObject {
     optional func moveTrashCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
     @objc
     optional func moveTrashPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
-
+    
+    /// Trash Delete Action
+    @objc
+    optional func deleteAllTrashCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc
+    optional func deleteAllTrashPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc
+    optional func deleteItemsTrashCloseButonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc
+    optional func deleteItemsTrashPrimaryButonTapped(_ alertVC: ChaGokAlertViewController)
+    
     /// none Action
     @objc
     optional func noneCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
@@ -121,6 +131,10 @@ extension ChaGokAlertViewModel {
             delegate?.updateFolderCloseButtonTapped?(alertVC)
         case .moveTrash:
             delegate?.moveTrashCloseButtonTapped?(alertVC)
+        case .deleteAllTrash:
+            delegate?.deleteAllTrashCloseButtonTapped?(alertVC)
+        case .deleteItemsTrash:
+            delegate?.deleteItemsTrashCloseButonTapped?(alertVC)
         case .none:
             delegate?.noneCloseButtonTapped?(alertVC)
         }
@@ -142,6 +156,10 @@ extension ChaGokAlertViewModel {
             delegate?.updateFolderPrimaryButtonTapped?(alertVC)
         case .moveTrash:
             delegate?.moveTrashPrimaryButtonTapped?(alertVC)
+        case .deleteAllTrash:
+            delegate?.deleteAllTrashPrimaryButtonTapped?(alertVC)
+        case .deleteItemsTrash:
+            delegate?.deleteItemsTrashPrimaryButonTapped?(alertVC)
         case .none:
             delegate?.nonePrimaryButtonTapped?(alertVC)
         }
@@ -204,6 +222,8 @@ public extension ChaGokAlertViewModel {
         case createFolder(TextFieldView.Field)
         case updateFolder(TextFieldView.Field)
         case moveTrash
+        case deleteAllTrash
+        case deleteItemsTrash
         case none
 
         var state: AlertState {
@@ -266,6 +286,24 @@ public extension ChaGokAlertViewModel {
                     bodyStyle: .basic(subTitle: "휴지통으로 이동되며,\n직접 비우기 전까지 보관돼요."),
                     cancelButtonStyle: .init(type: .close, text: "취소"),
                     primaryButtonStyle: .init(type: .danger, text: "삭제")
+                )
+            case .deleteAllTrash:
+                AlertState(
+                    header: .init(
+                        title: "휴지통을 비울까요?"
+                    ),
+                    bodyStyle: .basic(subTitle: "모든 파일이 영구 삭제되며\n되돌릴 수 없어요"),
+                    cancelButtonStyle: .init(type: .close, text: "취소"),
+                    primaryButtonStyle: .init(type: .danger, text: "비우기")
+                )
+            case .deleteItemsTrash:
+                AlertState(
+                    header: .init(
+                        title: "선택한 항목을 삭제할까요?"
+                    ),
+                    bodyStyle: .basic(subTitle: "선택한 항목이 영구 삭제되며\n되돌릴 수 없어요"),
+                    cancelButtonStyle: .init(type: .close, text: "취소"),
+                    primaryButtonStyle: .init(type: .danger, text: "삭제하기")
                 )
             case .none:
                 AlertState(

--- a/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
+++ b/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
@@ -267,7 +267,7 @@ public extension ChaGokAlertViewModel {
                     ),
                     bodyStyle: .textField(field: field, subTitle: "새로 만들 폴더의 이름을\n입력해주세요."),
                     cancelButtonStyle: .init(type: .close, text: "취소"),
-                    primaryButtonStyle: .init(type: .close, text: "만들기")
+                    primaryButtonStyle: .init(type: .primary, text: "만들기")
                 )
             case .updateFolder(let field):
                 AlertState(

--- a/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
+++ b/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
@@ -66,9 +66,9 @@ public protocol ChaGokAlertButtonTappedDelegate: AnyObject {
     @objc
     optional func deleteAllTrashPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
     @objc
-    optional func deleteItemsTrashCloseButonTapped(_ alertVC: ChaGokAlertViewController)
+    optional func deleteItemsTrashCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
     @objc
-    optional func deleteItemsTrashPrimaryButonTapped(_ alertVC: ChaGokAlertViewController)
+    optional func deleteItemsTrashPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
 
     /// none Action
     @objc
@@ -134,7 +134,7 @@ extension ChaGokAlertViewModel {
         case .deleteAllTrash:
             delegate?.deleteAllTrashCloseButtonTapped?(alertVC)
         case .deleteItemsTrash:
-            delegate?.deleteItemsTrashCloseButonTapped?(alertVC)
+            delegate?.deleteItemsTrashCloseButtonTapped?(alertVC)
         case .none:
             delegate?.noneCloseButtonTapped?(alertVC)
         }
@@ -159,7 +159,7 @@ extension ChaGokAlertViewModel {
         case .deleteAllTrash:
             delegate?.deleteAllTrashPrimaryButtonTapped?(alertVC)
         case .deleteItemsTrash:
-            delegate?.deleteItemsTrashPrimaryButonTapped?(alertVC)
+            delegate?.deleteItemsTrashPrimaryButtonTapped?(alertVC)
         case .none:
             delegate?.nonePrimaryButtonTapped?(alertVC)
         }

--- a/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
+++ b/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
@@ -1,0 +1,239 @@
+import Foundation
+
+@MainActor
+public protocol ChaGokAlertCoordinatorDelegate: AnyObject {
+    /// Open Alert
+    func present(environment: ChaGokAlertViewModel.AlertEnvironment)
+    /// Close Alert
+    func dismiss()
+}
+
+@MainActor
+@objc public protocol ChaGokAlertButtonTappedDelegate: AnyObject {
+    // recordingCancel Action
+    @objc optional func recordingCancelCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc optional func recordingCancelPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+
+    // recordingComplete Action
+    @objc optional func recordingCompleteCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc optional func recordingCompletePrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+
+    // languageSelect Action
+    @objc optional func languageSelectCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc optional func languageSelectPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+
+    // createFolder Action
+    @objc optional func createFolderCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc optional func createFolderPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+
+    // updateFolder Action
+    @objc optional func updateFolderCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc optional func updateFolderPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+
+    // moveTrash Action
+    @objc optional func moveTrashCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc optional func moveTrashPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+
+    // none Action
+    @objc optional func noneCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc optional func nonePrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+}
+
+@MainActor
+@Observable
+public final class ChaGokAlertViewModel {
+    private(set) var environment: AlertEnvironment
+    private(set) var state: AlertState
+
+    public init(environment: AlertEnvironment = .none) {
+        self.environment = environment
+        self.state = environment.state
+    }
+
+    public convenience init(state: AlertState) {
+        self.init(environment: .none)
+        self.state = state
+    }
+    
+    @ObservationIgnored
+    public var header: Header {
+        state.header
+    }
+
+    @ObservationIgnored
+    public var style: BodyStyle {
+        state.bodyStyle
+    }
+    
+    weak var coordinator: ChaGokAlertCoordinatorDelegate?
+}
+
+// MARK: - Action
+extension ChaGokAlertViewModel {
+    func dismiss() {
+        coordinator?.dismiss()
+    }
+    
+    public func update(environment: AlertEnvironment) {
+        self.environment = environment
+        state = environment.state
+    }
+
+    func didTapCancel(delegate: ChaGokAlertButtonTappedDelegate?, alertVC: ChaGokAlertViewController) {
+        switch environment {
+        case .recordingCancel:
+            delegate?.recordingCancelCloseButtonTapped?(alertVC)
+        case .recordingComplete:
+            delegate?.recordingCompleteCloseButtonTapped?(alertVC)
+        case .languageSelect:
+            delegate?.languageSelectCloseButtonTapped?(alertVC)
+        case .createFolder:
+            delegate?.createFolderCloseButtonTapped?(alertVC)
+        case .updateFolder:
+            delegate?.updateFolderCloseButtonTapped?(alertVC)
+        case .moveTrash:
+            delegate?.moveTrashCloseButtonTapped?(alertVC)
+        case .none:
+            delegate?.noneCloseButtonTapped?(alertVC)
+        }
+    }
+
+    func didTapPrimary(delegate: ChaGokAlertButtonTappedDelegate?, alertVC: ChaGokAlertViewController) {
+        switch environment {
+        case .recordingCancel:
+            delegate?.recordingCancelPrimaryButtonTapped?(alertVC)
+        case .recordingComplete:
+            delegate?.recordingCompletePrimaryButtonTapped?(alertVC)
+        case .languageSelect:
+            delegate?.languageSelectPrimaryButtonTapped?(alertVC)
+        case .createFolder:
+            delegate?.createFolderPrimaryButtonTapped?(alertVC)
+        case .updateFolder:
+            delegate?.updateFolderPrimaryButtonTapped?(alertVC)
+        case .moveTrash:
+            delegate?.moveTrashPrimaryButtonTapped?(alertVC)
+        case .none:
+            delegate?.nonePrimaryButtonTapped?(alertVC)
+        }
+    }
+}
+
+// MARK: - Alert Model
+
+public extension ChaGokAlertViewModel {
+
+    struct Header: Equatable {
+        let title: String
+
+        init(title: String) {
+            self.title = title
+        }
+    }
+
+    enum BodyStyle {
+        case basic(subTitle: String)
+        case languagePicker(LanguagePicker)
+        case textField(field: TextFieldView.Field, subTitle: String)
+    }
+    
+    enum ButtonType {
+        case close
+        case `default`
+        case primary
+        case danger
+    }
+    
+    struct ButtonStyle {
+        let type: ButtonType
+        let text: String
+    }
+
+    struct AlertState {
+        let header: Header
+        let bodyStyle: BodyStyle
+        let cancelButtonStyle: ButtonStyle
+        let primaryButtonStyle: ButtonStyle
+
+        init(header: Header, bodyStyle: BodyStyle, cancelButtonStyle: ButtonStyle, primaryButtonStyle: ButtonStyle) {
+            self.header = header
+            self.bodyStyle = bodyStyle
+            self.cancelButtonStyle = cancelButtonStyle
+            self.primaryButtonStyle = primaryButtonStyle
+        }
+    }
+
+    @MainActor
+    public enum AlertEnvironment {
+        case recordingCancel
+        case recordingComplete
+        case languageSelect(LanguagePicker)
+        case createFolder(TextFieldView.Field)
+        case updateFolder(TextFieldView.Field)
+        case moveTrash
+        case none
+
+        var state: AlertState {
+            switch self {
+            case .recordingCancel:
+                AlertState(
+                    header: .init(
+                        title: "녹음을 취소할까요?"
+                    ),
+                    bodyStyle: .basic(subTitle: "지금까지 녹음한 내용은\n저장되지 않아요."),
+                    cancelButtonStyle: .init(type: .close, text: "계속 녹음"),
+                    primaryButtonStyle: .init(type: .danger, text: "녹음 취소")
+                )
+            case .recordingComplete:
+                AlertState(
+                    header: .init(
+                        title: "녹음을 저장하고 종료할까요?"
+                    ),
+                    bodyStyle: .basic(subTitle: "지금까지 녹음한 내용이\n기록됩니다."),
+                    cancelButtonStyle: .init(type: .close, text: "아니오"),
+                    primaryButtonStyle: .init(type: .primary, text: "저장 후 종료")
+                )
+            case .languageSelect(let picker):
+                AlertState(
+                    header: .init(title: "녹음 언어 변경"),
+                    bodyStyle: .languagePicker(picker),
+                    cancelButtonStyle: .init(type: .close, text: "취소"),
+                    primaryButtonStyle: .init(type: .primary, text: "저장하기")
+                )
+            case .createFolder(let field):
+                AlertState(
+                    header: .init(
+                        title: "새 폴더"
+                    ),
+                    bodyStyle: .textField(field: field, subTitle: "새로 만들 폴더의 이름을\n입력해주세요."),
+                    cancelButtonStyle: .init(type: .close, text: "취소"),
+                    primaryButtonStyle: .init(type: .primary, text: "만들기")
+                )
+            case .updateFolder(let field):
+                AlertState(
+                    header: .init(
+                        title: "폴더 이름 수정"
+                    ),
+                    bodyStyle: .textField(field: field, subTitle: "수정 할 폴더의 이름을 입력해주세요"),
+                    cancelButtonStyle: .init(type: .close, text: "취소"),
+                    primaryButtonStyle: .init(type: .primary, text: "수정하기")
+                )
+            case .moveTrash:
+                AlertState(
+                    header: .init(
+                        title: "기록을 삭제할까요?"
+                    ),
+                    bodyStyle: .basic(subTitle: "휴지통으로 이동되며,\n직접 비우기 전까지 보관돼요."),
+                    cancelButtonStyle: .init(type: .close, text: "취소"),
+                    primaryButtonStyle: .init(type: .danger, text: "삭제")
+                )
+            case .none:
+                AlertState(
+                    header: .init(title: ""),
+                    bodyStyle: .basic(subTitle: ""),
+                    cancelButtonStyle: .init(type: .close, text: "취소"),
+                    primaryButtonStyle: .init(type: .primary, text: "저장하기")
+                )
+            }
+        }
+    }
+}

--- a/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
+++ b/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
@@ -59,7 +59,7 @@ public protocol ChaGokAlertButtonTappedDelegate: AnyObject {
     optional func moveTrashCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
     @objc
     optional func moveTrashPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
-    
+
     /// Trash Delete Action
     @objc
     optional func deleteAllTrashCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
@@ -69,7 +69,7 @@ public protocol ChaGokAlertButtonTappedDelegate: AnyObject {
     optional func deleteItemsTrashCloseButonTapped(_ alertVC: ChaGokAlertViewController)
     @objc
     optional func deleteItemsTrashPrimaryButonTapped(_ alertVC: ChaGokAlertViewController)
-    
+
     /// none Action
     @objc
     optional func noneCloseButtonTapped(_ alertVC: ChaGokAlertViewController)

--- a/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
+++ b/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
@@ -1,42 +1,65 @@
+import Domain
 import Foundation
 
 @MainActor
 public protocol ChaGokAlertCoordinatorDelegate: AnyObject {
     /// Open Alert
-    func present(environment: ChaGokAlertViewModel.AlertEnvironment)
-    /// Close Alert
-    func dismiss()
+    func presentAlert(
+        environment: ChaGokAlertViewModel.AlertEnvironment,
+        delegate: ChaGokAlertButtonTappedDelegate?
+    )
+}
+
+public extension ChaGokAlertCoordinatorDelegate {
+    func presentAlert(environment: ChaGokAlertViewModel.AlertEnvironment) {
+        presentAlert(environment: environment, delegate: nil)
+    }
 }
 
 @MainActor
-@objc public protocol ChaGokAlertButtonTappedDelegate: AnyObject {
-    // recordingCancel Action
-    @objc optional func recordingCancelCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
-    @objc optional func recordingCancelPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+@objc
+public protocol ChaGokAlertButtonTappedDelegate: AnyObject {
+    /// recordingCancel Action
+    @objc
+    optional func recordingCancelCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc
+    optional func recordingCancelPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
 
-    // recordingComplete Action
-    @objc optional func recordingCompleteCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
-    @objc optional func recordingCompletePrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+    /// recordingComplete Action
+    @objc
+    optional func recordingCompleteCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc
+    optional func recordingCompletePrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
 
-    // languageSelect Action
-    @objc optional func languageSelectCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
-    @objc optional func languageSelectPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+    /// languageSelect Action
+    @objc
+    optional func languageSelectCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc
+    optional func languageSelectPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
 
-    // createFolder Action
-    @objc optional func createFolderCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
-    @objc optional func createFolderPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+    /// createFolder Action
+    @objc
+    optional func createFolderCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc
+    optional func createFolderPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
 
-    // updateFolder Action
-    @objc optional func updateFolderCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
-    @objc optional func updateFolderPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+    /// updateFolder Action
+    @objc
+    optional func updateFolderCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc
+    optional func updateFolderPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
 
-    // moveTrash Action
-    @objc optional func moveTrashCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
-    @objc optional func moveTrashPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+    /// moveTrash Action
+    @objc
+    optional func moveTrashCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc
+    optional func moveTrashPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
 
-    // none Action
-    @objc optional func noneCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
-    @objc optional func nonePrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
+    /// none Action
+    @objc
+    optional func noneCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc
+    optional func nonePrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
 }
 
 @MainActor
@@ -44,17 +67,18 @@ public protocol ChaGokAlertCoordinatorDelegate: AnyObject {
 public final class ChaGokAlertViewModel {
     private(set) var environment: AlertEnvironment
     private(set) var state: AlertState
+    private(set) var selectedLanguage: Language?
 
     public init(environment: AlertEnvironment = .none) {
         self.environment = environment
-        self.state = environment.state
+        state = environment.state
     }
 
     public convenience init(state: AlertState) {
         self.init(environment: .none)
         self.state = state
     }
-    
+
     @ObservationIgnored
     public var header: Header {
         state.header
@@ -64,16 +88,13 @@ public final class ChaGokAlertViewModel {
     public var style: BodyStyle {
         state.bodyStyle
     }
-    
-    weak var coordinator: ChaGokAlertCoordinatorDelegate?
+
+    public weak var coordinator: ChaGokAlertCoordinatorDelegate?
 }
 
 // MARK: - Action
+
 extension ChaGokAlertViewModel {
-    func dismiss() {
-        coordinator?.dismiss()
-    }
-    
     public func update(environment: AlertEnvironment) {
         self.environment = environment
         state = environment.state
@@ -116,12 +137,15 @@ extension ChaGokAlertViewModel {
             delegate?.nonePrimaryButtonTapped?(alertVC)
         }
     }
+
+    func setSelectedLanguage(_ language: Language) {
+        selectedLanguage = language
+    }
 }
 
 // MARK: - Alert Model
 
 public extension ChaGokAlertViewModel {
-
     struct Header: Equatable {
         let title: String
 
@@ -132,17 +156,17 @@ public extension ChaGokAlertViewModel {
 
     enum BodyStyle {
         case basic(subTitle: String)
-        case languagePicker(LanguagePicker)
+        case languagePicker(Language)
         case textField(field: TextFieldView.Field, subTitle: String)
     }
-    
+
     enum ButtonType {
         case close
         case `default`
         case primary
         case danger
     }
-    
+
     struct ButtonStyle {
         let type: ButtonType
         let text: String
@@ -163,10 +187,10 @@ public extension ChaGokAlertViewModel {
     }
 
     @MainActor
-    public enum AlertEnvironment {
+    enum AlertEnvironment {
         case recordingCancel
         case recordingComplete
-        case languageSelect(LanguagePicker)
+        case languageSelect(Language)
         case createFolder(TextFieldView.Field)
         case updateFolder(TextFieldView.Field)
         case moveTrash
@@ -192,10 +216,10 @@ public extension ChaGokAlertViewModel {
                     cancelButtonStyle: .init(type: .close, text: "아니오"),
                     primaryButtonStyle: .init(type: .primary, text: "저장 후 종료")
                 )
-            case .languageSelect(let picker):
+            case .languageSelect(let selectedLanguage):
                 AlertState(
                     header: .init(title: "녹음 언어 변경"),
-                    bodyStyle: .languagePicker(picker),
+                    bodyStyle: .languagePicker(selectedLanguage),
                     cancelButtonStyle: .init(type: .close, text: "취소"),
                     primaryButtonStyle: .init(type: .primary, text: "저장하기")
                 )

--- a/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
+++ b/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
@@ -19,6 +19,11 @@ public extension ChaGokAlertCoordinatorDelegate {
 @MainActor
 @objc
 public protocol ChaGokAlertButtonTappedDelegate: AnyObject {
+    /// mic Permission Action
+    @objc
+    optional func micPermissionCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
+    @objc
+    optional func micPermissionPrimaryButtonTapped(_ alertVC: ChaGokAlertViewController)
     /// recordingCancel Action
     @objc
     optional func recordingCancelCloseButtonTapped(_ alertVC: ChaGokAlertViewController)
@@ -102,6 +107,8 @@ extension ChaGokAlertViewModel {
 
     func didTapCancel(delegate: ChaGokAlertButtonTappedDelegate?, alertVC: ChaGokAlertViewController) {
         switch environment {
+        case .micPermissionRequired:
+            delegate?.micPermissionCloseButtonTapped?(alertVC)
         case .recordingCancel:
             delegate?.recordingCancelCloseButtonTapped?(alertVC)
         case .recordingComplete:
@@ -121,6 +128,8 @@ extension ChaGokAlertViewModel {
 
     func didTapPrimary(delegate: ChaGokAlertButtonTappedDelegate?, alertVC: ChaGokAlertViewController) {
         switch environment {
+        case .micPermissionRequired:
+            delegate?.micPermissionPrimaryButtonTapped?(alertVC)
         case .recordingCancel:
             delegate?.recordingCancelPrimaryButtonTapped?(alertVC)
         case .recordingComplete:
@@ -188,6 +197,7 @@ public extension ChaGokAlertViewModel {
 
     @MainActor
     enum AlertEnvironment {
+        case micPermissionRequired
         case recordingCancel
         case recordingComplete
         case languageSelect(Language)
@@ -198,6 +208,13 @@ public extension ChaGokAlertViewModel {
 
         var state: AlertState {
             switch self {
+            case .micPermissionRequired:
+                AlertState(
+                    header: .init(title: "마이크 권한이 필요해요"),
+                    bodyStyle: .basic(subTitle: "설정에서 마이크 권한을\n허용해주세요."),
+                    cancelButtonStyle: .init(type: .close, text: "나중에"),
+                    primaryButtonStyle: .init(type: .primary, text: "설정으로 이동")
+                )
             case .recordingCancel:
                 AlertState(
                     header: .init(

--- a/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
+++ b/Presentation/Sources/ViewModel/Alert/ChaGokAlertViewModel.swift
@@ -247,7 +247,7 @@ public extension ChaGokAlertViewModel {
                     ),
                     bodyStyle: .textField(field: field, subTitle: "새로 만들 폴더의 이름을\n입력해주세요."),
                     cancelButtonStyle: .init(type: .close, text: "취소"),
-                    primaryButtonStyle: .init(type: .primary, text: "만들기")
+                    primaryButtonStyle: .init(type: .close, text: "만들기")
                 )
             case .updateFolder(let field):
                 AlertState(

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -31,6 +31,7 @@ public final class FolderDetailViewModel {
     private(set) var order: Order = .createdAt
     private(set) var select: SelectionMode = .none
     private(set) var selectedItems: [VoiceNote] = []
+    public private(set) var isTrashMode: Bool = false
     @ObservationIgnored
     private var observationTask: Task<Void, Never>?
 
@@ -48,10 +49,12 @@ public final class FolderDetailViewModel {
     public init(
         title: String,
         folderID: UUID,
+        isTrashMode: Bool = false,
         voiceNoteUseCase: any VoiceNoteUseCase
     ) {
         self.title = title
         self.folderID = folderID
+        self.isTrashMode = isTrashMode
         self.voiceNoteUseCase = voiceNoteUseCase
         sortItems()
     }

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -31,12 +31,13 @@ public final class FolderDetailViewModel {
     private(set) var order: Order = .createdAt
     private(set) var select: SelectionMode = .none
     private(set) var selectedItems: [VoiceNote] = []
-    private(set) var showAlert: Bool = false
-
-    public weak var coordinator: FolderDetailCoordinatorDelegate?
-
     @ObservationIgnored
     private var observationTask: Task<Void, Never>?
+
+    // MARK: - 화면 전환
+
+    public weak var coordinator: FolderDetailCoordinatorDelegate?
+    public weak var alertCoordinator: ChaGokAlertCoordinatorDelegate?
 
     // MARK: - UseCase
 
@@ -120,16 +121,13 @@ extension FolderDetailViewModel {
         selectedItems = []
     }
 
-    func closeAlertView() {
-        showAlert = false
-    }
-
-    func openAlertView() {
+    /// 삭제 버튼 Tapped
+    func deleteButtonTapped(alertAction: () -> Void) {
         guard !selectedItems.isEmpty else {
             setSelectionMode(.none)
             return
         }
-        showAlert = true
+        alertAction()
     }
 }
 
@@ -186,7 +184,10 @@ extension FolderDetailViewModel {
 
 extension FolderDetailViewModel {
     func move() {
-        guard !selectedItems.isEmpty else { return }
+        guard !selectedItems.isEmpty else {
+            setSelectionMode(.none)
+            return
+        }
         do {
             for note in selectedItems {
                 try voiceNoteUseCase.moveToTrash(noteID: note.id)

--- a/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderViewModel.swift
@@ -18,11 +18,12 @@ public final class FolderViewModel {
     // MARK: - State
 
     var category: CategoryToggle
-    private(set) var showTextField: Bool = false
     private(set) var editFolder: Folder?
     private(set) var mode: TextFieldView.Mode = .create
     private(set) var errorMessage: String?
     public weak var coordinator: FolderCoordinatorDelegate?
+    public weak var alertCoordinator: ChaGokAlertCoordinatorDelegate?
+    public var showFolderAlert: ((TextFieldView.Field) -> Void)?
 
     // MARK: - Dependencies
 
@@ -49,15 +50,23 @@ extension FolderViewModel {
     func openTextField(for folder: Folder? = nil) {
         errorMessage = nil
         editFolder = folder
-        setMode(folder == nil ? .create : .edit)
-        showTextField = true
+        let currentMode: TextFieldView.Mode = folder == nil ? .create : .edit
+        setMode(currentMode)
+        let field = TextFieldView.Field(
+            mode: currentMode,
+            title: "",
+            subTitle: "",
+            placeHolder: "폴더 이름을 적어주세요",
+            text: folder?.name ?? "",
+            errorMessage: nil
+        )
+        showFolderAlert?(field)
     }
 
     func closeTextField() {
         errorMessage = nil
         editFolder = nil
         setMode(.create)
-        showTextField = false
     }
 }
 

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -44,8 +44,6 @@ public final class MainViewModel {
         categoryData[selectedCategoryIndex].items.isEmpty
     }
 
-    private(set) var showPermissionAlert: Bool = false
-
     private(set) var errorMessage: String?
 
     // MARK: - UseCase
@@ -110,14 +108,6 @@ extension MainViewModel {
 
     func setDidScroll(_ didScroll: Bool) {
         self.didScroll = didScroll
-    }
-
-    func closePermissionAlert() {
-        showPermissionAlert = false
-    }
-
-    func openPermissionAlert() {
-        showPermissionAlert = true
     }
 }
 
@@ -269,10 +259,10 @@ extension MainViewModel {
 // MARK: - Mic Permission
 
 extension MainViewModel {
-    func handleRecordButtonTap() {
+    func handleRecordButtonTap(alertAction: () -> Void) {
         let status = microphoneRepository.checkMicrophonePermission()
         if status != .authorized {
-            openPermissionAlert()
+            alertAction()
         } else {
             presentRecodingView()
         }

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -45,7 +45,6 @@ public final class MainViewModel {
     }
 
     private(set) var showPermissionAlert: Bool = false
-    private(set) var showLanguageAlert: Bool = false
 
     private(set) var errorMessage: String?
 
@@ -74,6 +73,7 @@ public final class MainViewModel {
 
     // TODO: 화면 전환
     public weak var mainCoordinator: MainCoordinatorDelegate?
+    public weak var alertCoordinator: ChaGokAlertCoordinatorDelegate?
 
     public init(
         microphoneRepository: any VoiceRecordRepository,
@@ -118,14 +118,6 @@ extension MainViewModel {
 
     func openPermissionAlert() {
         showPermissionAlert = true
-    }
-
-    func closeLanguageAlert() {
-        showLanguageAlert = false
-    }
-
-    func openLanguageAlert() {
-        showLanguageAlert = true
     }
 }
 

--- a/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
@@ -25,7 +25,6 @@ public final class RecordingViewModel {
         var amplitude: Float = 0
         var recordingState: RecordingState = .idle
         var errorMessage: String?
-        var showAlert: Bool = false
 
         var displayStartDate: String {
             let formatter = DateFormatter()
@@ -51,8 +50,6 @@ public final class RecordingViewModel {
         case openCancelAlertButtonTapped
         case cancelButtonTapped
         case finishButtonTapped
-        case closeAlertButtonTapped
-        case openAlertButtonTapped
         case errorOccurred(Error)
     }
 
@@ -119,10 +116,6 @@ public final class RecordingViewModel {
                     send(.errorOccurred(error))
                 }
             }
-        case .closeAlertButtonTapped:
-            state.showAlert = false
-        case .openAlertButtonTapped:
-            state.showAlert = true
         case .errorOccurred(let error):
             state.errorMessage = error.localizedDescription
         }

--- a/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
@@ -48,6 +48,7 @@ public final class RecordingViewModel {
         case viewDidAppear
         case recordButtonTapped
         case openCancelAlertButtonTapped
+        case openCompleteAlertButtonTapped
         case cancelButtonTapped
         case finishButtonTapped
         case errorOccurred(Error)
@@ -59,6 +60,7 @@ public final class RecordingViewModel {
     public weak var coordinator: RecordingCoordinating?
     public weak var alertCoordinator: ChaGokAlertCoordinatorDelegate?
     public var showCancelAlert: (() -> Void)?
+    public var showCompleteAlert: (() -> Void)?
 
     var state: State = .init()
     private var waveformTask: Task<Void, Never>?
@@ -93,6 +95,8 @@ public final class RecordingViewModel {
             } else {
                 showCancelAlert?()
             }
+        case .openCompleteAlertButtonTapped:
+            showCompleteAlert?()
         case .cancelButtonTapped:
             stopTimer()
             waveformTask?.cancel()

--- a/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/RecordingViewModel.swift
@@ -48,6 +48,7 @@ public final class RecordingViewModel {
     public enum Action {
         case viewDidAppear
         case recordButtonTapped
+        case openCancelAlertButtonTapped
         case cancelButtonTapped
         case finishButtonTapped
         case closeAlertButtonTapped
@@ -59,8 +60,10 @@ public final class RecordingViewModel {
     private let voiceNoteUseCase: any VoiceNoteUseCase
 
     public weak var coordinator: RecordingCoordinating?
+    public weak var alertCoordinator: ChaGokAlertCoordinatorDelegate?
+    public var showCancelAlert: (() -> Void)?
 
-    private(set) var state: State = .init()
+    var state: State = .init()
     private var waveformTask: Task<Void, Never>?
     private var timerTask: Task<Void, Never>?
     private var actionTask: Task<Void, Never>?
@@ -86,6 +89,12 @@ public final class RecordingViewModel {
                 pauseRecording()
             case .idle:
                 startRecording()
+            }
+        case .openCancelAlertButtonTapped:
+            if state.recordingDuration <= 3 {
+                send(.cancelButtonTapped)
+            } else {
+                showCancelAlert?()
             }
         case .cancelButtonTapped:
             stopTimer()

--- a/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
+++ b/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
@@ -1,3 +1,4 @@
+import Core
 import Domain
 import Foundation
 
@@ -52,12 +53,18 @@ public final class SearchViewModel {
     private(set) var filteredItems: [ContentItem] = []
     private(set) var query: String = ""
     public weak var coordinator: SearchCoordinatorDelegate?
+    private let folderRepository: FolderRepository
 
     // MARK: Initialize
 
-    public init(type: SearchType, items: [ContentItem]) {
+    public init(
+        type: SearchType,
+        items: [ContentItem],
+        folderRepository: FolderRepository
+    ) {
         self.type = type
         self.items = items
+        self.folderRepository = folderRepository
     }
 
     // MARK: - Action
@@ -84,6 +91,17 @@ public final class SearchViewModel {
         searchState = results.isEmpty ? .emptyResult : .result
     }
 
+    func parentFolder(id: UUID) -> String {
+        do {
+            let folder: Folder = try folderRepository.fetch(by: id)
+            return folder.name
+        } catch {
+            AppLogger.error(error)
+        }
+
+        return ""
+    }
+
     func clearSearch() {
         coordinator?.pop()
     }
@@ -98,3 +116,61 @@ public final class SearchViewModel {
         coordinator?.pushVoiceNoteView(voiceNote: voiceNote)
     }
 }
+
+#if DEBUG
+    public extension SearchViewModel {
+        static func preview() -> SearchViewModel {
+            SearchViewModel(
+                type: .main,
+                items: [
+                    .folder(.init(name: "쓰레기 1")),
+                    .folder(.init(name: "쓰레기 2")),
+                    .folder(.init(name: "쓰레기 3")),
+                    .voiceNote(
+                        .init(
+                            title: "음성",
+                            folderID: UUID(),
+                            voiceRecord: VoiceRecord(
+                                audioFilePath: "qwe", duration: 23.0
+                            ),
+                            analysisState: .completed
+                        )
+                    )
+                ],
+                folderRepository: PreviewFolderRepository()
+            )
+        }
+    }
+
+    private struct PreviewFolderRepository: FolderRepository {
+        func create(_ folder: Folder) throws(FolderRepositoryError) -> Folder {
+            folder
+        }
+
+        func fetchAll() throws(FolderRepositoryError) -> [Folder] {
+            []
+        }
+
+        func fetch(by id: UUID) throws(FolderRepositoryError) -> Folder {
+            Folder(name: "미리보기 폴더", kind: .custom)
+        }
+
+        func fetch(by kind: FolderKind) throws(FolderRepositoryError) -> [Folder] {
+            []
+        }
+
+        func update(_ folder: Folder) throws(FolderRepositoryError) -> Folder {
+            folder
+        }
+
+        func observe(by kind: FolderKind) throws(FolderRepositoryError) -> AsyncStream<[Folder]> {
+            AsyncStream { $0.finish() }
+        }
+
+        func observeTrashed() throws(FolderRepositoryError) -> AsyncStream<[Folder]> {
+            AsyncStream { $0.finish() }
+        }
+
+        func delete(id: UUID) throws(FolderRepositoryError) {}
+    }
+#endif

--- a/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
+++ b/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
@@ -7,7 +7,7 @@ public protocol SearchCoordinatorDelegate: AnyObject {
     /// 뒤로 가기
     func pop()
     /// 폴더 Push
-    func pushMyFolderDetailView(_ folder: Folder)
+    func pushMyFolderDetailView(_ folder: Folder, isTrashMode: Bool)
     /// 음성 노트 Push
     func pushVoiceNoteView(voiceNote: VoiceNote)
 }
@@ -49,6 +49,7 @@ public final class SearchViewModel {
     private(set) var items: [ContentItem]
     @ObservationIgnored
     let type: SearchType
+    public private(set) var isTrashMode: Bool = false
     private(set) var searchState: SearchState = .empty
     private(set) var filteredItems: [ContentItem] = []
     private(set) var query: String = ""
@@ -60,10 +61,12 @@ public final class SearchViewModel {
     public init(
         type: SearchType,
         items: [ContentItem],
+        isTrashMode: Bool = false,
         folderRepository: FolderRepository
     ) {
         self.type = type
         self.items = items
+        self.isTrashMode = isTrashMode
         self.folderRepository = folderRepository
     }
 
@@ -109,7 +112,7 @@ public final class SearchViewModel {
     // MARK: - Coordinator
 
     func pushFolder(_ folder: Folder) {
-        coordinator?.pushMyFolderDetailView(folder)
+        coordinator?.pushMyFolderDetailView(folder, isTrashMode: isTrashMode)
     }
 
     func pushVoiceNote(_ voiceNote: VoiceNote) {

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -108,7 +108,7 @@ extension TrashViewModel {
     func deselectItem(_ item: ContentItem) {
         selectedItems.removeAll { $0.id == item.id }
     }
-    
+
     func deleteButtonTapped(alertAction: () -> Void) {
         guard !selectedItems.isEmpty else {
             setSelectionMode(.none)

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -320,6 +320,8 @@ extension TrashViewModel {
                     if index.isMultiple(of: 2) {
                         let createdOffset = TimeInterval((index + 2) * 43200) * -1
                         let updatedOffset = TimeInterval((index + 1) * 21600) * -1
+                        let deletedOffset = TimeInterval((index + 1) * 10800) * -1
+
                         notes.append(
                             VoiceNote(
                                 title: "휴지통 메모 \(index + 1)",
@@ -333,6 +335,7 @@ extension TrashViewModel {
                                 ),
                                 transcript: nil,
                                 summary: nil,
+                                deletedAt: now.addingTimeInterval(deletedOffset),
                                 analysisState: .pending
                             )
                         )

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -9,9 +9,9 @@ public protocol TrashCoordinatorDelegate: AnyObject {
     /// 음성 노트 Push
     func pushVoiceNoteView(voiceNote: VoiceNote)
     /// 상세 폴더 Push
-    func pushMyFolderDetailView(_ folder: Folder)
+    func pushMyFolderDetailView(_ folder: Folder, isHidden: Bool)
     /// 검색 화면 Push함수
-    func pushSearchView(type: SearchViewModel.SearchType, items: [ContentItem])
+    func pushSearchView(type: SearchViewModel.SearchType, items: [ContentItem], isHidden: Bool)
 }
 
 @MainActor
@@ -19,6 +19,7 @@ public protocol TrashCoordinatorDelegate: AnyObject {
 public final class TrashViewModel {
     // MARK: - State
 
+    private(set) var isHidden: Bool = true
     private(set) var items: [ContentItem] = []
     private(set) var errorMessage: String?
     private(set) var select: SelectionMode = .none
@@ -92,11 +93,11 @@ extension TrashViewModel {
     }
 
     func pushDetailFolder(_ folder: Folder) {
-        coordinator?.pushMyFolderDetailView(folder)
+        coordinator?.pushMyFolderDetailView(folder, isHidden: isHidden)
     }
 
     func pushSearch() {
-        coordinator?.pushSearchView(type: .trash, items: items)
+        coordinator?.pushSearchView(type: .trash, items: items, isHidden: isHidden)
     }
 
     func selectItem(_ item: ContentItem) {

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -107,6 +107,14 @@ extension TrashViewModel {
     func deselectItem(_ item: ContentItem) {
         selectedItems.removeAll { $0.id == item.id }
     }
+    
+    func deleteButtonTapped(alertAction: () -> Void) {
+        guard !selectedItems.isEmpty else {
+            setSelectionMode(.none)
+            return
+        }
+        alertAction()
+    }
 }
 
 // MARK: - Lifecycle

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -23,9 +23,8 @@ public final class TrashViewModel {
     private(set) var errorMessage: String?
     private(set) var select: SelectionMode = .none
     private(set) var selectedItems: [ContentItem] = []
-    private(set) var showTrashAlert: Bool = false
-
     public weak var coordinator: TrashCoordinatorDelegate?
+    public weak var alertCoordinator: ChaGokAlertCoordinatorDelegate?
 
     @ObservationIgnored
     private var foldersObservationTask: Task<Void, Never>?
@@ -78,14 +77,6 @@ extension TrashViewModel {
 
     private func allClearSelected() {
         selectedItems.removeAll()
-    }
-
-    func openTrashAlert() {
-        showTrashAlert = true
-    }
-
-    func closeTrashAlert() {
-        showTrashAlert = false
     }
 }
 

--- a/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
@@ -144,31 +144,32 @@ final class FolderDetailViewModelTests: XCTestCase {
         XCTAssertFalse(sut.mockCoordinator.presentFolderListCalled)
     }
 
-    func test_AlertView_상태변경() {
+    func test_deleteButtonTapped_아이템선택시_alertAction호출() {
         let sut = makeSUT()
         let note = VoiceNote.stub(title: "테스트 노트")
 
-        // 아이템이 선택된 상태여야 얼럿이 열림
         sut.viewModel.selectItem(note)
-        sut.viewModel.openAlertView()
-        XCTAssertTrue(sut.viewModel.showAlert)
 
-        sut.viewModel.closeAlertView()
-        XCTAssertFalse(sut.viewModel.showAlert)
+        var alertActionCalled = false
+        sut.viewModel.deleteButtonTapped {
+            alertActionCalled = true
+        }
+
+        XCTAssertTrue(alertActionCalled)
     }
 
-    func test_openAlertView_아이템선택없을시_상태원복() {
+    func test_deleteButtonTapped_아이템선택없을시_상태원복() {
         let sut = makeSUT()
 
-        // 선택 모드이지만 아이템은 없는 상태
         sut.viewModel.setSelectionMode(.multiple)
         XCTAssertEqual(sut.viewModel.select, .multiple)
 
-        // 아이템 없이 얼럿 오픈 시도
-        sut.viewModel.openAlertView()
+        var alertActionCalled = false
+        sut.viewModel.deleteButtonTapped {
+            alertActionCalled = true
+        }
 
-        // 얼럿은 열리지 않고 선택 모드도 해제되어야 함
-        XCTAssertFalse(sut.viewModel.showAlert)
+        XCTAssertFalse(alertActionCalled)
         XCTAssertEqual(sut.viewModel.select, .none)
     }
 

--- a/Presentation/Tests/Folder/FolderViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderViewModelTests.swift
@@ -101,10 +101,10 @@ final class FolderViewModelTests: XCTestCase {
     func test_openTextFieldView_호출시_상태변경() {
         let sut = makeSUT()
         let folder = Folder(name: "수정 폴더")
-        
+
         var showFolderAlertCalled = false
         var passedField: TextFieldView.Field?
-        
+
         sut.viewModel.showFolderAlert = { field in
             showFolderAlertCalled = true
             passedField = field

--- a/Presentation/Tests/Folder/FolderViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderViewModelTests.swift
@@ -65,7 +65,6 @@ final class FolderViewModelTests: XCTestCase {
         let sut = makeSUT()
 
         XCTAssertEqual(sut.viewModel.category.title, "개인 폴더")
-        XCTAssertFalse(sut.viewModel.showTextField)
         XCTAssertNil(sut.viewModel.editFolder)
     }
 
@@ -102,10 +101,20 @@ final class FolderViewModelTests: XCTestCase {
     func test_openTextFieldView_호출시_상태변경() {
         let sut = makeSUT()
         let folder = Folder(name: "수정 폴더")
+        
+        var showFolderAlertCalled = false
+        var passedField: TextFieldView.Field?
+        
+        sut.viewModel.showFolderAlert = { field in
+            showFolderAlertCalled = true
+            passedField = field
+        }
 
         sut.viewModel.openTextField(for: folder)
 
-        XCTAssertTrue(sut.viewModel.showTextField)
+        XCTAssertTrue(showFolderAlertCalled)
+        XCTAssertEqual(passedField?.mode, .edit)
+        XCTAssertEqual(passedField?.text, "수정 폴더")
         XCTAssertEqual(sut.viewModel.editFolder?.name, "수정 폴더")
     }
 
@@ -115,7 +124,6 @@ final class FolderViewModelTests: XCTestCase {
 
         sut.viewModel.closeTextField()
 
-        XCTAssertFalse(sut.viewModel.showTextField)
         XCTAssertNil(sut.viewModel.editFolder)
     }
 
@@ -136,7 +144,6 @@ final class FolderViewModelTests: XCTestCase {
 
         sut.mockFolderRepo.verify()
         XCTAssertEqual(sut.viewModel.category.items.count, 1)
-        XCTAssertFalse(sut.viewModel.showTextField)
     }
 
     func test_fetchAll_정상로드() async {
@@ -210,6 +217,5 @@ final class FolderViewModelTests: XCTestCase {
         }
 
         XCTAssertNil(sut.viewModel.editFolder)
-        XCTAssertFalse(sut.viewModel.showTextField)
     }
 }

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -193,32 +193,17 @@ final class MainViewModelTests: XCTestCase {
         XCTAssertFalse(sut.viewModel.didScroll)
     }
 
-    func test_AlertView_상태변경() {
-        let sut = makeSUT()
-
-        sut.viewModel.openPermissionAlert()
-        XCTAssertTrue(sut.viewModel.showPermissionAlert)
-
-        sut.viewModel.closePermissionAlert()
-        XCTAssertFalse(sut.viewModel.showPermissionAlert)
-
-        sut.viewModel.openLanguageAlert()
-        XCTAssertTrue(sut.viewModel.showLanguageAlert)
-
-        sut.viewModel.closeLanguageAlert()
-        XCTAssertFalse(sut.viewModel.showLanguageAlert)
-    }
-
     func test_handleRecordButtonTap_권한허용_바로녹음화면이동() async {
         let sut = makeSUT()
         await sut.mockVoiceRecordRepo.setCheckPermissionResult(.authorized)
         await sut.mockVoiceRecordRepo.expectCheckPermission(callCount: 1)
 
-        sut.viewModel.handleRecordButtonTap()
+        var alertActionCalled = false
+        sut.viewModel.handleRecordButtonTap(alertAction: { alertActionCalled = true })
 
         await sut.mockVoiceRecordRepo.verify()
         XCTAssertTrue(sut.mockCoordinator.presentRecodingViewCalled)
-        XCTAssertFalse(sut.viewModel.showPermissionAlert)
+        XCTAssertFalse(alertActionCalled)
     }
 
     func test_handleRecordButtonTap_권한거부_알럿노출() async {
@@ -226,11 +211,12 @@ final class MainViewModelTests: XCTestCase {
         await sut.mockVoiceRecordRepo.setCheckPermissionResult(.denied)
         await sut.mockVoiceRecordRepo.expectCheckPermission(callCount: 1)
 
-        sut.viewModel.handleRecordButtonTap()
+        var alertActionCalled = false
+        sut.viewModel.handleRecordButtonTap(alertAction: { alertActionCalled = true })
 
         await sut.mockVoiceRecordRepo.verify()
         XCTAssertFalse(sut.mockCoordinator.presentRecodingViewCalled)
-        XCTAssertTrue(sut.viewModel.showPermissionAlert)
+        XCTAssertTrue(alertActionCalled)
     }
 
     func test_handleRecordButtonTap_권한미결정_알럿노출() async {
@@ -238,11 +224,12 @@ final class MainViewModelTests: XCTestCase {
         await sut.mockVoiceRecordRepo.setCheckPermissionResult(.notDetermined)
         await sut.mockVoiceRecordRepo.expectCheckPermission(callCount: 1)
 
-        sut.viewModel.handleRecordButtonTap()
+        var alertActionCalled = false
+        sut.viewModel.handleRecordButtonTap(alertAction: { alertActionCalled = true })
 
         await sut.mockVoiceRecordRepo.verify()
         XCTAssertFalse(sut.mockCoordinator.presentRecodingViewCalled)
-        XCTAssertTrue(sut.viewModel.showPermissionAlert)
+        XCTAssertTrue(alertActionCalled)
     }
 
     // MARK: - Language Tests

--- a/Presentation/Tests/Recording/RecordingViewModelTests.swift
+++ b/Presentation/Tests/Recording/RecordingViewModelTests.swift
@@ -67,7 +67,6 @@ extension RecordingViewModelTests {
         XCTAssertEqual(sut.viewModel.state.amplitude, 0)
         XCTAssertNil(sut.viewModel.state.errorMessage)
         XCTAssertEqual(sut.viewModel.state.recordingDuration, 0)
-        XCTAssertFalse(sut.viewModel.state.showAlert)
     }
 }
 
@@ -241,32 +240,56 @@ extension RecordingViewModelTests {
         XCTAssertEqual(sut.coordinator.cancelRecordingCallCount, 1)
         await sut.repository.verify()
     }
+
+    func test_openCancelAlertButtonTapped_duration이_3초이하면_cancelButtonTapped가_호출된다() async {
+        // Given
+        let sut = makeSUT()
+        sut.viewModel.state.recordingDuration = 3
+        await sut.repository.setCancelResult(.success(()))
+        await sut.repository.expectCancelRecording(callCount: 1)
+
+        // When
+        sut.viewModel.send(.openCancelAlertButtonTapped)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        XCTAssertEqual(sut.coordinator.cancelRecordingCallCount, 1)
+        await sut.repository.verify()
+    }
+
+    func test_openCancelAlertButtonTapped_duration이_3초초과면_showCancelAlert가_호출된다() {
+        // Given
+        let sut = makeSUT()
+        sut.viewModel.state.recordingDuration = 4
+        var showCancelAlertCalled = false
+        sut.viewModel.showCancelAlert = {
+            showCancelAlertCalled = true
+        }
+
+        // When
+        sut.viewModel.send(.openCancelAlertButtonTapped)
+
+        // Then
+        XCTAssertTrue(showCancelAlertCalled)
+    }
 }
 
 // MARK: - 완료
 
 extension RecordingViewModelTests {
-    func test_openAlertButtonTapped_showAlert를true로변경한다() {
+    func test_openCompleteAlertButtonTapped_showCompleteAlert가_호출된다() {
         // Given
         let sut = makeSUT()
+        var showCompleteAlertCalled = false
+        sut.viewModel.showCompleteAlert = {
+            showCompleteAlertCalled = true
+        }
 
         // When
-        sut.viewModel.send(.openAlertButtonTapped)
+        sut.viewModel.send(.openCompleteAlertButtonTapped)
 
         // Then
-        XCTAssertTrue(sut.viewModel.state.showAlert)
-    }
-
-    func test_closeAlertButtonTapped_showAlert를false로변경한다() {
-        // Given
-        let sut = makeSUT()
-        sut.viewModel.send(.openAlertButtonTapped)
-
-        // When
-        sut.viewModel.send(.closeAlertButtonTapped)
-
-        // Then
-        XCTAssertFalse(sut.viewModel.state.showAlert)
+        XCTAssertTrue(showCompleteAlertCalled)
     }
 }
 

--- a/Presentation/Tests/Trash/TrashViewModelTests.swift
+++ b/Presentation/Tests/Trash/TrashViewModelTests.swift
@@ -20,11 +20,11 @@ final class MockTrashCoordinatorDelegate: TrashCoordinatorDelegate {
         pushedVoiceNote = voiceNote
     }
 
-    func pushMyFolderDetailView(_ folder: Folder) {
+    func pushMyFolderDetailView(_ folder: Folder, isHidden: Bool) {
         pushedFolder = folder
     }
 
-    func pushSearchView(type: SearchViewModel.SearchType, items: [ContentItem]) {
+    func pushSearchView(type: SearchViewModel.SearchType, items: [ContentItem], isHidden: Bool) {
         pushSearchViewCalled = true
         pushedSearchType = type
         pushedSearchItems = items

--- a/Presentation/Tests/Trash/TrashViewModelTests.swift
+++ b/Presentation/Tests/Trash/TrashViewModelTests.swift
@@ -95,16 +95,33 @@ final class TrashViewModelTests: XCTestCase {
 
         XCTAssertTrue(sut.viewModel.items.isEmpty, "초기 항목 배열은 비어있어야 합니다.")
         XCTAssertNil(sut.viewModel.errorMessage, "초기 에러 메시지는 없어야 합니다.")
-        XCTAssertFalse(sut.viewModel.showTrashAlert, "초기 경고창 상태는 false여야 합니다.")
     }
 
-    func test_openTrashAlert_상태변경() {
+    func test_deleteButtonTapped_선택항목존재시_alertAction호출() {
         let sut = makeSUT()
-        XCTAssertFalse(sut.viewModel.showTrashAlert)
+        let folder = Folder(name: "테스트 폴더")
+        sut.viewModel.selectItem(.folder(folder))
 
-        sut.viewModel.openTrashAlert()
+        var alertActionCalled = false
+        sut.viewModel.deleteButtonTapped {
+            alertActionCalled = true
+        }
 
-        XCTAssertTrue(sut.viewModel.showTrashAlert, "알럿 상태가 true가 되어야 합니다.")
+        XCTAssertTrue(alertActionCalled, "선택된 항목이 있으면 alertAction이 호출되어야 합니다.")
+    }
+
+    func test_deleteButtonTapped_선택항목없을시_상태원복() {
+        let sut = makeSUT()
+        sut.viewModel.setSelectionMode(.multiple)
+        XCTAssertEqual(sut.viewModel.select, .multiple)
+
+        var alertActionCalled = false
+        sut.viewModel.deleteButtonTapped {
+            alertActionCalled = true
+        }
+
+        XCTAssertFalse(alertActionCalled, "선택된 항목이 없으면 alertAction이 호출되지 않아야 합니다.")
+        XCTAssertEqual(sut.viewModel.select, .none, "선택 모드가 none으로 원복되어야 합니다.")
     }
 
     func test_didTapBack_코디네이터pop호출() {


### PR DESCRIPTION
## ✨ 작업 요약
> 폴더/휴지통 알럿(Alert) UI 시스템 통합 및 뷰 재구성, 휴지통 읽기 전용 모드 적용, 시간 표기 정책 개편

-

## 📋 구체적인 내용
- **추가/변경된 동작**:
  1. **알럿(Alert) 시스템 통합 및 에러 핸들링 복구**
     - 기존 `FolderViewController`, `TrashViewController` 등 개별적으로 관리되던 알럿 UI를 표준화된 `ChaGokAlertViewController`로 전면 마이그레이션.
     - (폴더 생성/수정 등) 에러 발생 시, 알럿 창이 즉시 닫히지 않고 내부 `TextFieldView`에 실시간으로 빨간색 에러 메시지를 띄우도록 구조를 변경했습니다. (`setErrorMessage` 연동)
  2. **상대 시간 표기 (날짜 포맷) 정책 변경**
     - 기존 "몇 분 전", "몇 시간 전" 표기 방식을 폐기하고, Calendar 기반의 명확한 일 단위 분기 정책을 도입했습니다.
     - 당일: "오늘" / 7일 이내: "N일 전" / 7일 초과: "yyyy.MM.dd" 형태로 간결하게 표시되도록 `Date+Formatting`을 리팩토링했습니다.
  3. **Diffable DataSource 하이라이트 버그 픽스**
     - `SearchViewController`에서 검색어(`query`)가 변경되어도 기존 셀의 SwiftUI 뷰 하이라이트가 업데이트되지 않던 현상을 해결했습니다.
     - `updateDataSource` 호출 시 `snapshot.reconfigureItems`를 통해 카드 뷰의 강제 재렌더링을 유도했습니다.
  4. **휴지통 폴더 읽기 전용 (Read-Only) 모드 추가**
     - 휴지통 또는 휴지통 내 검색을 통해 폴더 상세 화면에 진입한 경우, 아이템을 조작하지 못하도록 방어 로직을 구성했습니다.
     - `isTrashMode` 활성화 시 폴더 내 아이템 삭제 액션(스와이프) 및 네비게이션 액션(수정/검색/더보기)을 완전히 숨김 처리했습니다.

- **영향 받는 화면/모듈**:
  - `Search`, `Folder`, `Trash`, `Alert` 등 Presentation 전역 및 Navigation 흐름
  - `Date` Extension (포매팅 유틸 클래스)

---

## 🔗 연관 이슈

- closed #248

---

## 🧩 설계·구현 노트

- **선택한 방식**
  - **알럿 내 에러 피드백 방식**: `FolderViewController`에서 알럿의 Primary 버튼 클릭 시 즉시 창을 내리지 않고, `vm.create()`를 선행시켜 에러가 발생하면 `alertVC.setErrorMessage()`로 에러 텍스트만 업데이트하도록 델리게이트 통신 구조를 변경했습니다. 
  - **Diffable DataSource 강제 리렌더링**: SwiftUI의 `@State`가 아닌 ViewModel의 값에 의존하는 `UIHostingConfiguration` 특성상, 데이터(Item)의 ID가 동일하면 뷰가 다시 그려지지 않는 한계가 있습니다. 이를 `reconfigureItems`를 활용해 UIKit 레벨에서 명시적인 갱신을 트리거하는 방식으로 해결했습니다.
- **고려했다가 제외한 방식**
  - 휴지통 내부에서 "음성 노트"를 열었을 때의 읽기 전용 제한 로직도 초기에 도입했었으나, 사용자 경험 저하 및 다른 플로우와의 충돌 우려를 고려해 음성 노트는 제외하고 폴더 상세 뷰(`FolderDetailViewController`)에만 `isTrashMode`를 적용하기로 최종 롤백(제외) 하였습니다.

---

## ✅ 확인 사항

- [x] 정상 플로우 동작 확인 (휴지통 내 검색, 알럿 테스트)
- [x] 엣지 케이스 / 빈 값·에러 처리 확인 (중복된 폴더 생성 시 경고 라벨 표출 확인)
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [x] (로직 추가 시) 테스트 추가 여부 (`TrashViewModelTests`, `FolderViewModelTests`, `DateFormattingTests` 등 시그니처 갱신 완료)

---

## 👀 리뷰 포인트

- [ ] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- 알럿 내 `TextFieldView` 에러 메세지가 정상적으로 업데이트되는 뷰 갱신 로직 (알럿을 강제로 닫지 않고 메세지만 띄우는 부분)
- `TrashCoordinator` -> `SearchCoordinator` -> `FolderDetail`로 이어지는 파이프라인의 `isTrashMode` 상태 전달 구조

---

## 📚 참고
