### PR TITLE
STT 멀티 사운드 지원하도록 코드 수정합니다.

### DIFF
--- a/Data/Sources/Repositories/VoiceRecords/DefaultVoiceRecordRepository.swift
+++ b/Data/Sources/Repositories/VoiceRecords/DefaultVoiceRecordRepository.swift
@@ -180,7 +180,7 @@ public actor DefaultVoiceRecordRepository: VoiceRecordRepository {
 
     private func activateSession() throws(VoiceRecordRepositoryError) {
         do {
-            try AVAudioSession.sharedInstance().setCategory(.record, mode: .default)
+            try AVAudioSession.sharedInstance().setCategory(.record, mode: .spokenAudio, options: [.duckOthers])
             try AVAudioSession.sharedInstance().setActive(true)
         } catch {
             throw .startFailed


### PR DESCRIPTION
- 사용자 음성 및 외부 목소리까지 인식을 잘 할 수 있도록 합니다.

## ✨ 작업 요약
> 한 줄로 무엇을 추가/변경했는지

- `AVAudioSession` 설정을 `mode: .default`에서 `mode: .spokenAudio` + `options: [.duckOthers]`로 변경해 음성 인식 친화적으로 조정했습니다.

## 📋 구체적인 내용
- 추가/변경된 동작:
- 녹음 세션 활성화 시 `setCategory(.record, mode: .spokenAudio, options: [.duckOthers])` 적용
- 주변 오디오를 완전히 끄기보다 ducking 처리하여 사용자 음성과 외부 음성 인식 환경을 개선
- 영향 받는 화면/모듈:
- `Data/Sources/Repositories/VoiceRecords/DefaultVoiceRecordRepository.swift`
- 음성 녹음/인식 시작 플로우 전반 (`activateSession()` 경유)

---

## 🔗 연관 이슈

- closed #254

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
- `mode: .spokenAudio`를 사용해 음성 콘텐츠 중심의 오디오 세션 의도를 명확히 함
- `duckOthers` 옵션으로 다른 오디오와의 공존성을 유지하면서도 입력 음성의 명료도를 확보

- **고려했다가 제외한 방식**
- 기존 `mode: .default` 유지: 일반 녹음에는 무난하지만 음성 인식 목적에 대한 최적화가 부족
- 다른 앱 오디오를 완전히 중단시키는 방향: 사용자 경험 저하 가능성으로 제외

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [ ] 정상 플로우 동작 확인
- [ ] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [ ] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [x] 로직·엣지 케이스
- [x] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [x] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- `spokenAudio + duckOthers` 조합이 실제 디바이스/상황(통화 직후, 백그라운드 오디오 재생 중 등)에서 의도대로 동작하는지 확인 부탁드립니다.

---

## 📚 참고

- 변경 커밋: `edc49113cafd71602cff622cf9146568dca14721`