### PR TITLE
Whiper 모델을 통해 STT 전사를 구현합니다.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Tuist setup cache
         run: tuist setup cache
 
+      - name: Install dependencies
+        run: tuist install
+
       - name: Run tests
         run: tuist test
 

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -25,11 +25,18 @@ public final class AppDIContainer {
         languageRepository: languageRepository
     )
     private lazy var summaryRepository = DefaultSummaryRepository()
+    private lazy var whisperProvider = WhisperKitProvider(
+        storageService: storageService,
+        languageRepository: languageRepository
+    )
 
+    private lazy var sttWhisperRepository = DefaultWhisperSTTRepository(
+        whisperProvider: whisperProvider
+    )
     /// Analysis (Domain Service)
     private(set) lazy var voiceNoteAnalysisService = DefaultVoiceNoteAnalysisService(
         voiceNoteRepository: voiceNoteRepository,
-        sttRepository: sttRepository,
+        sttRepository: sttWhisperRepository,
         summaryRepository: summaryRepository,
         languageRepository: languageRepository
     )
@@ -43,6 +50,16 @@ public final class AppDIContainer {
     )
     public init() throws {
         localDataBase = try CoreDataLocalDataBase()
+    }
+
+    // MARK: - Whisper 모델 ( preload , download ) Status
+
+    public func isWhisperModelDownloaded() -> Bool {
+        WhisperKitProvider.isModelDownloaded(storageService: storageService)
+    }
+
+    public func preloadWhisperKit() async {
+        await whisperProvider.preload()
     }
 
     // MARK: - Repository
@@ -146,6 +163,12 @@ public final class AppDIContainer {
 
     public func makeChaGokAlertViewModel(environment: ChaGokAlertViewModel.AlertEnvironment) -> ChaGokAlertViewModel {
         return ChaGokAlertViewModel(environment: environment)
+    }
+
+    public func makeDownloadOnDeviceViewModel() -> DownloadOnDeviceViewModel {
+        return DownloadOnDeviceViewModel(
+            repository: sttWhisperRepository
+        )
     }
 
     #if DEBUG

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -83,12 +83,30 @@ extension MainCoordinator: MainCoordinatorDelegate {
 
     func presentRecodingView() {
         let navController = UINavigationController()
-        let viewModel = dependencyContainer.makeRecordingViewModel()
-        viewModel.coordinator = self
-        viewModel.alertCoordinator = self
-        let recordingVC = RecordingViewController(viewModel: viewModel)
-        navController.modalPresentationStyle = .fullScreen
-        navController.setViewControllers([recordingVC], animated: false)
+        let isModelDownloaded = dependencyContainer.isWhisperModelDownloaded()
+
+        if isModelDownloaded {
+            let viewModel = dependencyContainer.makeRecordingViewModel()
+            viewModel.coordinator = self
+            viewModel.alertCoordinator = self
+            let recordingVC = RecordingViewController(viewModel: viewModel)
+            navController.isNavigationBarHidden = false
+            navController.modalPresentationStyle = .fullScreen
+            navController.setViewControllers([recordingVC], animated: false)
+        } else {
+            let viewModel = dependencyContainer.makeDownloadOnDeviceViewModel()
+            viewModel.coordinator = self
+            let downloadVC = DownloadOnDeviceViewController(vm: viewModel)
+            navController.isNavigationBarHidden = true
+            navController.modalPresentationStyle = .pageSheet
+            navController.setViewControllers([downloadVC], animated: false)
+
+            if let sheet = navController.sheetPresentationController {
+                sheet.detents = [.medium()]
+                sheet.prefersGrabberVisible = true
+            }
+        }
+
         presenter.present(navController, animated: true)
     }
 }
@@ -176,6 +194,22 @@ extension MainCoordinator: ChaGokAlertCoordinatorDelegate {
             topVC = presented
         }
         topVC.present(alertVC, animated: true)
+    }
+}
+
+// MARK: - DownloadWhisperCoordinatorDelegate
+
+extension MainCoordinator: DownloadOnDeviceCoordinatorDelegate {
+    func dismissSheet(completion: Bool) {
+        if completion { // 모델 다운로드 완료 후
+            presenter.dismiss(animated: true) { [weak self] in
+                Task {
+                    await self?.dependencyContainer.preloadWhisperKit()
+                }
+            }
+        } else {
+            presenter.dismiss(animated: true)
+        }
     }
 }
 

--- a/Data/Project.swift
+++ b/Data/Project.swift
@@ -21,7 +21,8 @@ private let dataTarget = Target.target(
     resources: ["Resources/**"],
     dependencies: [
         .project(target: "Core", path: "../Core"),
-        .project(target: "Domain", path: "../Domain")
+        .project(target: "Domain", path: "../Domain"),
+        .external(name: "ArgmaxOSS")
     ]
 )
 

--- a/Data/Sources/Infrastructure/Whisper/WhisperKitProvider.swift
+++ b/Data/Sources/Infrastructure/Whisper/WhisperKitProvider.swift
@@ -1,0 +1,101 @@
+import Core
+import Domain
+import Foundation
+import WhisperKit
+
+public actor WhisperKitProvider {
+    private let storageService: any StorageService
+    private let languageRepository: any LanguageRepository
+
+    // MARK: - Configuration
+
+    private var cachedWhisper: WhisperKit?
+    private let modelDirectory = "WhisperModels"
+    private var decodingOptions: DecodingOptions {
+        DecodingOptions(
+            language: whisperLanguageCode(for: languageRepository.fetchLanguage()),
+            skipSpecialTokens: true
+        )
+    }
+
+    public var downloadedBaseURL: URL {
+        storageService.absoluteURL(for: modelDirectory)
+    }
+
+    public init(
+        storageService: any StorageService,
+        languageRepository: any LanguageRepository
+    ) {
+        self.storageService = storageService
+        self.languageRepository = languageRepository
+    }
+
+    public static func isModelDownloaded(storageService: any StorageService) -> Bool {
+        let downloadBase = storageService.absoluteURL(for: "WhisperModels")
+        let recommendedModel = WhisperKit.recommendedModels().default
+        let modelPath = downloadBase
+            .appendingPathComponent("models")
+            .appendingPathComponent("argmaxinc")
+            .appendingPathComponent("whisperkit-coreml")
+            .appendingPathComponent(recommendedModel)
+
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: modelPath.path, isDirectory: &isDirectory) && isDirectory
+            .boolValue
+    }
+
+    private func getOrLoadWhisper() async throws -> WhisperKit {
+        if let cached = cachedWhisper {
+            return cached
+        }
+
+        let downloadBase = storageService.absoluteURL(for: modelDirectory)
+        let recommendedModel = WhisperKit.recommendedModels().default
+        let modelFolderPath = downloadBase
+            .appendingPathComponent("models")
+            .appendingPathComponent("argmaxinc")
+            .appendingPathComponent("whisperkit-coreml")
+            .appendingPathComponent(recommendedModel)
+
+        AppLogger.info("WhisperKit 모델 로드 시작: \(modelFolderPath.path)")
+
+        let config = WhisperKitConfig(
+            model: recommendedModel,
+            modelFolder: modelFolderPath.path,
+            download: false
+        )
+        let whisper = try await WhisperKit(config)
+
+        cachedWhisper = whisper
+        AppLogger.info("WhisperKit 모델 로드 완료")
+        return whisper
+    }
+
+    public func transcribe(audioFilePath: String) async throws -> [TranscriptionResult] {
+        let whisper = try await getOrLoadWhisper()
+        let audioURL = storageService.absoluteURL(for: audioFilePath)
+        AppLogger.info("오디오 전사 실행: \(audioURL.lastPathComponent)")
+        return try await whisper.transcribe(audioPath: audioURL.path, decodeOptions: decodingOptions)
+    }
+
+    public func preload() async {
+        _ = try? await getOrLoadWhisper()
+    }
+
+    public func clearCache() {
+        cachedWhisper = nil
+    }
+}
+
+// MARK: - Helper ( Private )
+
+private extension WhisperKitProvider {
+    func whisperLanguageCode(for language: Language) -> String {
+        switch language {
+        case .ko:
+            return "ko"
+        case .en:
+            return "en"
+        }
+    }
+}

--- a/Data/Sources/Repositories/VoiceNotes/DefaultWhisperSTTRepository.swift
+++ b/Data/Sources/Repositories/VoiceNotes/DefaultWhisperSTTRepository.swift
@@ -1,0 +1,148 @@
+import Core
+import Domain
+import Foundation
+import Speech
+import WhisperKit
+
+public actor DefaultWhisperSTTRepository: STTRepository {
+    private let whisperProvider: WhisperKitProvider
+
+    public init(
+        whisperProvider: WhisperKitProvider
+    ) {
+        self.whisperProvider = whisperProvider
+    }
+
+    @discardableResult
+    public func download(
+        progressHandler: (@Sendable (Progress) -> Void)? = nil
+    ) async throws(STTRepositoryError) -> URL {
+        let downloadBaseURL = await whisperProvider.downloadedBaseURL
+
+        do {
+            let recommendedModel: String = WhisperKit.recommendedModels().default
+            AppLogger.info("추천하는 모델은 : \(recommendedModel)")
+            let modelFolder = try await WhisperKit.download(
+                variant: recommendedModel,
+                downloadBase: downloadBaseURL,
+                progressCallback: progressHandler
+            )
+            // 다운로드 후 캐시된 인스턴스를 초기화하여 다음 transcribe 시 새 모델을 로드하도록 함
+            await whisperProvider.clearCache()
+            return modelFolder
+        } catch is CancellationError {
+            throw .cancelled
+        } catch {
+            throw .unknown(error)
+        }
+    }
+
+    public func transcribe(audioFilePath: String) async throws(STTRepositoryError) -> Transcript {
+        guard !Task.isCancelled else { throw .cancelled }
+
+        do {
+            let result = try await whisperProvider.transcribe(
+                audioFilePath: audioFilePath
+            )
+
+            let sections = Self.groupIntoSections(result.flatMap(\.segments))
+            if !sections.isEmpty {
+                return Transcript(sections: sections)
+            }
+
+            let text = result
+                .map(\.text)
+                .joined(separator: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { throw STTRepositoryError.transcribeFailed }
+            return Transcript(sections: [TranscriptSection(timestamp: 0, text: text)])
+        } catch let error as STTRepositoryError {
+            throw error
+        } catch {
+            throw .unknown(error)
+        }
+    }
+
+    public nonisolated func checkSTTPermission() -> PermissionStatus {
+        switch SFSpeechRecognizer.authorizationStatus() {
+        case .authorized:
+            return .authorized
+        case .denied, .restricted:
+            return .denied
+        case .notDetermined:
+            return .notDetermined
+        @unknown default:
+            return .denied
+        }
+    }
+
+    public func requestSTTPermission() async throws(STTPermissionRepositoryError) -> PermissionStatus {
+        if Task.isCancelled { throw .cancelled }
+
+        let status = await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+
+        switch status {
+        case .authorized:
+            return .authorized
+        case .denied, .restricted:
+            return .denied
+        case .notDetermined:
+            return .notDetermined
+        @unknown default:
+            return .denied
+        }
+    }
+}
+
+// MARK: - Private
+
+fileprivate extension DefaultWhisperSTTRepository {
+    private static func groupIntoSections(_ segments: [TranscriptionSegment]) -> [TranscriptSection] {
+        var sections: [TranscriptSection] = []
+        var currentTimestamp: TimeInterval?
+        var currentTexts: [String] = []
+        var previousEnd: TimeInterval?
+
+        for segment in segments {
+            let text = segment.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { continue }
+
+            let start = TimeInterval(segment.start)
+            let end = TimeInterval(segment.end)
+
+            guard let timestamp = currentTimestamp else {
+                currentTimestamp = start
+                currentTexts = [text]
+                previousEnd = end
+                continue
+            }
+
+            let gap = max(0, start - (previousEnd ?? start))
+            if gap > Policy.scriptGroupingPauseThreshold {
+                let merged = currentTexts.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+                if !merged.isEmpty {
+                    sections.append(TranscriptSection(timestamp: timestamp, text: merged))
+                }
+                currentTimestamp = start
+                currentTexts = [text]
+            } else {
+                currentTexts.append(text)
+            }
+
+            previousEnd = end
+        }
+
+        if let timestamp = currentTimestamp {
+            let merged = currentTexts.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+            if !merged.isEmpty {
+                sections.append(TranscriptSection(timestamp: timestamp, text: merged))
+            }
+        }
+
+        return sections
+    }
+}

--- a/Data/Sources/Repositories/VoiceRecords/DefaultVoiceRecordRepository.swift
+++ b/Data/Sources/Repositories/VoiceRecords/DefaultVoiceRecordRepository.swift
@@ -180,7 +180,7 @@ public actor DefaultVoiceRecordRepository: VoiceRecordRepository {
 
     private func activateSession() throws(VoiceRecordRepositoryError) {
         do {
-            try AVAudioSession.sharedInstance().setCategory(.record, mode: .spokenAudio, options: [.duckOthers])
+            try AVAudioSession.sharedInstance().setCategory(.record, mode: .default)
             try AVAudioSession.sharedInstance().setActive(true)
         } catch {
             throw .startFailed

--- a/Domain/Sources/Errors/VoiceNotes/Repositories/STTRepositoryError.swift
+++ b/Domain/Sources/Errors/VoiceNotes/Repositories/STTRepositoryError.swift
@@ -4,6 +4,8 @@ import Foundation
 public enum STTRepositoryError: LocalizedError, Sendable {
     /// 오디오 전사(Transcription) 실패.
     case transcribeFailed
+    /// 모델 다운로드 실패.
+    case downloadFailed
     /// 취소됨.
     case cancelled
     /// 알 수 없는 에러.
@@ -13,6 +15,8 @@ public enum STTRepositoryError: LocalizedError, Sendable {
         switch self {
         case .transcribeFailed:
             return "음성 인식에 실패했습니다."
+        case .downloadFailed:
+            return "모델 다운로드에 실패했습니다."
         case .cancelled:
             return nil
         case .unknown(let error):

--- a/Domain/Sources/Interfaces/VoiceNotes/STTRepository.swift
+++ b/Domain/Sources/Interfaces/VoiceNotes/STTRepository.swift
@@ -16,4 +16,20 @@ public protocol STTRepository: Sendable {
     /// - Returns: 요청 결과 권한 상태.
     /// - Throws: `STTPermissionRepositoryError`
     func requestSTTPermission() async throws(STTPermissionRepositoryError) -> PermissionStatus
+
+    /// 온디바이스 모델 다운로드를 진행합니다.
+    /// Speech 프레임워크를 사용할 경우 함수를 호출하지 않으며, Whisper 또는 다른 HuggingFace 모델 다운로드 용도로 사용합니다.
+    /// - Returns: 모델 다운로드 경로
+    /// - Throws: `STTRepositoryError`
+    @discardableResult
+    func download(progressHandler: (@Sendable (Progress) -> Void)?) async throws(STTRepositoryError) -> URL
+}
+
+public extension STTRepository {
+    @discardableResult
+    func download(
+        progressHandler: (@Sendable (Progress) -> Void)? = nil
+    ) async throws(STTRepositoryError) -> URL {
+        throw .downloadFailed
+    }
 }

--- a/Domain/Testing/Interfaces/Mocks/VoiceNote/MockSTTRepository.swift
+++ b/Domain/Testing/Interfaces/Mocks/VoiceNote/MockSTTRepository.swift
@@ -8,16 +8,19 @@ public actor MockSTTRepository: STTRepository {
     private var result: Result<Transcript, STTRepositoryError>?
     private nonisolated(unsafe) var checkResult: PermissionStatus?
     private var requestResult: Result<PermissionStatus, STTPermissionRepositoryError>?
+    private var downloadResult: Result<URL, STTRepositoryError>?
 
     private var actualCallCount = 0
     private var actualAudioFilePath: String?
     private nonisolated(unsafe) var actualCheckSTTPermissionCallCount = 0
     private var actualRequestSTTPermissionCallCount = 0
+    private var actualDownloadCallCount = 0
 
     private var expectedCallCount: Int?
     private var expectedAudioFilePath: String?
     private nonisolated(unsafe) var expectedCheckSTTPermissionCallCount: Int?
     private var expectedRequestSTTPermissionCallCount: Int?
+    private var expectedDownloadCallCount: Int?
 
     public func setResult(_ result: Result<Transcript, STTRepositoryError>) {
         self.result = result
@@ -31,6 +34,10 @@ public actor MockSTTRepository: STTRepository {
         requestResult = result
     }
 
+    public func setDownloadResult(_ result: Result<URL, STTRepositoryError>) {
+        downloadResult = result
+    }
+
     public func expectTranscribe(callCount: Int, audioFilePath: String? = nil) {
         expectedCallCount = callCount
         expectedAudioFilePath = audioFilePath
@@ -42,6 +49,10 @@ public actor MockSTTRepository: STTRepository {
 
     public func expectRequestSTTPermission(callCount: Int) {
         expectedRequestSTTPermissionCallCount = callCount
+    }
+
+    public func expectDownload(callCount: Int) {
+        expectedDownloadCallCount = callCount
     }
 
     public func verify(file: StaticString = #filePath, line: UInt = #line) {
@@ -69,6 +80,15 @@ public actor MockSTTRepository: STTRepository {
                 actualRequestSTTPermissionCallCount,
                 expected,
                 "STT 권한 요청 호출 횟수가 일치하지 않습니다.",
+                file: file,
+                line: line
+            )
+        }
+        if let expected = expectedDownloadCallCount {
+            XCTAssertEqual(
+                actualDownloadCallCount,
+                expected,
+                "다운로드 호출 횟수가 일치하지 않습니다.",
                 file: file,
                 line: line
             )
@@ -112,6 +132,23 @@ public actor MockSTTRepository: STTRepository {
         case .none:
             XCTFail("MockSTTRepository.requestResult 가 설정되지 않았습니다.")
             throw .unknown(NSError(domain: "MockSTTRepository.requestResult", code: -1))
+        }
+    }
+
+    @discardableResult
+    public func download(
+        progressHandler: (@Sendable (Progress) -> Void)? = nil
+    ) async throws(STTRepositoryError) -> URL {
+        actualDownloadCallCount += 1
+
+        switch downloadResult {
+        case .success(let url):
+            return url
+        case .failure(let error):
+            throw error
+        case .none:
+            XCTFail("MockSTTRepository.downloadResult 가 설정되지 않았습니다.")
+            throw .unknown(NSError(domain: "MockSTTRepository.downloadResult", code: -1))
         }
     }
 }

--- a/Presentation/Sources/View/Recoding/DownloadOnDeviceViewController.swift
+++ b/Presentation/Sources/View/Recoding/DownloadOnDeviceViewController.swift
@@ -1,0 +1,256 @@
+import Foundation
+import UIKit
+
+public final class DownloadOnDeviceViewController: UIViewController, Alertable {
+    // MARK: Componenet
+
+    private lazy var titleLabel: UILabel = {
+        let t = UILabel()
+        t.translatesAutoresizingMaskIntoConstraints = false
+        t.setTypography(text: "차곡 모델 다운로드", style: .title2)
+        t.textColor = UIColor.gray950
+        return t
+    }()
+
+    private lazy var subTitleLabel: UILabel = {
+        let t = UILabel()
+        t.translatesAutoresizingMaskIntoConstraints = false
+        t.setTypography(
+            text: "차곡은 AI를 당신의 다비아스에서 실행 합니다.\n덕분에", style: .body1
+        )
+        t.numberOfLines = 0
+        t.textColor = UIColor.gray800
+        return t
+    }()
+
+    private lazy var subTitle2Label: UILabel = {
+        let t = UILabel()
+        t.translatesAutoresizingMaskIntoConstraints = false
+        t.setTypography(
+            text: "모델을 통해 압도적인 정확도와 음성 인식 및 AI 요약을 경험해보세요.", style: .label
+        )
+        t.numberOfLines = 2
+        t.textColor = UIColor.gray800
+        return t
+    }()
+
+    private var cancelButton: GlassButton = {
+        let button = GlassButton.close("나중에")
+        button.isExclusiveTouch = true
+        return button
+    }()
+
+    private var primaryButton: GlassButton = .primary("다운로드")
+    private var cancelDownloadButton: GlassButton = .primary("취소")
+    private let bottomArea: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private var bottomContainer: UIStackView = {
+        let bottom = UIStackView()
+        bottom.translatesAutoresizingMaskIntoConstraints = false
+        bottom.axis = .horizontal
+        bottom.spacing = 12
+        return bottom
+    }()
+
+    private let progressTitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setTypography(text: "모델 다운로드 중", style: .subtitle2)
+        label.textColor = .gray950
+        return label
+    }()
+
+    private let progressPercentLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setTypography(text: "0%", style: .subtitle2)
+        label.textColor = .gray950
+        label.textAlignment = .right
+        return label
+    }()
+
+    private let progressView: UIProgressView = {
+        let progressView = UIProgressView(progressViewStyle: .default)
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        progressView.trackTintColor = .gray500
+        progressView.progressTintColor = .point900
+        progressView.progress = 0
+        return progressView
+    }()
+
+    private lazy var progressHeaderStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [progressTitleLabel, progressPercentLabel])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.alignment = .center
+        return stack
+    }()
+
+    private lazy var progressContainer: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [progressHeaderStack, progressView])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = 8
+        stack.isHidden = true
+        return stack
+    }()
+
+    // MARK: - Initialize
+
+    private let vm: DownloadOnDeviceViewModel
+
+    public init(vm: DownloadOnDeviceViewModel) {
+        self.vm = vm
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    // MARK: - LifeCycle
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .gray200
+        setup()
+        setupActions()
+    }
+
+    override public func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        vm.cancelDownload()
+    }
+
+    override public func updateProperties() {
+        super.updateProperties()
+        applyDownloadState()
+    }
+
+    private func setup() {
+        let firstList = createListLabelText(text: "무료로 계속 사용 가능합니다")
+        let secondList = createListLabelText(text: "데이터가 외부로 유출되지 않고 안전하게 사용 가능합니다.")
+        for item in [titleLabel, subTitleLabel, firstList, secondList, subTitle2Label] {
+            view.addSubview(item)
+        }
+
+        bottomContainer.addArrangedSubview(cancelButton)
+        bottomContainer.addArrangedSubview(primaryButton)
+        view.addSubview(bottomArea)
+        bottomArea.addSubview(bottomContainer)
+        bottomArea.addSubview(cancelDownloadButton)
+        view.addSubview(progressContainer)
+
+        NSLayoutConstraint.activate([
+            // titleLabel
+            titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            // subTitleLabel
+            subTitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 10),
+            subTitleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            subTitleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            // firstList
+            firstList.topAnchor.constraint(equalTo: subTitleLabel.bottomAnchor, constant: 10),
+            firstList.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            firstList.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            // secondList
+            secondList.topAnchor.constraint(equalTo: firstList.bottomAnchor, constant: 8),
+            secondList.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            secondList.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            // subTitleLabel2
+            subTitle2Label.topAnchor.constraint(equalTo: secondList.bottomAnchor, constant: 10),
+            subTitle2Label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            subTitle2Label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            // bottomArea
+            bottomArea.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            bottomArea.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            bottomArea.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            bottomArea.heightAnchor.constraint(equalToConstant: Constant.commonButtonHeight),
+            // bottomContainer
+            bottomContainer.topAnchor.constraint(equalTo: bottomArea.topAnchor),
+            bottomContainer.leadingAnchor.constraint(equalTo: bottomArea.leadingAnchor),
+            bottomContainer.trailingAnchor.constraint(equalTo: bottomArea.trailingAnchor),
+            bottomContainer.bottomAnchor.constraint(equalTo: bottomArea.bottomAnchor),
+            // cancelDownloadButton
+            cancelDownloadButton.topAnchor.constraint(equalTo: bottomArea.topAnchor),
+            cancelDownloadButton.leadingAnchor.constraint(equalTo: bottomArea.leadingAnchor),
+            cancelDownloadButton.trailingAnchor.constraint(equalTo: bottomArea.trailingAnchor),
+            cancelDownloadButton.bottomAnchor.constraint(equalTo: bottomArea.bottomAnchor),
+            // progressContainer
+            progressContainer.bottomAnchor.constraint(equalTo: bottomArea.topAnchor, constant: -12),
+            progressContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            progressContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            // progressView
+            progressView.heightAnchor.constraint(equalToConstant: 4)
+        ])
+    }
+}
+
+// MARK: - Helper
+
+extension DownloadOnDeviceViewController {
+    /// 장점을 표현하기 위한 list label을 생성 하는 함수
+    private func createListLabelText(symbol: String = "checkmark", text: String) -> UIStackView {
+        let listLabel = UIStackView()
+        let imageView = UIImageView()
+        let label = UILabel()
+        [listLabel, imageView, label].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
+        // listLabel
+        listLabel.spacing = 8
+        // image
+        let symbolConfig: UIImage.SymbolConfiguration = .init(pointSize: 12, weight: .bold)
+        imageView.image = UIImage(systemName: symbol, withConfiguration: symbolConfig)
+        imageView.tintColor = .point900
+        imageView.contentMode = .scaleAspectFit
+        // label
+        label.setTypography(text: text, style: .label)
+        label.textColor = .gray950
+        label.numberOfLines = 2
+        listLabel.addArrangedSubview(imageView)
+        listLabel.addArrangedSubview(label)
+
+        return listLabel
+    }
+}
+
+// MARK: - Bindings
+
+private extension DownloadOnDeviceViewController {
+    func setupActions() {
+        cancelButton.addAction(UIAction { [weak self] _ in
+            self?.vm.dismiss()
+        }, for: .touchUpInside)
+
+        primaryButton.addAction(UIAction { [weak self] _ in
+            self?.vm.download()
+        }, for: .touchUpInside)
+
+        cancelDownloadButton.addAction(UIAction { [weak self] _ in
+            self?.vm.cancelDownload()
+        }, for: .touchUpInside)
+    }
+
+    /// 다운로드 진행 상태값을 업데이트 합니다.
+    func applyDownloadState() {
+        let isDownloading = vm.isDownloading
+        cancelButton.isExclusiveTouch = isDownloading
+        bottomContainer.isHidden = isDownloading
+        cancelDownloadButton.isExclusiveTouch = !isDownloading
+        cancelDownloadButton.isHidden = !isDownloading
+        progressContainer.isHidden = !isDownloading
+
+        guard isDownloading else {
+            progressView.setProgress(0, animated: false)
+            progressPercentLabel.setTypography(text: "0%", style: .subtitle2)
+            return
+        }
+        let fraction = Float(vm.progressFraction ?? 0)
+        progressView.setProgress(fraction, animated: true)
+        progressPercentLabel.setTypography(text: vm.progressPercentText, style: .subtitle2)
+    }
+}

--- a/Presentation/Sources/ViewModel/Recording/DownloadOnDeviceViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/DownloadOnDeviceViewModel.swift
@@ -1,0 +1,91 @@
+import Core
+import Domain
+import Foundation
+
+@MainActor
+public protocol DownloadOnDeviceCoordinatorDelegate: AnyObject {
+    /// 시트를 닫습니다
+    /// - Parameter completion: true: 다운로드 완료 / false: 취소 또는 나중에
+    func dismissSheet(completion: Bool)
+}
+
+@MainActor
+@Observable
+public final class DownloadOnDeviceViewModel {
+    // MARK: - State
+
+    private(set) var progressFraction: Double?
+    private(set) var isDownloading: Bool = false
+    private(set) var errorMessage: String?
+
+    public weak var coordinator: DownloadOnDeviceCoordinatorDelegate?
+    private let repository: any STTRepository
+    @ObservationIgnored
+    private var downloadTask: Task<Void, Never>?
+    @ObservationIgnored
+    var progressPercentText: String {
+        guard let fraction = progressFraction else { return "0%" }
+        return "\(Int((fraction * 100).rounded()))%"
+    }
+
+    // MARK: - Initialize
+
+    public init(
+        repository: any STTRepository
+    ) {
+        self.repository = repository
+    }
+}
+
+// MARK: - Actions
+
+extension DownloadOnDeviceViewModel {
+    /// 모델의 다운로드를 진행 하며 현재 상태를 handler를 통해 반환합니다.
+    func download() {
+        guard downloadTask == nil else { return }
+
+        downloadTask = Task { [weak self] in
+            guard let self else { return }
+            isDownloading = true
+            do {
+                _ = try await repository.download { [weak self] progress in
+                    Task { @MainActor [weak self] in
+                        self?.progressFraction = progress.fractionCompleted
+                    }
+                }
+            } catch let error as STTRepositoryError {
+                switch error {
+                case .cancelled:
+                    self.progressFraction = nil
+                default:
+                    AppLogger.error(error)
+                    self.errorMessage = error.localizedDescription
+                    self.progressFraction = nil
+                }
+            } catch {
+                AppLogger.error(error)
+                errorMessage = error.localizedDescription
+                progressFraction = nil
+            }
+            downloadTask = nil
+            isDownloading = false
+            dismiss()
+        }
+    }
+
+    func dismissError() {
+        errorMessage = nil
+    }
+
+    func cancelDownload() {
+        downloadTask?.cancel()
+        downloadTask = nil
+        isDownloading = false
+        progressFraction = nil
+    }
+
+    func dismiss() {
+        let condition: Bool = !isDownloading && progressFraction == 1
+        coordinator?.dismissSheet(completion: condition)
+    }
+}

--- a/Presentation/Tests/Recording/DownloadOnDeviceViewModelTests.swift
+++ b/Presentation/Tests/Recording/DownloadOnDeviceViewModelTests.swift
@@ -96,12 +96,12 @@ extension DownloadOnDeviceViewModelTests {
 // MARK: - 다운로드 취소 및 기타
 
 extension DownloadOnDeviceViewModelTests {
-    func test_cancelDownload_호출시_다운로드를취소하고_상태가초기화된다() async throws {
+    func test_cancelDownload_호출시_다운로드를취소하고_상태가초기화된다() async {
         // Given
         let sut = makeSUT()
         let dummyURL = URL(fileURLWithPath: "/dummy/path")
         await sut.repository.setDownloadResult(.success(dummyURL))
-        
+
         sut.viewModel.download() // Task 시작
 
         // When

--- a/Presentation/Tests/Recording/DownloadOnDeviceViewModelTests.swift
+++ b/Presentation/Tests/Recording/DownloadOnDeviceViewModelTests.swift
@@ -1,0 +1,124 @@
+@testable import Presentation
+import Domain
+import DomainTesting
+import XCTest
+
+@MainActor
+final class MockDownloadOnDeviceCoordinator: DownloadOnDeviceCoordinatorDelegate {
+    private(set) var dismissSheetCallCount = 0
+    private(set) var completionValue: Bool?
+
+    func dismissSheet(completion: Bool) {
+        dismissSheetCallCount += 1
+        completionValue = completion
+    }
+}
+
+@MainActor
+final class DownloadOnDeviceViewModelTests: XCTestCase {
+    private struct SUT {
+        let viewModel: DownloadOnDeviceViewModel
+        let repository: MockSTTRepository
+        let coordinator: MockDownloadOnDeviceCoordinator
+    }
+
+    private func makeSUT() -> SUT {
+        let repository = MockSTTRepository()
+        let coordinator = MockDownloadOnDeviceCoordinator()
+        let viewModel = DownloadOnDeviceViewModel(repository: repository)
+        viewModel.coordinator = coordinator
+
+        return SUT(
+            viewModel: viewModel,
+            repository: repository,
+            coordinator: coordinator
+        )
+    }
+}
+
+// MARK: - 초기 상태
+
+extension DownloadOnDeviceViewModelTests {
+    func test_뷰모델생성시_초기상태를확인한다() {
+        // Given & When
+        let sut = makeSUT()
+
+        // Then
+        XCTAssertFalse(sut.viewModel.isDownloading)
+        XCTAssertNil(sut.viewModel.progressFraction)
+        XCTAssertNil(sut.viewModel.errorMessage)
+        XCTAssertEqual(sut.viewModel.progressPercentText, "0%")
+    }
+}
+
+// MARK: - 다운로드
+
+extension DownloadOnDeviceViewModelTests {
+    func test_다운로드를_성공적으로_완료하면_isDownloading이_false가되고_coordinator를호출한다() async throws {
+        // Given
+        let sut = makeSUT()
+        let dummyURL = URL(fileURLWithPath: "/dummy/path")
+        await sut.repository.setDownloadResult(.success(dummyURL))
+        await sut.repository.expectDownload(callCount: 1)
+
+        // When
+        sut.viewModel.download()
+
+        // Wait for async task to complete
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        XCTAssertFalse(sut.viewModel.isDownloading)
+        XCTAssertEqual(sut.coordinator.dismissSheetCallCount, 1)
+        XCTAssertEqual(sut.coordinator.completionValue, false) // Note: 성공이더라도 progressFraction이 1이 아니면 false가 반환됩니다.
+        await sut.repository.verify()
+    }
+
+    func test_다운로드가_실패하면_errorMessage를_설정하고_isDownloading이_false가된다() async throws {
+        // Given
+        let sut = makeSUT()
+        await sut.repository.setDownloadResult(.failure(.downloadFailed))
+        await sut.repository.expectDownload(callCount: 1)
+
+        // When
+        sut.viewModel.download()
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        XCTAssertFalse(sut.viewModel.isDownloading)
+        XCTAssertNotNil(sut.viewModel.errorMessage)
+        XCTAssertEqual(sut.coordinator.dismissSheetCallCount, 1)
+        await sut.repository.verify()
+    }
+}
+
+// MARK: - 다운로드 취소 및 기타
+
+extension DownloadOnDeviceViewModelTests {
+    func test_cancelDownload_호출시_다운로드를취소하고_상태가초기화된다() {
+        // Given
+        let sut = makeSUT()
+        sut.viewModel.download() // Task 시작
+        XCTAssertTrue(sut.viewModel.isDownloading)
+
+        // When
+        sut.viewModel.cancelDownload()
+
+        // Then
+        XCTAssertFalse(sut.viewModel.isDownloading)
+        XCTAssertNil(sut.viewModel.progressFraction)
+    }
+
+    func test_dismissError_호출시_errorMessage가_nil이된다() {
+        // Given
+        let sut = makeSUT()
+
+        // 에러를 강제로 주입하기 위해 다운로드 실패 플로우를 한 번 태웁니다.
+        sut.viewModel.download()
+        sut.viewModel.dismissError() // 직접 지우기 시뮬레이션
+
+        // Then
+        XCTAssertNil(sut.viewModel.errorMessage)
+    }
+}

--- a/Presentation/Tests/Recording/DownloadOnDeviceViewModelTests.swift
+++ b/Presentation/Tests/Recording/DownloadOnDeviceViewModelTests.swift
@@ -96,11 +96,13 @@ extension DownloadOnDeviceViewModelTests {
 // MARK: - 다운로드 취소 및 기타
 
 extension DownloadOnDeviceViewModelTests {
-    func test_cancelDownload_호출시_다운로드를취소하고_상태가초기화된다() {
+    func test_cancelDownload_호출시_다운로드를취소하고_상태가초기화된다() async throws {
         // Given
         let sut = makeSUT()
+        let dummyURL = URL(fileURLWithPath: "/dummy/path")
+        await sut.repository.setDownloadResult(.success(dummyURL))
+        
         sut.viewModel.download() // Task 시작
-        XCTAssertTrue(sut.viewModel.isDownloading)
 
         // When
         sut.viewModel.cancelDownload()

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "d7b890a2472ccd0d78e6a24e60bd2a603fe9b6e579fd99ab73df2c4d81b48eb6",
+  "pins" : [
+    {
+      "identity" : "argmax-oss-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/argmaxinc/argmax-oss-swift.git",
+      "state" : {
+        "revision" : "25c62997041c134b03ca82731ce2f6fd2cae1eb9",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -3,5 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "ChaGok",
-    dependencies: []
+    dependencies: [
+        .package(url: "https://github.com/argmaxinc/argmax-oss-swift.git", from: "1.0.0")
+    ]
 )


### PR DESCRIPTION
---

## ✨ 작업 요약
> 한 줄로 무엇을 추가/변경했는지

- WhisperKit 동시성 경고(Sendable) 및 전사 버그 해결, 불필요한 모델 상태 캐싱을 제거하여 STT 아키텍처를 최적화했습니다.

## 📋 구체적인 내용
- **추가/변경된 동작**:
  - `WhisperKitProvider` 내부에서 오디오 파일의 절대 경로를 직접 변환하여 전사하도록 수정 (기존에 모델 폴더 경로를 전사 시도하여 아무 결과가 나오지 않던 치명적 버그 수정)
  - `WhisperKit` 인스턴스가 Actor(`WhisperKitProvider`) 경계를 벗어나지 않도록 캡슐화하여 Swift 6 Strict Concurrency 환경에서의 Sendable 경고 완벽 해결
  - `WhisperModelAvailabilityUseCase` 삭제: 파일 유무(`FileManager`)만을 검사하는 O(1) 작업이므로, 불필요한 캐싱과 백그라운드 프리로딩 대신 `AppDIContainer`에서 직접 동기식(`isModelDownloaded`)으로 검사하도록 아키텍처 간소화
  - `MainCoordinator`의 `presentRecodingView`가 동기식 파일 체크 결과를 바로 받아 시트(Sheet)를 띄우도록 최적화
  - `DownloadOnDeviceViewModelTests`를 `RecordingViewModelTests`와 동일한 SUT(System Under Test) 팩토리 및 Coordinator Mock 패턴으로 전면 리팩토링 및 단위 테스트 보강

- **영향 받는 화면/모듈**:
  - **Data/Infrastructure**: `WhisperKitProvider`, `DefaultWhisperSTTRepository`
  - **Domain**: `STTRepository` 프로토콜, `WhisperModelAvailabilityUseCase` (삭제)
  - **App/Presentation**: `AppDIContainer`, `MainCoordinator`, `DownloadOnDeviceViewController`
  - **Test**: `MockSTTRepository`, `DownloadOnDeviceViewModelTests`

---

## 🔗 연관 이슈

- closed #256 (이슈 번호는 알맞게 수정해주세요!)

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
  - 모델 다운로드 상태를 체크하는 것은 결국 `FileManager.default.fileExists`라는 매우 빠르고 단순한 로컬 시스템 호출입니다. 굳이 도메인 계층(UseCase)에서 비동기 상태로 관리하고 캐싱할 필요가 없어 전부 덜어냈습니다. `WhisperKitProvider`가 정적(static) 메서드로 파일 유무만 체크해 주면 `MainCoordinator`에서 블로킹 없이 부드럽게 뷰를 전환할 수 있습니다.
- **고려했다가 제외한 방식**
  - 기존 방식인 UseCase 캐싱 유지: 앱 진입 시 `Task`를 띄워 상태를 들고 있는 방식이었으나, 생명주기 내내 불필요하게 상태가 떠다니며, 의존성이 복잡해져서 배제했습니다.

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [x] 정상 플로우 동작 확인 (음성 녹음 후 실제 텍스트 전사 정상 작동)
- [x] 엣지 케이스 / 빈 값·에러 처리 확인 (경로 변환 누락 예외 테스트)
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [x] (로직 추가 시) 테스트 추가 여부 (DownloadOnDeviceViewModelTests 및 Mock 업데이트 완료)

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] UI/UX (해당 시)
- [x] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- `AppDIContainer` 및 `MainCoordinator`에서 덜어낸 캐싱/프리로딩 관련 코드 다이어트 부분
- `DownloadOnDeviceViewModelTests`의 SUT 패턴 적용 및 `CoordinatorDelegate` Mock 동작 검증

---

## 📚 참고