### PR TITLE
설정 화면 WebView 적용합니다.

### DIFF
--- a/App/Project.swift
+++ b/App/Project.swift
@@ -47,10 +47,7 @@ private let appTarget = Target.target(
             "NSMicrophoneUsageDescription": "음성 메모를 녹음하기 위해 마이크 권한이 필요합니다.",
             "NSSpeechRecognitionUsageDescription": "음성을 텍스트로 변환하기 위해 음성 인식 권한이 필요합니다.",
             "ITSAppUsesNonExemptEncryption": false,
-            "UIBackgroundModes": ["audio"],
-            "NSAppTransportSecurity": .dictionary([
-                "NSAllowsArbitraryLoads": .boolean(true)
-            ])
+            "UIBackgroundModes": ["audio"]
         ]
     ),
     sources: ["Sources/**/*.swift"],

--- a/App/Project.swift
+++ b/App/Project.swift
@@ -47,7 +47,10 @@ private let appTarget = Target.target(
             "NSMicrophoneUsageDescription": "음성 메모를 녹음하기 위해 마이크 권한이 필요합니다.",
             "NSSpeechRecognitionUsageDescription": "음성을 텍스트로 변환하기 위해 음성 인식 권한이 필요합니다.",
             "ITSAppUsesNonExemptEncryption": false,
-            "UIBackgroundModes": ["audio"]
+            "UIBackgroundModes": ["audio"],
+            "NSAppTransportSecurity": .dictionary([
+                "NSAllowsArbitraryLoads": .boolean(true)
+            ])
         ]
     ),
     sources: ["Sources/**/*.swift"],

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -223,7 +223,19 @@ extension MainCoordinator: DownloadOnDeviceCoordinatorDelegate {
     }
 }
 
-extension MainCoordinator: SettingCoordinatorDelegate {}
+// MARK: - SettingCoordinatorDelegate
+
+extension MainCoordinator: SettingCoordinatorDelegate {
+    func pushTermsOfUseView() {
+        let termsVC = TermsOfUseViewController()
+        presenter.pushViewController(termsVC, animated: true)
+    }
+
+    func pushPrivacyPolicyView() {
+        let privacyVC = PrivacyPolicyViewController()
+        presenter.pushViewController(privacyVC, animated: true)
+    }
+}
 
 // MARK: - Helpers
 

--- a/Presentation/Sources/DesignSystem/Constant.swift
+++ b/Presentation/Sources/DesignSystem/Constant.swift
@@ -329,3 +329,14 @@ public extension Constant {
     /// SummarySection keywords 셀 상단 여백 (12)
     static let summarySectionKeywordsTopInset: CGFloat = 12
 }
+
+// MARK: - WebView URL
+
+public extension Constant {
+    /// 개인정보 처리 방침
+    static let privacyPolicy: String = "https://sunset-bar-890.notion.site/369d9da368aa80538cced7f6c56e339a?pvs=74"
+    /// 이용 약관
+    static let termsOfUse: String = "https://sunset-bar-890.notion.site/369d9da368aa8033be62f317299c07f2"
+    /// 고객 문의
+    static let customerInquiry: String = "https://docs.google.com/forms/d/e/1FAIpQLSeevBvqUuIG4yBEos3T6KEZc_R1GgbMLAZYG9iHTc4JMv7DIg/viewform?usp=publish-editor"
+}

--- a/Presentation/Sources/View/Setting/PrivacyPolicyViewController.swift
+++ b/Presentation/Sources/View/Setting/PrivacyPolicyViewController.swift
@@ -1,0 +1,58 @@
+import UIKit
+import WebKit
+
+/// 개인정보 처리 방침 WebView Controller
+public final class PrivacyPolicyViewController: UIViewController, WKUIDelegate {
+    // MARK: - Component
+
+    private let backItem: NavigationItemButton = .init(
+        normalItem: .init(title: "개인정보 처리 방침", imageName: "chevron.left"),
+        selectedItem: .init(title: "개인정보 처리 방침", imageName: "chevron.left"),
+        attributedString: Typography.header2.textAttributes
+    )
+
+    private var webView: WKWebView!
+
+    override public func loadView() {
+        super.loadView()
+        view = UIView()
+        let configuration = WKWebViewConfiguration()
+        webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.uiDelegate = self
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
+        view.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigation()
+        setupWebView()
+    }
+
+    private func setupNavigation() {
+        backItem.addAction(UIAction { [weak self] _ in
+            self?.navigationController?.popViewController(animated: true)
+        }, for: .touchUpInside)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backItem)
+        navigationItem.leftBarButtonItem?.hidesSharedBackground = true
+    }
+
+    private func setupWebView() {
+        guard let privacyUrl = URL(string: Constant.privacyPolicy) else { return }
+        let request = URLRequest(url: privacyUrl)
+        webView.load(request)
+    }
+}
+
+#Preview {
+    UINavigationController(
+        rootViewController: PrivacyPolicyViewController()
+    )
+}

--- a/Presentation/Sources/View/Setting/SettingViewController.swift
+++ b/Presentation/Sources/View/Setting/SettingViewController.swift
@@ -158,10 +158,12 @@ public final class SettingViewController: CollectionViewController {
     }
 }
 
-#Preview {
-    UINavigationController(
-        rootViewController: SettingViewController(
-            vm: .preview
+#if DEBUG
+    #Preview {
+        UINavigationController(
+            rootViewController: SettingViewController(
+                vm: .preview
+            )
         )
-    )
-}
+    }
+#endif

--- a/Presentation/Sources/View/Setting/SettingViewController.swift
+++ b/Presentation/Sources/View/Setting/SettingViewController.swift
@@ -101,6 +101,7 @@ public final class SettingViewController: CollectionViewController {
 
         let defaultCellRegistration = UICollectionView
             .CellRegistration<UICollectionViewListCell, Item> { cell, indexPath, itemIdentifier in
+                guard case .none(let label) = itemIdentifier.data else { return }
                 var content = cell.defaultContentConfiguration()
                 content.text = itemIdentifier.title
                 content.secondaryText = itemIdentifier.subTitle
@@ -108,6 +109,13 @@ public final class SettingViewController: CollectionViewController {
                 content.textProperties.color = .gray950
                 cell.contentConfiguration = content
                 cell.backgroundConfiguration = .clear()
+                cell.addTapGesture { [weak self] in
+                    switch label {
+                    case .privacyPolicy: self?.vm.pushPrivacyPolicy()
+                    case .termsOfUse: self?.vm.pushTermsOfUse()
+                    case .customerInquiry: self?.customerInquiryLink()
+                    }
+                }
             }
 
         return DataSource(collectionView: collectionView) { col, indexPath, itemIdentifier in
@@ -148,13 +156,20 @@ public final class SettingViewController: CollectionViewController {
         snapshot.appendItems(modelItems, toSection: .model)
 
         let labelItems = [
-            Item(title: "이용약관", subTitle: nil, data: .none),
-            Item(title: "개인 정보 처리 방침", subTitle: nil, data: .none),
-            Item(title: "고객 문의", subTitle: nil, data: .none)
+            Item(title: "이용약관", subTitle: nil, data: .none(.termsOfUse)),
+            Item(title: "개인정보 처리 방침", subTitle: nil, data: .none(.privacyPolicy)),
+            Item(title: "고객 문의", subTitle: nil, data: .none(.customerInquiry))
         ]
         snapshot.appendItems(labelItems, toSection: .label)
 
         dataSource.apply(snapshot, animatingDifferences: animate)
+    }
+
+    /// 고객 문의 링크 함수
+    private func customerInquiryLink() {
+        if let url = URL(string: Constant.customerInquiry) {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
     }
 }
 

--- a/Presentation/Sources/View/Setting/TermsOfUseViewController.swift
+++ b/Presentation/Sources/View/Setting/TermsOfUseViewController.swift
@@ -1,0 +1,52 @@
+import UIKit
+import WebKit
+
+/// 이용약관 WebView Controller
+public final class TermsOfUseViewController: UIViewController, WKUIDelegate {
+    // MARK: - Component
+
+    let backItem: NavigationItemButton = .init(
+        normalItem: .init(title: "이용 약관", imageName: "chevron.left"),
+        selectedItem: .init(title: "이용 약관", imageName: "chevron.left"),
+        attributedString: Typography.header2.textAttributes
+    )
+
+    private var webView: WKWebView!
+
+    override public func loadView() {
+        super.loadView()
+        view = UIView()
+        let configuration = WKWebViewConfiguration()
+        webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.uiDelegate = self
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
+        view.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigation()
+        setupWebView()
+    }
+
+    private func setupNavigation() {
+        backItem.addAction(UIAction { [weak self] _ in
+            self?.navigationController?.popViewController(animated: true)
+        }, for: .touchUpInside)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backItem)
+        navigationItem.leftBarButtonItem?.hidesSharedBackground = true
+    }
+
+    private func setupWebView() {
+        guard let privacyUrl = URL(string: Constant.termsOfUse) else { return }
+        let request = URLRequest(url: privacyUrl)
+        webView.load(request)
+    }
+}

--- a/Presentation/Sources/ViewModel/Setting/SettingViewModel.swift
+++ b/Presentation/Sources/ViewModel/Setting/SettingViewModel.swift
@@ -6,6 +6,10 @@ import Observation
 public protocol SettingCoordinatorDelegate: AnyObject {
     /// 뒤로가기
     func pop()
+    /// 이용약관 push
+    func pushTermsOfUseView()
+    /// 개인정보 처리 방침 push
+    func pushPrivacyPolicyView()
 }
 
 @MainActor
@@ -143,6 +147,14 @@ public final class SettingViewModel {
             }
         }
     }
+
+    func pushTermsOfUse() {
+        coordinator?.pushTermsOfUseView()
+    }
+
+    func pushPrivacyPolicy() {
+        coordinator?.pushPrivacyPolicyView()
+    }
 }
 
 // MARK: - Data
@@ -163,6 +175,12 @@ extension SettingViewModel {
     enum ItemData: Hashable {
         case lang(Language)
         case model([ChaGokModelState])
-        case none
+        case none(LabelData)
+    }
+
+    enum LabelData: Hashable {
+        case termsOfUse // 이용약관
+        case privacyPolicy // 개인 정보 처리 방침
+        case customerInquiry // 고객 문의
     }
 }

--- a/Presentation/Tests/Setting/SettingViewModelTests.swift
+++ b/Presentation/Tests/Setting/SettingViewModelTests.swift
@@ -6,9 +6,19 @@ import XCTest
 @MainActor
 final class MockSettingCoordinatorDelegate: SettingCoordinatorDelegate {
     var popCalled = false
+    var pushTermsCalled = false
+    var pushPrivacyCalled = false
 
     func pop() {
         popCalled = true
+    }
+
+    func pushTermsOfUseView() {
+        pushTermsCalled = true
+    }
+
+    func pushPrivacyPolicyView() {
+        pushPrivacyCalled = true
     }
 }
 
@@ -258,6 +268,28 @@ final class SettingViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertTrue(sut.mockCoordinator.popCalled)
+    }
+
+    func test_pushTermsOfUse_코디네이터호출() {
+        // Arrange
+        let sut = makeSUT()
+
+        // Act
+        sut.viewModel.pushTermsOfUse()
+
+        // Assert
+        XCTAssertTrue(sut.mockCoordinator.pushTermsCalled)
+    }
+
+    func test_pushPrivacyPolicy_코디네이터호출() {
+        // Arrange
+        let sut = makeSUT()
+
+        // Act
+        sut.viewModel.pushPrivacyPolicy()
+
+        // Assert
+        XCTAssertTrue(sut.mockCoordinator.pushPrivacyCalled)
     }
 
     // MARK: - None Model Tests


### PR DESCRIPTION
## ✨ 작업 요약
> 한 줄로 무엇을 추가/변경했는지

- WebView 레이아웃 및 뒤로 동작 수정, coordinator mock 및 관련 단위 테스트 추가

## 📋 구체적인 내용
- 추가/변경된 동작:
  - `TermsOfUseViewController`에서 `WKWebView`를 서브뷰로 추가하고 Auto Layout 제약을 적용하여 네비게이션 바/세이프영역 이슈 완화
  - 뒤로가기 버튼 액션을 `popViewController` 또는 `dismiss`로 분기하도록 수정
  - `MockSettingCoordinatorDelegate`에 `pushTermsOfUseView()` 및 `pushPrivacyPolicyView()` 구현 추가
  - `SettingViewModelTests`에 `pushTermsOfUse` 및 `pushPrivacyPolicy` 관련 테스트 추가
- 영향 받는 화면/모듈:
  - Presentation/Sources/View/Setting/TermsOfUseViewController.swift
  - Presentation/Tests/Setting/SettingViewModelTests.swift

---

## 🔗 연관 이슈
- closed #262

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
  - `loadView()`에서 `view = UIView()`로 설정하고 `webView`를 추가하여 명시적으로 Auto Layout을 적용했습니다. 네비게이션 바 영역과 스크롤 inset 이슈를 분리 관리하기 위해서입니다.
  - 뒤로 동작은 `navigationController` 스택에 따라 `pop` 또는 `dismiss`로 분기해 재사용성을 높였습니다.
- **고려했다가 제외한 방식**
  - `webView`를 루트 뷰로 직접 설정하는 방식은 네비게이션/세이프영역 처리를 통제하기 어렵다고 판단해 제외했습니다.

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [ ] 정상 플로우 동작 확인
- [ ] 엣지 케이스 / 빈 값·에러 처리 확인
- [x] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [ ] 설계·구조 적절성
- [ ] 로직·엣지 케이스
- [ ] 예외/에러 핸들링
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**

- `TermsOfUseViewController`의 레이아웃이 네비게이션/홈 인디케이터 등과 충돌하지 않는지
- mock/테스트가 coordinator contract 변경을 충분히 반영하고 있는지

---

## 📚 참고

-

