### PR TITLE
다운로도 동기화 버그 및 휴지통 진입 시 음성 노트 기능 차단힙니다.

### DIFF
--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -127,13 +127,14 @@ public final class AppDIContainer {
         )
     }
 
-    public func makeVoiceNoteViewModel(voiceNote: VoiceNote) -> VoiceNoteViewModel {
+    public func makeVoiceNoteViewModel(voiceNote: VoiceNote, isTrashMode: Bool = false) -> VoiceNoteViewModel {
         VoiceNoteViewModel(
             voiceNote: voiceNote,
             voiceNoteUseCase: voiceNoteUseCase,
             folderUseCase: folderUseCase,
             playbackRepository: DefaultVoiceRecordPlaybackRepository(storageService: storageService),
-            availableSupportModelRepository: availableSupportModelRepository
+            availableSupportModelRepository: availableSupportModelRepository,
+            isTrashMode: isTrashMode
         )
     }
 

--- a/App/Sources/AppDIContainer.swift
+++ b/App/Sources/AppDIContainer.swift
@@ -76,6 +76,11 @@ public final class AppDIContainer {
     // MARK: - Whisper 모델 ( preload , download ) Status
 
     public func isWhisperModelDownloaded() async -> Bool {
+        let status = await onDeviceStatusUseCase.checkStatus(model: .whisper)
+        if case .downloading = status.storage {
+            return false
+        }
+
         do {
             _ = try await whisperProvider.getDownloadPath()
             return true

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -65,8 +65,8 @@ extension MainCoordinator: MainCoordinatorDelegate {
         presenter.pushViewController(myFolderVC, animated: true)
     }
 
-    func pushVoiceNoteView(voiceNote: VoiceNote) {
-        let voiceNoteVM = dependencyContainer.makeVoiceNoteViewModel(voiceNote: voiceNote)
+    func pushVoiceNoteView(voiceNote: VoiceNote, isTrashMode: Bool = false) {
+        let voiceNoteVM = dependencyContainer.makeVoiceNoteViewModel(voiceNote: voiceNote, isTrashMode: isTrashMode)
         voiceNoteVM.coordinator = self
         let voiceNoteVC = VoiceNoteViewController(viewModel: voiceNoteVM)
         presenter.pushViewController(voiceNoteVC, animated: true)

--- a/Data/Sources/Infrastructure/OnDevice/MLXSupport/MLXModelProvider.swift
+++ b/Data/Sources/Infrastructure/OnDevice/MLXSupport/MLXModelProvider.swift
@@ -23,20 +23,20 @@ public actor MLXModelProvider: MLXModelDataSource {
         progressHandler: @Sendable @escaping (Progress) -> Void
     ) async throws(MLXModelDataSourceError) {
         #if DEBUG
-        // ⚠️ 디버깅용 시뮬레이션: 에러 상황별 핸들링을 안전하게 테스트하기 위한 디버그 스위치입니다.
-        try? await Task.sleep(nanoseconds: 2 * 1_000_000_000)
+            // ⚠️ 디버깅용 시뮬레이션: 에러 상황별 핸들링을 안전하게 테스트하기 위한 디버그 스위치입니다.
+            try? await Task.sleep(nanoseconds: 2 * 1_000_000_000)
 
-        // [옵션 1] 네트워크 오류 시뮬레이션 (networkFailed)
-        // -> 활성화 시 "네트워크 연결이 유실되었습니다" 문구가 노출됩니다.
-        // throw URLError(.notConnectedToInternet)
+            // [옵션 1] 네트워크 오류 시뮬레이션 (networkFailed)
+            // -> 활성화 시 "네트워크 연결이 유실되었습니다" 문구가 노출됩니다.
+            // throw URLError(.notConnectedToInternet)
 
-        // [옵션 2] 알 수 없는 시스템 오류 시뮬레이션 (unknown)
-        // -> 활성화 시 "다운로드에 실패했습니다" 문구와 상세 에러 문구가 노출됩니다.
-        throw .unknown(NSError(
-            domain: "SimulatedErrorDomain",
-            code: 999,
-            userInfo: [NSLocalizedDescriptionKey: "알 수 없는 기기 내부 디스크 쓰기 오류가 발생했습니다. (Simulated)"]
-        ))
+            // [옵션 2] 알 수 없는 시스템 오류 시뮬레이션 (unknown)
+            // -> 활성화 시 "다운로드에 실패했습니다" 문구와 상세 에러 문구가 노출됩니다.
+            throw .unknown(NSError(
+                domain: "SimulatedErrorDomain",
+                code: 999,
+                userInfo: [NSLocalizedDescriptionKey: "알 수 없는 기기 내부 디스크 쓰기 오류가 발생했습니다. (Simulated)"]
+            ))
         #endif
         do {
             let model: ChaGokModel = ChaGokModelSupport.current.model

--- a/Data/Sources/Infrastructure/OnDevice/MLXSupport/MLXModelProvider.swift
+++ b/Data/Sources/Infrastructure/OnDevice/MLXSupport/MLXModelProvider.swift
@@ -22,6 +22,22 @@ public actor MLXModelProvider: MLXModelDataSource {
     public func download(
         progressHandler: @Sendable @escaping (Progress) -> Void
     ) async throws(MLXModelDataSourceError) {
+        #if DEBUG
+        // ⚠️ 디버깅용 시뮬레이션: 에러 상황별 핸들링을 안전하게 테스트하기 위한 디버그 스위치입니다.
+        try? await Task.sleep(nanoseconds: 2 * 1_000_000_000)
+
+        // [옵션 1] 네트워크 오류 시뮬레이션 (networkFailed)
+        // -> 활성화 시 "네트워크 연결이 유실되었습니다" 문구가 노출됩니다.
+        // throw URLError(.notConnectedToInternet)
+
+        // [옵션 2] 알 수 없는 시스템 오류 시뮬레이션 (unknown)
+        // -> 활성화 시 "다운로드에 실패했습니다" 문구와 상세 에러 문구가 노출됩니다.
+        throw .unknown(NSError(
+            domain: "SimulatedErrorDomain",
+            code: 999,
+            userInfo: [NSLocalizedDescriptionKey: "알 수 없는 기기 내부 디스크 쓰기 오류가 발생했습니다. (Simulated)"]
+        ))
+        #endif
         do {
             let model: ChaGokModel = ChaGokModelSupport.current.model
             let configuration = try matchModelConfiguration(model: model)

--- a/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
+++ b/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
@@ -125,8 +125,14 @@ public actor WhisperKitProvider: WhisperDataSource {
         let recommendedModel = WhisperKit.recommendedModels().default
         let relativePath = "huggingface/models/argmaxinc/whisperkit-coreml/\(recommendedModel)"
         let defaultPath = storageService.absoluteURL(for: relativePath)
+        
+        let configPath = "\(relativePath)/config.json"
+        let vocabPath = "\(relativePath)/vocab.json"
 
-        if storageService.exists(relativePath: relativePath) {
+        // 디렉토리 존재뿐만 아니라 핵심 구성 파일(config.json, vocab.json)의 완결성 검사를 수행하여 부분 다운로드 및 비정상 종료된 찌꺼기를 필터링합니다.
+        if storageService.exists(relativePath: relativePath),
+           storageService.exists(relativePath: configPath),
+           storageService.exists(relativePath: vocabPath) {
             modelDirectory = defaultPath
             self.recommendedModel = recommendedModel
             AppLogger.info("whisper 저장 위치 (디스크 감지) : \(defaultPath)")

--- a/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
+++ b/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
@@ -34,20 +34,20 @@ public actor WhisperKitProvider: WhisperDataSource {
         AppLogger.info("WhisperKit 모델 다운로드 시작")
 
         #if DEBUG
-        // ⚠️ 디버깅용 시뮬레이션: 에러 상황별 핸들링을 안전하게 테스트하기 위한 디버그 스위치입니다.
-        try await Task.sleep(nanoseconds: 2 * 1_000_000_000)
-        
-        // [옵션 1] 네트워크 오류 시뮬레이션 (networkFailed)
-        // -> 활성화 시 "네트워크 연결이 유실되었습니다" 문구가 노출됩니다.
-        // throw URLError(.notConnectedToInternet)
-        
-        // [옵션 2] 알 수 없는 시스템 오류 시뮬레이션 (unknown)
-        // -> 활성화 시 "다운로드에 실패했습니다" 문구와 상세 에러 문구가 노출됩니다.
-        throw NSError(
-            domain: "SimulatedErrorDomain",
-            code: 999,
-            userInfo: [NSLocalizedDescriptionKey: "알 수 없는 기기 내부 디스크 쓰기 오류가 발생했습니다. (Simulated)"]
-        )
+            // ⚠️ 디버깅용 시뮬레이션: 에러 상황별 핸들링을 안전하게 테스트하기 위한 디버그 스위치입니다.
+            try await Task.sleep(nanoseconds: 2 * 1_000_000_000)
+
+            // [옵션 1] 네트워크 오류 시뮬레이션 (networkFailed)
+            // -> 활성화 시 "네트워크 연결이 유실되었습니다" 문구가 노출됩니다.
+            // throw URLError(.notConnectedToInternet)
+
+            // [옵션 2] 알 수 없는 시스템 오류 시뮬레이션 (unknown)
+            // -> 활성화 시 "다운로드에 실패했습니다" 문구와 상세 에러 문구가 노출됩니다.
+            throw NSError(
+                domain: "SimulatedErrorDomain",
+                code: 999,
+                userInfo: [NSLocalizedDescriptionKey: "알 수 없는 기기 내부 디스크 쓰기 오류가 발생했습니다. (Simulated)"]
+            )
         #endif
 
         let path = try await WhisperKit.download(
@@ -142,14 +142,15 @@ public actor WhisperKitProvider: WhisperDataSource {
         let recommendedModel = WhisperKit.recommendedModels().default
         let relativePath = "huggingface/models/argmaxinc/whisperkit-coreml/\(recommendedModel)"
         let defaultPath = storageService.absoluteURL(for: relativePath)
-        
+
         let configPath = "\(relativePath)/config.json"
         let vocabPath = "\(relativePath)/vocab.json"
 
         // 디렉토리 존재뿐만 아니라 핵심 구성 파일(config.json, vocab.json)의 완결성 검사를 수행하여 부분 다운로드 및 비정상 종료된 찌꺼기를 필터링합니다.
         if storageService.exists(relativePath: relativePath),
            storageService.exists(relativePath: configPath),
-           storageService.exists(relativePath: vocabPath) {
+           storageService.exists(relativePath: vocabPath)
+        {
             modelDirectory = defaultPath
             self.recommendedModel = recommendedModel
             AppLogger.info("whisper 저장 위치 (디스크 감지) : \(defaultPath)")

--- a/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
+++ b/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
@@ -33,6 +33,23 @@ public actor WhisperKitProvider: WhisperDataSource {
         AppLogger.info("WhisperKit 추천 모델 : \(recommendedModel)")
         AppLogger.info("WhisperKit 모델 다운로드 시작")
 
+        #if DEBUG
+        // ⚠️ 디버깅용 시뮬레이션: 에러 상황별 핸들링을 안전하게 테스트하기 위한 디버그 스위치입니다.
+        try await Task.sleep(nanoseconds: 2 * 1_000_000_000)
+        
+        // [옵션 1] 네트워크 오류 시뮬레이션 (networkFailed)
+        // -> 활성화 시 "네트워크 연결이 유실되었습니다" 문구가 노출됩니다.
+        // throw URLError(.notConnectedToInternet)
+        
+        // [옵션 2] 알 수 없는 시스템 오류 시뮬레이션 (unknown)
+        // -> 활성화 시 "다운로드에 실패했습니다" 문구와 상세 에러 문구가 노출됩니다.
+        throw NSError(
+            domain: "SimulatedErrorDomain",
+            code: 999,
+            userInfo: [NSLocalizedDescriptionKey: "알 수 없는 기기 내부 디스크 쓰기 오류가 발생했습니다. (Simulated)"]
+        )
+        #endif
+
         let path = try await WhisperKit.download(
             variant: recommendedModel,
             useBackgroundSession: false,

--- a/Data/Sources/Interfaces/MLXSupport/MLXModelDataSourceError.swift
+++ b/Data/Sources/Interfaces/MLXSupport/MLXModelDataSourceError.swift
@@ -15,7 +15,7 @@ public enum MLXModelDataSourceError: LocalizedError, Sendable {
     /// unknown
     case unknown(Error)
 
-    public var errorDescription: String {
+    public var errorDescription: String? {
         switch self {
         case .cancelled: return "작업이 취소되었습니다"
         case .networkFailed: return "네트워크 연결이 유실되었습니다"

--- a/Data/Sources/Interfaces/Whisper/WhisperDataSourceError.swift
+++ b/Data/Sources/Interfaces/Whisper/WhisperDataSourceError.swift
@@ -15,7 +15,7 @@ public enum WhisperDataSourceError: LocalizedError, Sendable {
     /// unknown
     case unknown(Error)
 
-    public var errorDescription: String {
+    public var errorDescription: String? {
         switch self {
         case .cancelled: return "작업이 취소되었습니다"
         case .networkFailed: return "네트워크 연결이 유실되었습니다"

--- a/Domain/Sources/Errors/OnDevice/DeleteOnDeviceRepositoryError.swift
+++ b/Domain/Sources/Errors/OnDevice/DeleteOnDeviceRepositoryError.swift
@@ -7,7 +7,7 @@ public enum DeleteOnDeviceRepositoryError: LocalizedError, Sendable {
     case deleteMLXFailed
     case unknown(Error)
 
-    public var errorDescription: String {
+    public var errorDescription: String? {
         switch self {
         case .cancelled:
             return "취소되었습니다"

--- a/Domain/Sources/Errors/OnDevice/OnDeviceRepositoryError.swift
+++ b/Domain/Sources/Errors/OnDevice/OnDeviceRepositoryError.swift
@@ -10,7 +10,7 @@ public enum OnDeviceRepositoryError: LocalizedError, Sendable {
     /// unknown
     case unknown(Error)
 
-    public var errorDescription: String {
+    public var errorDescription: String? {
         switch self {
         case .cancelled: return "작업이 취소되었습니다"
         case .networkFailed: return "네트워크 연결이 유실되었습니다"

--- a/Domain/Sources/UseCases/OnDevice/OnDeviceStatusUseCase.swift
+++ b/Domain/Sources/UseCases/OnDevice/OnDeviceStatusUseCase.swift
@@ -8,6 +8,8 @@ public protocol OnDeviceStatusUseCase: Sendable {
     func download(model: ChaGokModel) async throws(OnDeviceStatusUseCaseError)
     /// 모델 제거
     func delete(model: ChaGokModel) async throws(DeleteOnDeviceRepositoryError)
+    /// 현재 상태 조회
+    func checkStatus(model: ChaGokModel) async -> OnDeviceStatus
 }
 
 public actor DefaultOnDeviceStatusUseCase: OnDeviceStatusUseCase {
@@ -52,6 +54,7 @@ public actor DefaultOnDeviceStatusUseCase: OnDeviceStatusUseCase {
 
             try await repo.download { progress in
                 Task { [model] in
+                    guard await self.shouldPublishProgress(model: model) else { return }
                     await self.publish(
                         model: model,
                         status: OnDeviceStatus(storage: .downloading(progress: progress), runtime: .unloaded)
@@ -85,6 +88,7 @@ public actor DefaultOnDeviceStatusUseCase: OnDeviceStatusUseCase {
     }
 
     public func delete(model: ChaGokModel) async throws(DeleteOnDeviceRepositoryError) {
+        isDownloading[model] = false
         guard let repo = repo(for: model) else { return }
         do {
             let status = try await repo.delete()
@@ -95,12 +99,24 @@ public actor DefaultOnDeviceStatusUseCase: OnDeviceStatusUseCase {
         }
     }
 
-    private func syncStatus(model: ChaGokModel) async {
-        guard isDownloading[model] != true else { return }
+    public func checkStatus(model: ChaGokModel) async -> OnDeviceStatus {
+        if isDownloading[model] == true {
+            return latest[model] ?? OnDeviceStatus(storage: .downloading(progress: 0.0), runtime: .unloaded)
+        }
         if let repo = repo(for: model) {
             let status = await repo.checkStatus()
             latest[model] = status
+            return status
         }
+        return OnDeviceStatus(storage: .notDownloaded, runtime: .unloaded)
+    }
+
+    private func shouldPublishProgress(model: ChaGokModel) -> Bool {
+        return isDownloading[model] == true
+    }
+
+    private func syncStatus(model: ChaGokModel) async {
+        _ = await checkStatus(model: model)
     }
 
     private var lastPublishedTime: [ChaGokModel: Double] = [:]

--- a/Domain/Testing/Interfaces/Mocks/OnDevice/MockOnDeviceStatusUseCase.swift
+++ b/Domain/Testing/Interfaces/Mocks/OnDevice/MockOnDeviceStatusUseCase.swift
@@ -15,10 +15,23 @@ public final class MockOnDeviceStatusUseCase: OnDeviceStatusUseCase, @unchecked 
     public var actualSubscribeCallCount = 0
     public var actualDownloadCallCount = 0
     public var actualDeleteCallCount = 0
+    public var actualCheckStatusCallCount = 0
 
     public var subscribedModel: ChaGokModel?
     public var downloadedModel: ChaGokModel?
     public var deletedModel: ChaGokModel?
+    public var checkedModel: ChaGokModel?
+
+    public var checkStatusResult: OnDeviceStatus = OnDeviceStatus(
+        storage: .notDownloaded,
+        runtime: .unloaded
+    )
+
+    public func checkStatus(model: ChaGokModel) async -> OnDeviceStatus {
+        actualCheckStatusCallCount += 1
+        checkedModel = model
+        return checkStatusResult
+    }
 
     public func subscribe(model: ChaGokModel) async -> AsyncStream<OnDeviceStatus> {
         actualSubscribeCallCount += 1

--- a/Presentation/Sources/Component/Common/DownloadModelCard.swift
+++ b/Presentation/Sources/Component/Common/DownloadModelCard.swift
@@ -122,6 +122,7 @@ extension DownloadModelCard {
 extension DownloadModelCard {
     func updateStatus(_ storage: OnDeviceStatus.StorageState, errorMessage: String?) {
         self.storage = storage
+        self.errorMessage = errorMessage
         setNeedsUpdateProperties()
     }
 
@@ -161,7 +162,9 @@ extension DownloadModelCard {
             case .immutable:
                 immutableProgressView.isHidden = true
             }
-            downloadMessageLabel.setTypography(text: errorMessage, style: .body2)
+            downloadMessageLabel.isHidden = false
+            let msg = (errorMessage == nil || errorMessage?.isEmpty == true) ? "다운로드에 실패했습니다" : errorMessage
+            downloadMessageLabel.setTypography(text: msg, style: .body2)
             downloadMessageLabel.textColor = .danger
         }
     }

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteNavigationBar.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteNavigationBar.swift
@@ -61,11 +61,14 @@ final class VoiceNoteNavigationBar {
         title: String,
         editingMode: EditingMode? = nil,
         searchMode: Bool = false,
-        hasScriptEdits: Bool = false
+        hasScriptEdits: Bool = false,
+        isTrashMode: Bool = false
     ) -> Bool {
         currentEditingMode = editingMode
         let didToggleSearch = searchMode != lastSearchMode
         lastSearchMode = searchMode
+
+        titleContainerView.isUserInteractionEnabled = !isTrashMode
 
         switch editingMode {
         case .title:
@@ -99,7 +102,11 @@ final class VoiceNoteNavigationBar {
                 navigationItem.rightBarButtonItems = [doneItem]
             case nil:
                 navigationItem.leftBarButtonItem = backItem
-                navigationItem.rightBarButtonItems = [moreItem, searchItem]
+                if isTrashMode {
+                    navigationItem.rightBarButtonItems = [searchItem]
+                } else {
+                    navigationItem.rightBarButtonItems = [moreItem, searchItem]
+                }
             }
         }
 

--- a/Presentation/Sources/Component/VoiceNote/VoiceNoteSearchBar.swift
+++ b/Presentation/Sources/Component/VoiceNote/VoiceNoteSearchBar.swift
@@ -95,8 +95,11 @@ public final class VoiceNoteSearchBar: UIView {
             subview.translatesAutoresizingMaskIntoConstraints = false
         }
 
+        let heightConstraint = heightAnchor.constraint(equalToConstant: 46)
+        heightConstraint.priority = .init(999)
+
         NSLayoutConstraint.activate([
-            heightAnchor.constraint(equalToConstant: 46),
+            heightConstraint,
 
             searchContainer.topAnchor.constraint(equalTo: topAnchor),
             searchContainer.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/Presentation/Sources/View/Recording/DownloadOnDeviceViewController.swift
+++ b/Presentation/Sources/View/Recording/DownloadOnDeviceViewController.swift
@@ -170,13 +170,18 @@ private extension DownloadOnDeviceViewController {
     /// 다운로드 진행 상태값을 업데이트 합니다.
     func applyDownloadState() {
         let isDownloading = vm.isDownloading
+        let isFailed = vm.status.storage == .failed
+        let isShowingCard = isDownloading || isFailed
+
+        primaryButton.configuration?.title = isFailed ? "재시도" : "다운로드"
+
         cancelButton.isExclusiveTouch = isDownloading
         bottomContainer.isHidden = isDownloading
         cancelDownloadButton.isExclusiveTouch = !isDownloading
         cancelDownloadButton.isHidden = !isDownloading
-        infoBox.isHidden = isDownloading
-        downloadModelCard.isHidden = !isDownloading
-        if isDownloading {
+        infoBox.isHidden = isShowingCard
+        downloadModelCard.isHidden = !isShowingCard
+        if isShowingCard {
             downloadModelCard.updateStatus(
                 vm.status.storage,
                 errorMessage: vm.errorMessage

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteSummaryViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteSummaryViewController.swift
@@ -154,14 +154,14 @@ private extension VoiceNoteSummaryViewController {
 
         let warningCellReg = UICollectionView
             .CellRegistration<UICollectionViewCell, Item> { [weak self] cell, _, item in
-                guard case .failure = item, let self else { return }
+                guard case .failure(let isSupported) = item, let self else { return }
 
                 let title: String
                 let subTitle: String
                 let buttonTitle: String
                 let action: () -> Void
 
-                if !viewModel.isMLXModelSupported {
+                if !isSupported {
                     title = "요약을 생성하지 못했어요"
                     subTitle = "AI 요약 기능이\n현재 기기에서는 지원되지 않습니다"
                     buttonTitle = "스크립트"
@@ -265,7 +265,7 @@ private extension VoiceNoteSummaryViewController {
         if isFailed {
             snapshot.appendSections([.metadata, .failure])
             snapshot.appendItems([.metadata], toSection: .metadata)
-            snapshot.appendItems([.failure], toSection: .failure)
+            snapshot.appendItems([.failure(isMLXModelSupported: viewModel.isMLXModelSupported)], toSection: .failure)
 
             dataSource.apply(snapshot, animatingDifferences: true)
         } else {
@@ -377,6 +377,6 @@ extension VoiceNoteSummaryViewController {
         case keywords
         case keyPointSkeleton(number: Int, beginOffset: CFTimeInterval)
         case keywordsSkeleton(beginOffset: CFTimeInterval)
-        case failure
+        case failure(isMLXModelSupported: Bool)
     }
 }

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteSummaryViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteSummaryViewController.swift
@@ -240,6 +240,7 @@ private extension VoiceNoteSummaryViewController {
     }
 
     var regenerationChipState: RegenerationChip.State? {
+        guard !viewModel.isTrashMode else { return nil }
         switch viewModel.voiceNote.analysisState {
         // 첫 분석 중에는 요약 섹션이 비어 있어 칩을 숨긴다.
         case .pending, .summarizing, .transcribed, .transcribing, .transcriptionFailed: return nil

--- a/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
+++ b/Presentation/Sources/View/VoiceNote/VoiceNoteViewController.swift
@@ -194,7 +194,7 @@ private extension VoiceNoteViewController {
             self?.viewModel.exitSearchMode()
         }
 
-        navigationBar.apply(to: navigationItem, title: viewModel.title)
+        navigationBar.apply(to: navigationItem, title: viewModel.title, isTrashMode: viewModel.isTrashMode)
     }
 
     func setupTabBar() {
@@ -316,7 +316,8 @@ private extension VoiceNoteViewController {
             title: viewModel.title,
             editingMode: viewModel.editingMode,
             searchMode: viewModel.searchMode,
-            hasScriptEdits: viewModel.hasScriptEdits
+            hasScriptEdits: viewModel.hasScriptEdits,
+            isTrashMode: viewModel.isTrashMode
         )
     }
 
@@ -336,7 +337,8 @@ private extension VoiceNoteViewController {
             title: viewModel.title,
             editingMode: viewModel.editingMode,
             searchMode: isSearching,
-            hasScriptEdits: viewModel.hasScriptEdits
+            hasScriptEdits: viewModel.hasScriptEdits,
+            isTrashMode: viewModel.isTrashMode
         )
 
         if didToggle {

--- a/Presentation/Sources/ViewModel/CoordinatorDelegate/MainCoordinatorDelegate.swift
+++ b/Presentation/Sources/ViewModel/CoordinatorDelegate/MainCoordinatorDelegate.swift
@@ -10,7 +10,7 @@ public protocol MainCoordinatorDelegate: AnyObject {
     /// 개인 폴더로 push 하는 함수
     func pushMyFolderView(category: CategoryToggle)
     /// 음성 노트로 push 하는 함수
-    func pushVoiceNoteView(voiceNote: VoiceNote)
+    func pushVoiceNoteView(voiceNote: VoiceNote, isTrashMode: Bool)
     /// 녹음 시작 present 함수
     func presentRecodingView()
     /// 공용 Pop함수

--- a/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
+++ b/Presentation/Sources/ViewModel/Folder/FolderDetailViewModel.swift
@@ -7,7 +7,7 @@ public protocol FolderDetailCoordinatorDelegate: AnyObject {
     /// 뒤로 가기
     func pop()
     /// 음성 노트 가기
-    func pushVoiceNoteView(voiceNote: VoiceNote)
+    func pushVoiceNoteView(voiceNote: VoiceNote, isTrashMode: Bool)
     /// 폴더 이동 Sheet
     func presentFolderList(with voiceNotes: [VoiceNote], onComplete: ((String) -> Void)?)
     /// 검색 화면 Push함수
@@ -97,7 +97,7 @@ extension FolderDetailViewModel {
 
     /// 음성 노트 화면 전환
     func pushVoiceNote(voiceNote: VoiceNote) {
-        coordinator?.pushVoiceNoteView(voiceNote: voiceNote)
+        coordinator?.pushVoiceNoteView(voiceNote: voiceNote, isTrashMode: isTrashMode)
     }
 
     /// 폴더 이동 Present

--- a/Presentation/Sources/ViewModel/Main/MainViewModel.swift
+++ b/Presentation/Sources/ViewModel/Main/MainViewModel.swift
@@ -120,7 +120,7 @@ extension MainViewModel {
     }
 
     func pushVoiceNoteView(voiceNote: VoiceNote) {
-        mainCoordinator?.pushVoiceNoteView(voiceNote: voiceNote)
+        mainCoordinator?.pushVoiceNoteView(voiceNote: voiceNote, isTrashMode: false)
     }
 
     func presentRecodingView() {

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
@@ -72,6 +72,8 @@ public final class OnBoardingViewModel {
                 return "다운로드 중입니다..."
             case .downloaded:
                 return "다음"
+            case .failed:
+                return "재시도"
             default:
                 return "다운로드"
             }
@@ -203,6 +205,7 @@ extension OnBoardingViewModel {
 
     private func download() {
         scrollEnabled = false
+        self.errorMessage = nil
         downloadTask?.cancel()
         downloadTask = Task {
             defer {
@@ -216,6 +219,7 @@ extension OnBoardingViewModel {
                 self.status = OnDeviceStatus(storage: .downloading(progress: 0), runtime: .unloaded)
                 try await mlxRepository.download { progress in
                     Task { @MainActor in
+                        guard case .downloading = self.status.storage else { return }
                         self.status = OnDeviceStatus(storage: .downloading(progress: progress), runtime: .unloaded)
                     }
                 }
@@ -225,12 +229,13 @@ extension OnBoardingViewModel {
                 if case .cancelled = repoError {
                     self.status = OnDeviceStatus(storage: .notDownloaded, runtime: .unloaded)
                 } else {
-                    errorMessage = repoError.errorDescription
+                    self.errorMessage = repoError.errorDescription
+                    AppLogger.info(errorMessage ?? "nil")
                     self.status = OnDeviceStatus(storage: .failed, runtime: .unloaded)
                 }
             } catch {
                 AppLogger.error(error)
-                errorMessage = error.localizedDescription
+                self.errorMessage = error.localizedDescription
                 self.status = OnDeviceStatus(storage: .failed, runtime: .unloaded)
             }
         }

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
@@ -205,7 +205,7 @@ extension OnBoardingViewModel {
 
     private func download() {
         scrollEnabled = false
-        self.errorMessage = nil
+        errorMessage = nil
         downloadTask?.cancel()
         downloadTask = Task {
             defer {

--- a/Presentation/Sources/ViewModel/Recording/DownloadOnDeviceViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/DownloadOnDeviceViewModel.swift
@@ -86,7 +86,6 @@ extension DownloadOnDeviceViewModel {
         let useCase = onDeviceStatusUseCase
         Task {
             task?.cancel()
-            _ = await task?.value
             try? await useCase.delete(model: .whisper)
         }
     }
@@ -103,7 +102,6 @@ extension DownloadOnDeviceViewModel {
             let useCase = onDeviceStatusUseCase
             Task {
                 task?.cancel()
-                _ = await task?.value
                 try? await useCase.delete(model: .whisper)
             }
         } else {

--- a/Presentation/Sources/ViewModel/Recording/DownloadOnDeviceViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/DownloadOnDeviceViewModel.swift
@@ -64,7 +64,7 @@ extension DownloadOnDeviceViewModel {
     /// 모델의 다운로드를 유즈케이스에 요청합니다.
     func download() {
         guard downloadTask == nil else { return }
-        self.errorMessage = nil
+        errorMessage = nil
 
         downloadTask = Task {
             defer { downloadTask = nil }

--- a/Presentation/Sources/ViewModel/Recording/DownloadOnDeviceViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/DownloadOnDeviceViewModel.swift
@@ -64,8 +64,10 @@ extension DownloadOnDeviceViewModel {
     /// 모델의 다운로드를 유즈케이스에 요청합니다.
     func download() {
         guard downloadTask == nil else { return }
+        self.errorMessage = nil
 
         downloadTask = Task {
+            defer { downloadTask = nil }
             do {
                 try await onDeviceStatusUseCase.download(model: .whisper)
             } catch {

--- a/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
+++ b/Presentation/Sources/ViewModel/Search/SearchViewModel.swift
@@ -9,7 +9,7 @@ public protocol SearchCoordinatorDelegate: AnyObject {
     /// 폴더 Push
     func pushMyFolderDetailView(_ folder: Folder, isTrashMode: Bool)
     /// 음성 노트 Push
-    func pushVoiceNoteView(voiceNote: VoiceNote)
+    func pushVoiceNoteView(voiceNote: VoiceNote, isTrashMode: Bool)
 }
 
 @MainActor
@@ -116,7 +116,7 @@ public final class SearchViewModel {
     }
 
     func pushVoiceNote(_ voiceNote: VoiceNote) {
-        coordinator?.pushVoiceNoteView(voiceNote: voiceNote)
+        coordinator?.pushVoiceNoteView(voiceNote: voiceNote, isTrashMode: isTrashMode)
     }
 }
 

--- a/Presentation/Sources/ViewModel/Setting/SettingViewModel+Preview.swift
+++ b/Presentation/Sources/ViewModel/Setting/SettingViewModel+Preview.swift
@@ -52,6 +52,10 @@ import Foundation
         }
 
         actor PreviewOnDeviceStatusUseCase: OnDeviceStatusUseCase {
+            func checkStatus(model: Domain.ChaGokModel) async -> Domain.OnDeviceStatus {
+                .init(storage: .downloaded, runtime: .unloaded)
+            }
+
             func cancelDownload(model: Domain.ChaGokModel) async {}
 
             func subscribe(model: ChaGokModel) async -> AsyncStream<OnDeviceStatus> {

--- a/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
+++ b/Presentation/Sources/ViewModel/Trash/TrashViewModel.swift
@@ -7,7 +7,7 @@ public protocol TrashCoordinatorDelegate: AnyObject {
     /// 뒤로가기
     func pop()
     /// 음성 노트 Push
-    func pushVoiceNoteView(voiceNote: VoiceNote)
+    func pushVoiceNoteView(voiceNote: VoiceNote, isTrashMode: Bool)
     /// 상세 폴더 Push
     func pushMyFolderDetailView(_ folder: Folder, isHidden: Bool)
     /// 검색 화면 Push함수
@@ -89,7 +89,7 @@ extension TrashViewModel {
     }
 
     func pushVoiceNote(_ voiceNote: VoiceNote) {
-        coordinator?.pushVoiceNoteView(voiceNote: voiceNote)
+        coordinator?.pushVoiceNoteView(voiceNote: voiceNote, isTrashMode: true)
     }
 
     func pushDetailFolder(_ folder: Folder) {

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -22,7 +22,7 @@ public final class VoiceNoteViewModel {
     public private(set) var searchMode: Bool = false
     public private(set) var searchQuery: String = ""
     public private(set) var currentMatchIndex: Int = 0
-    public private(set) var isMLXModelSupported: Bool = true
+    public private(set) var isMLXModelSupported: Bool = (ChaGokModelSupport.current.model != .none)
 
     @ObservationIgnored
     private var playbackObservationTask: Task<Void, Never>?

--- a/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
+++ b/Presentation/Sources/ViewModel/VoiceNote/VoiceNoteViewModel.swift
@@ -23,6 +23,7 @@ public final class VoiceNoteViewModel {
     public private(set) var searchQuery: String = ""
     public private(set) var currentMatchIndex: Int = 0
     public private(set) var isMLXModelSupported: Bool = (ChaGokModelSupport.current.model != .none)
+    public let isTrashMode: Bool
 
     @ObservationIgnored
     private var playbackObservationTask: Task<Void, Never>?
@@ -46,13 +47,15 @@ public final class VoiceNoteViewModel {
         voiceNoteUseCase: any VoiceNoteUseCase,
         folderUseCase: any FolderUseCase,
         playbackRepository: any VoiceRecordPlaybackRepository,
-        availableSupportModelRepository: any AvailableModelSupportRepository
+        availableSupportModelRepository: any AvailableModelSupportRepository,
+        isTrashMode: Bool = false
     ) {
         self.voiceNote = voiceNote
         self.voiceNoteUseCase = voiceNoteUseCase
         self.folderUseCase = folderUseCase
         self.playbackRepository = playbackRepository
         self.availableSupportModelRepository = availableSupportModelRepository
+        self.isTrashMode = isTrashMode
     }
 
     // MARK: - View Actions
@@ -118,14 +121,17 @@ public final class VoiceNoteViewModel {
     }
 
     public func moveVoiceNote(onComplete: ((String) -> Void)? = nil) {
+        guard !isTrashMode else { return }
         coordinator?.presentMoveFolder(for: voiceNote, onComplete: onComplete)
     }
 
     public func enterTitleEditing() {
+        guard !isTrashMode else { return }
         editingMode = .title
     }
 
     public func enterScriptEditing() {
+        guard !isTrashMode else { return }
         if currentPlaybackState.status == .playing { pause() }
         editableScriptSections = scriptSections
         currentPage = .script
@@ -241,10 +247,12 @@ public final class VoiceNoteViewModel {
     }
 
     public func deleteVoiceNote() {
+        guard !isTrashMode else { return }
         moveToWasteBasket()
     }
 
     public func regenerateSummary() {
+        guard !isTrashMode else { return }
         if searchMode { exitSearchMode() }
         voiceNoteUseCase.regenerateSummary(id: voiceNote.id)
     }

--- a/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
+++ b/Presentation/Tests/Folder/FolderDetailViewModelTests.swift
@@ -17,7 +17,7 @@ final class MockFolderDetailCoordinatorDelegate: FolderDetailCoordinatorDelegate
         popCalled = true
     }
 
-    func pushVoiceNoteView(voiceNote: Domain.VoiceNote) {
+    func pushVoiceNoteView(voiceNote: Domain.VoiceNote, isTrashMode: Bool) {
         pushedVoiceNote = voiceNote
     }
 

--- a/Presentation/Tests/Main/MainViewModelTests.swift
+++ b/Presentation/Tests/Main/MainViewModelTests.swift
@@ -27,7 +27,7 @@ final class MockMainCoordinatorDelegate: MainCoordinatorDelegate {
         pushedCategory = category
     }
 
-    func pushVoiceNoteView(voiceNote: VoiceNote) {
+    func pushVoiceNoteView(voiceNote: VoiceNote, isTrashMode: Bool) {
         pushVoiceNoteViewCalled = true
         pushedVoiceNote = voiceNote
     }

--- a/Presentation/Tests/Recording/DownloadOnDeviceViewModelTests.swift
+++ b/Presentation/Tests/Recording/DownloadOnDeviceViewModelTests.swift
@@ -40,6 +40,10 @@ final class DownloadMockOnDeviceStatusUseCase: OnDeviceStatusUseCase, @unchecked
         deleteCallCount += 1
         lastDeletedModel = model
     }
+
+    func checkStatus(model: ChaGokModel) async -> OnDeviceStatus {
+        return OnDeviceStatus(storage: .notDownloaded, runtime: .unloaded)
+    }
 }
 
 @MainActor

--- a/Presentation/Tests/Setting/SettingViewModelTests.swift
+++ b/Presentation/Tests/Setting/SettingViewModelTests.swift
@@ -65,6 +65,12 @@ final class SettingMockOnDeviceStatusUseCase: OnDeviceStatusUseCase, @unchecked 
     func emit(status: OnDeviceStatus) {
         continuation?.yield(status)
     }
+
+    var checkStatusResult: OnDeviceStatus = OnDeviceStatus(storage: .notDownloaded, runtime: .unloaded)
+
+    func checkStatus(model: ChaGokModel) async -> OnDeviceStatus {
+        return checkStatusResult
+    }
 }
 
 @MainActor

--- a/Presentation/Tests/Trash/TrashViewModelTests.swift
+++ b/Presentation/Tests/Trash/TrashViewModelTests.swift
@@ -16,7 +16,7 @@ final class MockTrashCoordinatorDelegate: TrashCoordinatorDelegate {
         popCalled = true
     }
 
-    func pushVoiceNoteView(voiceNote: VoiceNote) {
+    func pushVoiceNoteView(voiceNote: VoiceNote, isTrashMode: Bool) {
         pushedVoiceNote = voiceNote
     }
 


### PR DESCRIPTION
## ✨ 작업 요약                                                                                                                                          
    > 온디바이스 모델 다운로드 에러 메시지(nil) 해결, 휴지통 내 음성 노트 진입 시 기능 차단(isTrashMode) 구현 및 검색바 오토 레이아웃 경고 해결              
                                                                                                                                                             
  ## 📋 구체적인 내용                                                                                                                                      
  - **추가/변경된 동작**:                                                                                                                                  
    - `LocalizedError` 프로토콜 스펙 불일치 해결: `OnDeviceRepositoryError`, `DeleteOnDeviceRepositoryError`, `MLXModelDataSourceError`,                   
`WhisperDataSourceError`에서 `errorDescription` 리턴 타입을 `String`에서 `String?`(Optional)으로 수정하였습니다.                                           
    - 기존에는 Non-Optional 타입 구현으로 인해 Swift 컴파일러가 프로토콜 기본 구현(`nil`)을 채택하여 에러 로그는 잡히나 UI 단에서 `errorMessage`가 계속    
`nil`이 되는 버그가 있었습니다. 이번 조치로 에러 메시지가 화면에 정상 노출됩니다.                                                                          
    - 디버그 및 에러 전파 개선: `MLXModelProvider` 및 `WhisperKitProvider`에서 실제 에러(URLError 등)를 원활히 던지도록 흐름을 보완하고,                   
`OnBoardingViewModel` 다운로드 시 이전 에러 상태가 남지 않도록 `errorMessage` 초기화 코드를 배치했습니다.                                                  
    - 온디바이스 모델 경로 검사 시 내부 파일 완결성 검사를 수행하여 `WarningConstraints` 등의 상세 분기를 반영하도록 `OnDeviceStatusUseCase` 로직을        
고도화했습니다.                                                                                                                                            
                                                                                                                                                           
  ### 2. 휴지통 모드에서의 음성 노트 상세화면 기능 통제 (`isTrashMode` 도입)                                                                               
  - **추가/변경된 동작**:                                                                                                                                  
    - `AppDIContainer`, `MainCoordinator`, 그리고 각 Coordinator Delegates(`FolderDetail`, `Search`, `Trash`)에 `isTrashMode: Bool` 파라미터를 추가하여    
음성 노트 진입 시 휴지통 상태 여부를 주입하도록 아키텍처를 연동했습니다.                                                                                   
    - **차단되는 기능 (`isTrashMode == true`)**:                                                                                                           
      - **편집 차단**: `VoiceNoteNavigationBar`에서 제목 탭 편집(`titleContainerView.isUserInteractionEnabled = false`)을 막고, 더보기 메뉴(`moreItem` -   
편집하기/이동하기/삭제하기) 노출을 완전히 제외했습니다.                                                                                                    
      - **삭제/이동 차단**: `VoiceNoteViewModel` 내부의 `deleteVoiceNote()`, `moveVoiceNote()` 기능 호출 시 가드문을 추가하여 원천 차단했습니다.           
      - **재생성 차단**: 휴지통 진입 상태일 경우 `VoiceNoteSummaryViewController`에서 재생성(Regeneration) 칩을 노출하지 않도록(`regenerationChipState =   
nil`) 하고, 뷰모델의 `regenerateSummary()`도 가드 차단했습니다.                                                                                            
      - **허용되는 기능**: 뒤로가기(Back), 음성 재생/일시정지/탐색(Seek), 검색(Search) 기능은 정상 동작합니다.                                             
                                                                                                                                                           
  ### 3. 검색바 진입 시 오토 레이아웃 제약 충돌 경고 해결                                                                                                  
  - **추가/변경된 동작**:                                                                                                                                  
    - `VoiceNoteSearchBar.swift`에서 46으로 고정되었던 높이 제약조건의 우선순위를 `.required(1000)`에서 `.init(999)`으로 낮췄습니다.                       
    - 네비게이션 바 내부 컨테이너(`_UINavigationBarTitleControl`)가 트랜지션이나 가로모드/키보드 상태에서 임시 적용하는 시스템 높이 제약(예: 33.33)과      
충돌을 막아, 레이아웃 경고(exited with error code 65 / unsatisfiable constraints) 로그를 근본적으로 제거했습니다.                                          
                                                                                                                                                           
  ### 4. 단위 테스트 및 Mock 동기화                                                                                                                        
  - **추가/변경된 동작**:                                                                                                                                  
    - 시그니처 변경에 맞춰 `MockOnDeviceStatusUseCase` 및 각 테스트 타겟(`FolderDetailViewModelTests`, `MainViewModelTests`,                               
`DownloadOnDeviceViewModelTests`, `SettingViewModelTests`, `TrashViewModelTests`)의 Mock Delegate 구현체를 업데이트하고 동기화했습니다.                    
                                                                                                                                                           
  - **영향 받는 화면/모듈**:                                                                                                                               
    - `Data` / `Domain` 레이어 (에러, 온디바이스 상태 제어)                                                                                                
    - `Presentation` 레이어 (온보딩 다운로드 뷰, 음성 노트 상세 화면, 검색 컴포넌트, 휴지통 연동 부)                                                       
                                                                                                                                                           
  ---                                                                                                                                                      
                                                                                                                                                           
  ## 🧩 설계·구현 노트                                                                                                                                     
  - **선택한 방식**                                                                                                                                        
    - **`LocalizedError` 프로토콜 일치**: 컴파일러 차원에서의 암시적 타입 불일치 버그였기에 커스텀 타입 수정을 통해 프로토콜 본연의 다형성을 유지하도록    
개선했습니다.                                                                                                                                              
    - **우선순위 999 조정**: 오토 레이아웃의 높이 고정 제약은 시스템 네비게이션 바와의 배치 충돌 시 워닝을 발생시키기 때문에, 시스템 제약을 우선하고       
평소에는 고정 높이 46을 깔끔히 유지할 수 있는 최적의 타협점인 999 우선순위를 적용했습니다.
    - **호환성을 살린 isTrashMode 전파**: `makeVoiceNoteViewModel` 및 `pushVoiceNoteView`에 디폴트 아규먼트(`isTrashMode: Bool = false`)를 지정하여, 휴지통
외 기존의 모든 상세 진입 흐름 코드를 건드리지 않고도 휴지통에서 진입하는 특정 라인만 안전하게 제어값을 태우도록 설계했습니다.

  ---

  ## ✅ 확인 사항
  - [x] 정상 플로우 동작 확인
  - [x] 엣지 케이스 / 빈 값·에러 처리 확인
  - [x] (UI 변경 시) 스크린샷 또는 GIF 첨부
  - [x] (로직 추가 시) 테스트 추가 여부

  ---

  ## 👀 리뷰 포인트

  - [x] 설계·구조 적절성
  - [x] 로직·엣지 케이스
  - [x] 예외/에러 핸들링
  - [x] UI/UX (해당 시)
  - [x] 성능·의존성 (해당 시)

  **특히 봐줬으면 하는 부분**
  - 