### PR TITLE
AppStore 심사 거절 솔루션, BackSwipe 활성화합니다

### DIFF
--- a/Presentation/Sources/Component/Common/DownloadModelCard.swift
+++ b/Presentation/Sources/Component/Common/DownloadModelCard.swift
@@ -144,9 +144,7 @@ extension DownloadModelCard {
             case .immutable:
                 immutableProgressView.isHidden = false
             }
-            downloadMessageLabel.isHidden = false
-            downloadMessageLabel.setTypography(text: "다운로드 중...", style: .body2)
-            downloadMessageLabel.textColor = .gray950
+            downloadMessageLabel.isHidden = true
         case .downloaded:
             switch style {
             case .default:

--- a/Presentation/Sources/DesignSystem/UINavigationController+Extensions.swift
+++ b/Presentation/Sources/DesignSystem/UINavigationController+Extensions.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+    
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
+}

--- a/Presentation/Sources/DesignSystem/UINavigationController+Extensions.swift
+++ b/Presentation/Sources/DesignSystem/UINavigationController+Extensions.swift
@@ -1,11 +1,11 @@
 import UIKit
 
 extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         interactivePopGestureRecognizer?.delegate = self
     }
-    
+
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         return viewControllers.count > 1
     }

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
@@ -90,7 +90,8 @@ public final class OnBoardingViewModel {
         case .download:
             switch status.storage {
             case .downloading: return "취소"
-            default: return "이전"
+            case .downloaded: return "이전"
+            default: return "나중에"
             }
         default:
             return "이전"
@@ -174,11 +175,15 @@ extension OnBoardingViewModel {
                 // 다운로드 중일 때는 다운로드 취소
                 downloadTask?.cancel()
                 downloadTask = nil
-            default:
+            case .downloaded:
+                // 이미 다운로드 완료했을 때는 이전 단계로
                 let nextIndex = currentStepIndex - 1
                 guard nextIndex >= 0 else { return }
                 isPaging = true
                 scrollAction(nextIndex)
+            default:
+                // 다운로드 안 했거나 실패했을 때는 '나중에' (다음 단계로 이동)
+                nextPage(scrollAction: scrollAction)
             }
         default: // 뒤로가기
             let nextIndex = currentStepIndex - 1


### PR DESCRIPTION
## ✨ 작업 요약
> 온보딩 단계의 모델 다운로드 건너뛰기 기능 추가

- 온보딩 과정에서 모델 다운로드를 건너뛸 수 있는 우회로("나중에" 버튼)를 추가하여 심사 중 무한 대기 현상을 예방합니다.

## 📋 구체적인 내용
- **추가/변경된 동작**:
  - **다운로드 건너뛰기 ("나중에") 기능 제공**: 온보딩 중 AI 모델 다운로드 단계에서 다운로드하지 않았거나 취소/실패했을 때, 왼쪽 하단 버튼을 `"나중에"`로 변경하고 클릭 시 다음 화면(언어 설정)으로 자동 스크롤(앞으로 이동)하도록 대응했습니다.
  - **다운로드 중 UI 클리닝**: 모델 카드(`DownloadModelCard`)가 다운로드 중인 상태(`downloading`)일 때, "다운로드 중..." 텍스트 라벨을 숨김 처리(`isHidden = true`)하여 프로그레스 바만 심플하게 표시되도록 정리했습니다.
  - **언어 선택 터치 영역 확대 (Guideline 4.0 대응)**: `LanguagePicker` 내부의 언어 행(`LanguageItemView`)의 텍스트 레이블 상하에 12pt의 여백을 두어, 애플의 휴먼 인터페이스 가이드라인(HUI)에 부합하도록 최소 44pt 이상의 세로 터치 영역을 확보했습니다.
- **영향 받는 화면/모듈**:
  - `Presentation` 모듈 내의 온보딩 화면 (`OnBoardingViewController`, `OnBoardingViewModel`, `OnBoardingDownloadView`)
  - 공용 컴포넌트 (`DownloadModelCard`, `LanguagePicker`)

---

## 🔗 연관 이슈

- closed #269

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
  - 온보딩 과정에서 1.5GB가 넘는 대용량 AI 모델 다운로드를 **우회 가능(Optional)**하게 변경하여 네트워크 차단 또는 비정상적인 지연 상황에서도 앱 진입이 막히지 않도록(Guideline 2.1(a) 대응) 설계했습니다.
  - 사용자가 "나중에"를 누르면 메인 화면 진입 후 설정(Settings) 탭에서 언제든 필요할 때 온디바이스 모델을 다운로드받을 수 있어 유연한 UX를 보장합니다.
- **고려했다가 제외한 방식**
  - 다운로드 화면 자체를 아예 생략하는 방식: 기기 성능에 맞춰 온디바이스 요약 처리를 원하는 유저들을 위해 기본 다운로드 진입 기능은 유지하는 편이 좋으므로, 화면을 없애기보다는 사용자가 건너뛸 수 있도록 '취소' 및 '나중에' 옵션을 부여하는 방식으로 설계했습니다.

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [x] 정상 플로우 동작 확인
- [x] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [ ] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [x] 로직·엣지 케이스
- [x] 예외/에러 핸들링
- [x] UI/UX (해당 시)

**특히 봐줬으면 하는 부분**

- 다운로드 취소/실패 상태에 따른 하단 버튼 타이틀("나중에", "재시도", "취소")과 그에 매칭된 페이지 이동 동작(`secondButtonAction`에서의 `nextPage` 호출)이 올바른 방향으로 작동하는지 확인 부탁드립니다.

---

## 📚 참고

- [App Store Review Guidelines - 2.1 Performance](https://developer.apple.com/app-store/review/guidelines/#performance)
- [App Store Review Guidelines - 4.0 Design](https://developer.apple.com/app-store/review/guidelines/#design)
