### PR TITLE
온보딩 UX 리펙토링 합니다.

### DIFF
--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -112,7 +112,8 @@ extension MainCoordinator: MainCoordinatorDelegate {
                 navController.setViewControllers([downloadVC], animated: false)
 
                 if let sheet = navController.sheetPresentationController {
-                    let isPad = UIDevice.current.userInterfaceIdiom == .pad || UIDevice.current.model.lowercased().contains("ipad")
+                    let isPad = UIDevice.current.userInterfaceIdiom == .pad || UIDevice.current.model.lowercased()
+                        .contains("ipad")
                     sheet.detents = isPad ? [.large()] : [.medium()]
                     sheet.prefersGrabberVisible = true
                 }

--- a/App/Sources/Coordinator/MainCoordinator.swift
+++ b/App/Sources/Coordinator/MainCoordinator.swift
@@ -112,7 +112,8 @@ extension MainCoordinator: MainCoordinatorDelegate {
                 navController.setViewControllers([downloadVC], animated: false)
 
                 if let sheet = navController.sheetPresentationController {
-                    sheet.detents = [.medium()]
+                    let isPad = UIDevice.current.userInterfaceIdiom == .pad || UIDevice.current.model.lowercased().contains("ipad")
+                    sheet.detents = isPad ? [.large()] : [.medium()]
                     sheet.prefersGrabberVisible = true
                 }
             }

--- a/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
+++ b/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
@@ -38,22 +38,22 @@ public actor WhisperKitProvider: WhisperDataSource {
         AppLogger.info("WhisperKit 추천 모델 : \(recommendedModel)")
         AppLogger.info("WhisperKit 모델 다운로드 시작")
 
-//        #if DEBUG
-//            // ⚠️ 디버깅용 시뮬레이션: 에러 상황별 핸들링을 안전하게 테스트하기 위한 디버그 스위치입니다.
-//            try await Task.sleep(nanoseconds: 2 * 1_000_000_000)
-//
-//            // [옵션 1] 네트워크 오류 시뮬레이션 (networkFailed)
-//            // -> 활성화 시 "네트워크 연결이 유실되었습니다" 문구가 노출됩니다.
-//            // throw URLError(.notConnectedToInternet)
-//
-//            // [옵션 2] 알 수 없는 시스템 오류 시뮬레이션 (unknown)
-//            // -> 활성화 시 "다운로드에 실패했습니다" 문구와 상세 에러 문구가 노출됩니다.
-//            throw NSError(
-//                domain: "SimulatedErrorDomain",
-//                code: 999,
-//                userInfo: [NSLocalizedDescriptionKey: "알 수 없는 기기 내부 디스크 쓰기 오류가 발생했습니다. (Simulated)"]
-//            )
-//        #endif
+        #if DEBUG
+            // ⚠️ 디버깅용 시뮬레이션: 에러 상황별 핸들링을 안전하게 테스트하기 위한 디버그 스위치입니다.
+            try await Task.sleep(nanoseconds: 2 * 1_000_000_000)
+
+            // [옵션 1] 네트워크 오류 시뮬레이션 (networkFailed)
+            // -> 활성화 시 "네트워크 연결이 유실되었습니다" 문구가 노출됩니다.
+            // throw URLError(.notConnectedToInternet)
+
+            // [옵션 2] 알 수 없는 시스템 오류 시뮬레이션 (unknown)
+            // -> 활성화 시 "다운로드에 실패했습니다" 문구와 상세 에러 문구가 노출됩니다.
+            throw NSError(
+                domain: "SimulatedErrorDomain",
+                code: 999,
+                userInfo: [NSLocalizedDescriptionKey: "알 수 없는 기기 내부 디스크 쓰기 오류가 발생했습니다. (Simulated)"]
+            )
+        #endif
 
         let path = try await WhisperKit.download(
             variant: recommendedModel,

--- a/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
+++ b/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
@@ -31,7 +31,7 @@ public actor WhisperKitProvider: WhisperDataSource {
         let recommended = WhisperKit.recommendedModels().default
         return ModelVariant.allCases.first { recommended.lowercased().contains($0.description.lowercased()) } ?? .tiny
     }
-    
+
     public func download(progressHandler: @Sendable @escaping (Progress) -> Void) async throws {
         let recommendedModel = WhisperKit.recommendedModels().default
         self.recommendedModel = recommendedModel

--- a/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
+++ b/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
@@ -38,22 +38,22 @@ public actor WhisperKitProvider: WhisperDataSource {
         AppLogger.info("WhisperKit 추천 모델 : \(recommendedModel)")
         AppLogger.info("WhisperKit 모델 다운로드 시작")
 
-        #if DEBUG
-            // ⚠️ 디버깅용 시뮬레이션: 에러 상황별 핸들링을 안전하게 테스트하기 위한 디버그 스위치입니다.
-            try await Task.sleep(nanoseconds: 2 * 1_000_000_000)
+        // #if DEBUG
+        //     // ⚠️ 디버깅용 시뮬레이션: 에러 상황별 핸들링을 안전하게 테스트하기 위한 디버그 스위치입니다.
+        //     try await Task.sleep(nanoseconds: 2 * 1_000_000_000)
 
-            // [옵션 1] 네트워크 오류 시뮬레이션 (networkFailed)
-            // -> 활성화 시 "네트워크 연결이 유실되었습니다" 문구가 노출됩니다.
-            // throw URLError(.notConnectedToInternet)
+        //     // [옵션 1] 네트워크 오류 시뮬레이션 (networkFailed)
+        //     // -> 활성화 시 "네트워크 연결이 유실되었습니다" 문구가 노출됩니다.
+        //     // throw URLError(.notConnectedToInternet)
 
-            // [옵션 2] 알 수 없는 시스템 오류 시뮬레이션 (unknown)
-            // -> 활성화 시 "다운로드에 실패했습니다" 문구와 상세 에러 문구가 노출됩니다.
-            throw NSError(
-                domain: "SimulatedErrorDomain",
-                code: 999,
-                userInfo: [NSLocalizedDescriptionKey: "알 수 없는 기기 내부 디스크 쓰기 오류가 발생했습니다. (Simulated)"]
-            )
-        #endif
+        //     // [옵션 2] 알 수 없는 시스템 오류 시뮬레이션 (unknown)
+        //     // -> 활성화 시 "다운로드에 실패했습니다" 문구와 상세 에러 문구가 노출됩니다.
+        //     throw NSError(
+        //         domain: "SimulatedErrorDomain",
+        //         code: 999,
+        //         userInfo: [NSLocalizedDescriptionKey: "알 수 없는 기기 내부 디스크 쓰기 오류가 발생했습니다. (Simulated)"]
+        //     )
+        // #endif
 
         let path = try await WhisperKit.download(
             variant: recommendedModel,

--- a/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
+++ b/Data/Sources/Infrastructure/OnDevice/Whisper/WhisperKitProvider.swift
@@ -27,6 +27,11 @@ public actor WhisperKitProvider: WhisperDataSource {
         self.languageRepository = languageRepository
     }
 
+    public func fetchModelVariant() async -> ModelVariant {
+        let recommended = WhisperKit.recommendedModels().default
+        return ModelVariant.allCases.first { recommended.lowercased().contains($0.description.lowercased()) } ?? .tiny
+    }
+    
     public func download(progressHandler: @Sendable @escaping (Progress) -> Void) async throws {
         let recommendedModel = WhisperKit.recommendedModels().default
         self.recommendedModel = recommendedModel

--- a/Data/Sources/Interfaces/Whisper/WhisperDataSource.swift
+++ b/Data/Sources/Interfaces/Whisper/WhisperDataSource.swift
@@ -5,7 +5,7 @@ import WhisperKit
 public protocol WhisperDataSource: Sendable {
     /// 추천 모델의 Variant 정보를 가져옵니다.
     func fetchModelVariant() async -> ModelVariant
-    
+
     /// 모델의 다운로드 경로를 전달합니다.
     func getDownloadPath() async throws(WhisperDataSourceError) -> URL
 

--- a/Data/Sources/Interfaces/Whisper/WhisperDataSource.swift
+++ b/Data/Sources/Interfaces/Whisper/WhisperDataSource.swift
@@ -3,6 +3,9 @@ import WhisperKit
 
 /// Whisper STT 모델 엔진을 제어하고 음성 전사 데이터를 제공하는 데이터 소스 인터페이스.
 public protocol WhisperDataSource: Sendable {
+    /// 추천 모델의 Variant 정보를 가져옵니다.
+    func fetchModelVariant() async -> ModelVariant
+    
     /// 모델의 다운로드 경로를 전달합니다.
     func getDownloadPath() async throws(WhisperDataSourceError) -> URL
 

--- a/Data/Sources/Repositories/OnDevice/DefaultMlxOnDeviceRepository.swift
+++ b/Data/Sources/Repositories/OnDevice/DefaultMlxOnDeviceRepository.swift
@@ -11,6 +11,12 @@ public final class DefaultMlxOnDeviceRepository: OnDeviceRepository {
         self.provider = provider
     }
 
+    public var modelSize: String {
+        get async {
+            return "약 3.58 GB"
+        }
+    }
+
     public func download(progressHandler: @Sendable @escaping (Double) -> Void) async throws(OnDeviceRepositoryError) {
         do {
             try await provider.download { progress in

--- a/Data/Sources/Repositories/OnDevice/DefaultWhisperOnDeviceRepository.swift
+++ b/Data/Sources/Repositories/OnDevice/DefaultWhisperOnDeviceRepository.swift
@@ -29,7 +29,7 @@ public struct DefaultWhisperOnDeviceRepository: OnDeviceRepository {
             }
         }
     }
-    
+
     public func download(progressHandler: @Sendable @escaping (Double) -> Void) async throws(OnDeviceRepositoryError) {
         do {
             try await provider.download { progress in

--- a/Data/Sources/Repositories/OnDevice/DefaultWhisperOnDeviceRepository.swift
+++ b/Data/Sources/Repositories/OnDevice/DefaultWhisperOnDeviceRepository.swift
@@ -12,6 +12,24 @@ public struct DefaultWhisperOnDeviceRepository: OnDeviceRepository {
         self.provider = provider
     }
 
+    public var modelSize: String {
+        get async {
+            let variant = await provider.fetchModelVariant()
+            switch variant {
+            case .tiny, .tinyEn:
+                return "약 75 MB"
+            case .base, .baseEn:
+                return "약 142 MB"
+            case .small, .smallEn:
+                return "약 466 MB"
+            case .medium, .mediumEn:
+                return "약 1.5 GB"
+            case .large, .largev2, .largev3:
+                return "약 3.0 GB"
+            }
+        }
+    }
+    
     public func download(progressHandler: @Sendable @escaping (Double) -> Void) async throws(OnDeviceRepositoryError) {
         do {
             try await provider.download { progress in

--- a/Domain/Sources/Interfaces/OnDevice/OnDeviceRepository.swift
+++ b/Domain/Sources/Interfaces/OnDevice/OnDeviceRepository.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public protocol OnDeviceRepository: Sendable {
+    /// 모델의 용량을 노출합니다.
+    var modelSize: String { get async }
     /// 모델 파일을 다운로드하여 로컬 캐시에 저장합니다. (메모리 적재 X)
     func download(progressHandler: @Sendable @escaping (Double) -> Void) async throws(OnDeviceRepositoryError)
     /// 모델을 제거합니다.

--- a/Domain/Sources/UseCases/OnDevice/OnDeviceStatusUseCase.swift
+++ b/Domain/Sources/UseCases/OnDevice/OnDeviceStatusUseCase.swift
@@ -10,6 +10,8 @@ public protocol OnDeviceStatusUseCase: Sendable {
     func delete(model: ChaGokModel) async throws(DeleteOnDeviceRepositoryError)
     /// 현재 상태 조회
     func checkStatus(model: ChaGokModel) async -> OnDeviceStatus
+    /// 모델의 용량 정보를 조회합니다
+    func fetchModelSize(model: ChaGokModel) async -> String
 }
 
 public actor DefaultOnDeviceStatusUseCase: OnDeviceStatusUseCase {
@@ -145,6 +147,11 @@ public actor DefaultOnDeviceStatusUseCase: OnDeviceStatusUseCase {
             return status
         }
         return OnDeviceStatus(storage: .notDownloaded)
+    }
+
+    public func fetchModelSize(model: ChaGokModel) async -> String {
+        guard let repo = repo(for: model) else { return "" }
+        return await repo.modelSize
     }
 
     private func syncStatus(model: ChaGokModel) async {

--- a/Domain/Testing/Interfaces/Mocks/OnDevice/MockOnDeviceRepository.swift
+++ b/Domain/Testing/Interfaces/Mocks/OnDevice/MockOnDeviceRepository.swift
@@ -6,6 +6,12 @@ import XCTest
 public final class MockOnDeviceRepository: OnDeviceRepository {
     public init() {}
 
+    public var modelSize: String {
+        get async {
+            "0 MB"
+        }
+    }
+
     public var downloadResult: Result<Void, OnDeviceRepositoryError> = .success(())
     public var deleteResult: Result<OnDeviceStatus, DeleteOnDeviceRepositoryError> = .success(OnDeviceStatus(
         storage: .notDownloaded

--- a/Domain/Testing/Interfaces/Mocks/OnDevice/MockOnDeviceStatusUseCase.swift
+++ b/Domain/Testing/Interfaces/Mocks/OnDevice/MockOnDeviceStatusUseCase.swift
@@ -31,6 +31,10 @@ public final class MockOnDeviceStatusUseCase: OnDeviceStatusUseCase, @unchecked 
         return checkStatusResult
     }
 
+    public func fetchModelSize(model: ChaGokModel) async -> String {
+        return "약 75 MB"
+    }
+
     public func subscribe(model: ChaGokModel) async -> AsyncStream<OnDeviceStatus> {
         actualSubscribeCallCount += 1
         subscribedModel = model

--- a/Presentation/Sources/Component/Common/DownloadModelCard.swift
+++ b/Presentation/Sources/Component/Common/DownloadModelCard.swift
@@ -101,7 +101,7 @@ extension DownloadModelCard {
         let container = UIStackView()
         let imageView = UIImageView()
         let nameLabel = UILabel()
-        
+
         for item in [container, imageView, nameLabel, sizeLabel] {
             item.translatesAutoresizingMaskIntoConstraints = false
         }

--- a/Presentation/Sources/Component/Common/DownloadModelCard.swift
+++ b/Presentation/Sources/Component/Common/DownloadModelCard.swift
@@ -75,6 +75,9 @@ final class DownloadModelCard: UIStackView {
         isLayoutMarginsRelativeArrangement = true
 
         addArrangedSubview(modelLabel)
+        modelLabel.setContentHuggingPriority(.required, for: .vertical)
+        modelLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+
         switch style {
         case .default:
             addArrangedSubview(defaultProgressView)
@@ -109,6 +112,8 @@ extension DownloadModelCard {
         // nameLabel
         nameLabel.setTypography(text: modelName, style: .body2)
         nameLabel.textColor = UIColor.gray950
+        nameLabel.setContentHuggingPriority(.required, for: .vertical)
+        nameLabel.setContentCompressionResistancePriority(.required, for: .vertical)
         // imageView
         let config: UIImage.SymbolConfiguration = .init(pointSize: 20, weight: .medium)
         imageView.image = UIImage(systemName: symbolName, withConfiguration: config)
@@ -121,6 +126,8 @@ extension DownloadModelCard {
         let spacer = UIView()
         // model size
         sizeLabel.setTypography(text: modelSize, style: .label)
+        sizeLabel.setContentHuggingPriority(.required, for: .vertical)
+        sizeLabel.setContentCompressionResistancePriority(.required, for: .vertical)
         for item in [imageView, nameLabel, spacer, sizeLabel] {
             container.addArrangedSubview(item)
         }

--- a/Presentation/Sources/Component/Common/DownloadModelCard.swift
+++ b/Presentation/Sources/Component/Common/DownloadModelCard.swift
@@ -8,6 +8,14 @@ final class DownloadModelCard: UIStackView {
     let style: ProgressStyle
     var storage: OnDeviceStatus.StorageState
     var errorMessage: String?
+    var modelSize: String
+
+    private let sizeLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = UIColor.point800
+        return label
+    }()
 
     // MARK: - Initialize
 
@@ -17,6 +25,7 @@ final class DownloadModelCard: UIStackView {
         style: ProgressStyle,
         storage: OnDeviceStatus.StorageState,
         errorMessage: String? = nil,
+        modelSize: String = "",
         frame: CGRect = .zero
     ) {
         self.symbolName = symbolName
@@ -24,6 +33,7 @@ final class DownloadModelCard: UIStackView {
         self.style = style
         self.storage = storage
         self.errorMessage = errorMessage
+        self.modelSize = modelSize
         super.init(frame: frame)
         setup()
     }
@@ -91,8 +101,8 @@ extension DownloadModelCard {
         let container = UIStackView()
         let imageView = UIImageView()
         let nameLabel = UILabel()
-
-        for item in [container, imageView, nameLabel] {
+        
+        for item in [container, imageView, nameLabel, sizeLabel] {
             item.translatesAutoresizingMaskIntoConstraints = false
         }
 
@@ -109,7 +119,9 @@ extension DownloadModelCard {
         container.spacing = 8
         // spacer
         let spacer = UIView()
-        for item in [imageView, nameLabel, spacer] {
+        // model size
+        sizeLabel.setTypography(text: modelSize, style: .label)
+        for item in [imageView, nameLabel, spacer, sizeLabel] {
             container.addArrangedSubview(item)
         }
 
@@ -120,9 +132,13 @@ extension DownloadModelCard {
 // MARK: - Update
 
 extension DownloadModelCard {
-    func updateStatus(_ storage: OnDeviceStatus.StorageState, errorMessage: String?) {
+    func updateStatus(_ storage: OnDeviceStatus.StorageState, errorMessage: String?, modelSize: String? = nil) {
         self.storage = storage
         self.errorMessage = errorMessage
+        if let modelSize {
+            self.modelSize = modelSize
+            sizeLabel.setTypography(text: modelSize, style: .label)
+        }
         setNeedsUpdateProperties()
     }
 

--- a/Presentation/Sources/Component/OnBoarding/OnBoardingCardView.swift
+++ b/Presentation/Sources/Component/OnBoarding/OnBoardingCardView.swift
@@ -63,12 +63,16 @@ extension OnBoardingCardView {
         translatesAutoresizingMaskIntoConstraints = false
         axis = .vertical
         spacing = Constant.onBoardingContentSpacing
-
         // headline·body는 intrinsic size만 차지하고,
         // 남는 수직 공간은 imageContainer가 흡수하도록 설정
         headlineLabel.setContentHuggingPriority(.required, for: .vertical)
         bodyLabel.setContentHuggingPriority(.required, for: .vertical)
         imageContainer.setContentHuggingPriority(.defaultLow, for: .vertical)
+
+        // 텍스트가 어떤 상황에서도 잘리거나 찌그러지지 않도록 높은 압축 저항 우선순위 설정
+        headlineLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+        bodyLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+        imageContainer.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
     }
 
     private func setupHierarchy() {

--- a/Presentation/Sources/Component/OnBoarding/OnBoardingDownloadView.swift
+++ b/Presentation/Sources/Component/OnBoarding/OnBoardingDownloadView.swift
@@ -37,7 +37,7 @@ final class OnBoardingDownloadView: UIStackView {
         storage: vm.status.storage,
         modelSize: vm.modelSize
     )
-    
+
     private lazy var timeLineGuideLabel: TimelineGuideLabel = .init(state: .notDownloaded)
 
     /// 남는 수직 공간을 흡수하는 빈 뷰 (OnBoardingCardView의 imageContainer 역할)

--- a/Presentation/Sources/Component/OnBoarding/OnBoardingDownloadView.swift
+++ b/Presentation/Sources/Component/OnBoarding/OnBoardingDownloadView.swift
@@ -37,6 +37,8 @@ final class OnBoardingDownloadView: UIStackView {
         storage: vm.status.storage,
         modelSize: vm.modelSize
     )
+    
+    private lazy var timeLineGuideLabel: TimelineGuideLabel = .init(state: .notDownloaded)
 
     /// 남는 수직 공간을 흡수하는 빈 뷰 (OnBoardingCardView의 imageContainer 역할)
     private let spacerView = UIView()
@@ -66,6 +68,7 @@ final class OnBoardingDownloadView: UIStackView {
         super.updateProperties()
         let storage = vm.status.storage
         downloadModelCard.updateStatus(storage, errorMessage: vm.errorMessage)
+        timeLineGuideLabel.updateLabelState(storage)
     }
 }
 
@@ -76,18 +79,29 @@ extension OnBoardingDownloadView {
         translatesAutoresizingMaskIntoConstraints = false
         axis = .vertical
         spacing = Constant.onBoardingContentSpacing
-
         // headline·body는 intrinsic size만 차지하고,
         // 남는 수직 공간은 imageContainer가 흡수하도록 설정
         headlineLabel.setContentHuggingPriority(.required, for: .vertical)
         bodyLabel.setContentHuggingPriority(.required, for: .vertical)
         downloadModelCard.setContentHuggingPriority(.required, for: .vertical)
+        timeLineGuideLabel.setContentHuggingPriority(.required, for: .vertical)
+        spacerView.setContentHuggingPriority(.defaultLow, for: .vertical)
+
+        // 텍스트 및 카드 찌그러짐 방지 제약조건 추가
+        headlineLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+        bodyLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+        downloadModelCard.setContentCompressionResistancePriority(.required, for: .vertical)
+        timeLineGuideLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+        spacerView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
     }
 
     private func setupHierarchy() {
         addArrangedSubview(headlineLabel)
         addArrangedSubview(bodyLabel)
         addArrangedSubview(downloadModelCard)
+        setCustomSpacing(0, after: downloadModelCard)
         addArrangedSubview(spacerView)
+        setCustomSpacing(0, after: spacerView)
+        addArrangedSubview(timeLineGuideLabel)
     }
 }

--- a/Presentation/Sources/Component/OnBoarding/OnBoardingDownloadView.swift
+++ b/Presentation/Sources/Component/OnBoarding/OnBoardingDownloadView.swift
@@ -34,7 +34,8 @@ final class OnBoardingDownloadView: UIStackView {
         symbolName: "externaldrive",
         modelName: "Gemma-4",
         style: .immutable,
-        storage: vm.status.storage
+        storage: vm.status.storage,
+        modelSize: vm.modelSize
     )
 
     /// 남는 수직 공간을 흡수하는 빈 뷰 (OnBoardingCardView의 imageContainer 역할)

--- a/Presentation/Sources/Component/OnBoarding/TimelineGuideLabel.swift
+++ b/Presentation/Sources/Component/OnBoarding/TimelineGuideLabel.swift
@@ -1,11 +1,11 @@
-import UIKit
 import Domain
+import UIKit
 
 final class TimelineGuideLabel: UILabel {
     private var timer: Timer?
     private var state: OnDeviceStatus.StorageState = .notDownloaded
     private var index: Int = 0
-    
+
     init(
         state: OnDeviceStatus.StorageState,
         frame: CGRect = .zero
@@ -14,30 +14,30 @@ final class TimelineGuideLabel: UILabel {
         super.init(frame: frame)
         setup()
     }
-    
+
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         nil
     }
-    
+
     override func updateProperties() {
         super.updateProperties()
         updateState()
     }
-    
+
     private func setup() {
         translatesAutoresizingMaskIntoConstraints = false
         textColor = UIColor.gray950
         numberOfLines = 0
         clipsToBounds = true
     }
-    
+
     func updateLabelState(_ state: OnDeviceStatus.StorageState) {
         guard self.state != state else { return }
         self.state = state
         setNeedsUpdateProperties()
     }
-    
+
     private func updateState() {
         switch state {
         case .notDownloaded, .downloaded, .failed:
@@ -46,15 +46,15 @@ final class TimelineGuideLabel: UILabel {
             startTimer()
         }
     }
-    
+
     /// timeLine을 시작합니다.
     private func startTimer() {
         guard timer == nil else { return }
-        
+
         // 시작하자마자 첫 텍스트가 바로 보이도록 설정
         index = 0
         updateLabel(animated: false)
-        
+
         // 4초 주기로 텍스트 롤링 타이머 구동
         timer = Timer.scheduledTimer(withTimeInterval: 4.0, repeats: true) { [weak self] _ in
             Task { @MainActor in
@@ -64,7 +64,7 @@ final class TimelineGuideLabel: UILabel {
             }
         }
     }
-    
+
     /// timeLine의 진행을 멈춥니다.
     private func stopTimer() {
         timer?.invalidate()
@@ -73,28 +73,28 @@ final class TimelineGuideLabel: UILabel {
         alpha = 1
         transform = .identity
     }
-    
+
     /// 텍스트 업데이트 및 아래에서 위로 올라오는 전환 효과 적용
     private func updateLabel(animated: Bool) {
         let nextText = toolTips[index % toolTips.count]
-        
+
         if animated {
             UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseIn, animations: {
                 self.alpha = 0
                 self.transform = CGAffineTransform(translationX: 0, y: -12)
             }) { [weak self] _ in
                 guard let self else { return }
-                self.text = nextText
-                self.setTypography(text: nextText, style: .body3, textAlignment: .center)
-                self.transform = CGAffineTransform(translationX: 0, y: 12)
-                
+                text = nextText
+                setTypography(text: nextText, style: .body3, textAlignment: .center)
+                transform = CGAffineTransform(translationX: 0, y: 12)
+
                 UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseOut, animations: {
                     self.alpha = 1
                     self.transform = .identity
                 })
             }
         } else {
-            self.text = nextText
+            text = nextText
             setTypography(text: text, style: .body3, textAlignment: .center)
         }
     }

--- a/Presentation/Sources/Component/OnBoarding/TimelineGuideLabel.swift
+++ b/Presentation/Sources/Component/OnBoarding/TimelineGuideLabel.swift
@@ -1,0 +1,115 @@
+import UIKit
+import Domain
+
+final class TimelineGuideLabel: UILabel {
+    private var timer: Timer?
+    private var state: OnDeviceStatus.StorageState = .notDownloaded
+    private var index: Int = 0
+    
+    init(
+        state: OnDeviceStatus.StorageState,
+        frame: CGRect = .zero
+    ) {
+        self.state = state
+        super.init(frame: frame)
+        setup()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+    
+    override func updateProperties() {
+        super.updateProperties()
+        updateState()
+    }
+    
+    private func setup() {
+        translatesAutoresizingMaskIntoConstraints = false
+        textColor = UIColor.gray950
+        numberOfLines = 0
+        clipsToBounds = true
+    }
+    
+    func updateLabelState(_ state: OnDeviceStatus.StorageState) {
+        guard self.state != state else { return }
+        self.state = state
+        setNeedsUpdateProperties()
+    }
+    
+    private func updateState() {
+        switch state {
+        case .notDownloaded, .downloaded, .failed:
+            stopTimer()
+        case .downloading:
+            startTimer()
+        }
+    }
+    
+    /// timeLine을 시작합니다.
+    private func startTimer() {
+        guard timer == nil else { return }
+        
+        // 시작하자마자 첫 텍스트가 바로 보이도록 설정
+        index = 0
+        updateLabel(animated: false)
+        
+        // 4초 주기로 텍스트 롤링 타이머 구동
+        timer = Timer.scheduledTimer(withTimeInterval: 4.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                self.index += 1
+                self.updateLabel(animated: true)
+            }
+        }
+    }
+    
+    /// timeLine의 진행을 멈춥니다.
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+        text = "" // 다운로드 중이 아닐 때는 표시하지 않음
+        alpha = 1
+        transform = .identity
+    }
+    
+    /// 텍스트 업데이트 및 아래에서 위로 올라오는 전환 효과 적용
+    private func updateLabel(animated: Bool) {
+        let nextText = toolTips[index % toolTips.count]
+        
+        if animated {
+            UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseIn, animations: {
+                self.alpha = 0
+                self.transform = CGAffineTransform(translationX: 0, y: -12)
+            }) { [weak self] _ in
+                guard let self else { return }
+                self.text = nextText
+                self.setTypography(text: nextText, style: .body3, textAlignment: .center)
+                self.transform = CGAffineTransform(translationX: 0, y: 12)
+                
+                UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseOut, animations: {
+                    self.alpha = 1
+                    self.transform = .identity
+                })
+            }
+        } else {
+            self.text = nextText
+            setTypography(text: text, style: .body3, textAlignment: .center)
+        }
+    }
+}
+
+extension TimelineGuideLabel {
+    /// timeline을 통해 보여줄 데이터
+    private var toolTips: [String] {
+        [
+            "차곡의 모든 인공지능 요약 연산은 기기 안에서만 처리돼요.\n내 소중한 대화 내용이 절대 외부 서버로 전송되거나 유출되지 않으니 안심하세요!",
+            "다운로드가 완료되면 인터넷이 연결되지 않은 비행기 모드나 데이터가 터지지 않는 깊은 산속에서도 음성 인식과 요약 기능을 그대로 사용할 수 있어요.",
+            "길게 녹음된 음성을 처음부터 다 들을 필요 없어요.\n차곡의 AI가 회의나 대화의 핵심 내용과 키워드만 일목요연하게 요약해 줍니다.",
+            "실수로 삭제한 소중한 기록은 휴지통 폴더에 보관돼요.\n완전히 지워지기 전이라면 언제든 터치 한 번으로 복구할 수 있어요.",
+            "폴더 기능을 활용해 회의록, 아이디어 노트, 강의 녹음 등 주제별로 정리해 보세요.\n정돈된 분류는 나중에 기록을 다시 꺼내볼 때 시간을 절약해 줘요.",
+            "안정적인 설치를 위해 기기에 약 4GB 이상의 여유 공간이 필요해요.\n다운로드가 원활하지 않다면 기기의 저장 공간을 직접 정리해 주세요."
+        ]
+    }
+}

--- a/Presentation/Sources/DesignSystem/Constant.swift
+++ b/Presentation/Sources/DesignSystem/Constant.swift
@@ -100,7 +100,7 @@ public extension Constant {
 
     /// OnBoarding 페이지네이션과 페이징뷰 사이의 상단 여백 (105)
     static let onBoardingPagingViewTopMargin: CGFloat = 105
-    
+
     /// OnBoarding IPad 용 페징 뷰 사이 상단 여백 ( 52 )
     static let onBoardingPagingViewTopMarginForiPad: CGFloat = 52
 

--- a/Presentation/Sources/DesignSystem/Constant.swift
+++ b/Presentation/Sources/DesignSystem/Constant.swift
@@ -100,6 +100,9 @@ public extension Constant {
 
     /// OnBoarding 페이지네이션과 페이징뷰 사이의 상단 여백 (105)
     static let onBoardingPagingViewTopMargin: CGFloat = 105
+    
+    /// OnBoarding IPad 용 페징 뷰 사이 상단 여백 ( 52 )
+    static let onBoardingPagingViewTopMarginForiPad: CGFloat = 52
 
     /// OnBoarding 페이징뷰와 버튼 사이의 하단 여백 (16)
     static let onBoardingPagingViewBottomMargin: CGFloat = 16

--- a/Presentation/Sources/View/OnBoarding/OnBoardingViewController.swift
+++ b/Presentation/Sources/View/OnBoarding/OnBoardingViewController.swift
@@ -69,12 +69,14 @@ public final class OnBoardingViewController: ViewController {
         // 버튼 상태 업데이트
         primaryButton.configuration?.title = vm.primaryButtonTitle
         primaryButton.isHidden = !vm.isPrimaryButtonEnabled
-        secondButton.configuration?.title = vm.secondButtonTitle
-        secondButton.isUserInteractionEnabled = vm.isSecondButtonEnabled
         primaryButton.configuration?.baseBackgroundColor = vm
             .isPrimaryButtonBgColor ? UIColor.point600 : UIColor.point200
             .withAlphaComponent(Constant.backgroundOpacity)
-        primaryButton.configuration?.baseForegroundColor = UIColor.gray900
+        secondButton.configuration?.title = vm.secondButtonTitle
+        secondButton.isUserInteractionEnabled = vm.isSecondButtonEnabled
+        secondButton.configuration?.background.backgroundColor = vm
+            .isSecondButtonBgColor ? UIColor.point600 : .clear
+        secondButton.configuration?.baseForegroundColor = vm.isSecondButtonBgColor ? UIColor.gray950 : UIColor.gray750
         // paginView
         pagingView.isScrollEnabled = vm.scrollEnabled
         // pagenation 업데이트
@@ -129,11 +131,14 @@ public final class OnBoardingViewController: ViewController {
     // MARK: - Constraint
 
     private func setupCardConstraint() {
+        let isPad = UIDevice.current.userInterfaceIdiom == .pad || UIDevice.current.model.lowercased().contains("ipad")
+        let topConstant: CGFloat = isPad ? Constant.onBoardingPagingViewTopMarginForiPad : Constant.onBoardingPagingViewTopMargin
+
         NSLayoutConstraint.activate([
             // 페이징 뷰 위치 제약 (페이지네이션과 다음 버튼 사이)
             pagingView.topAnchor.constraint(
                 equalTo: pagenation.bottomAnchor,
-                constant: Constant.onBoardingPagingViewTopMargin
+                constant: topConstant
             ),
             pagingView.leadingAnchor.constraint(
                 equalTo: view.leadingAnchor,

--- a/Presentation/Sources/View/OnBoarding/OnBoardingViewController.swift
+++ b/Presentation/Sources/View/OnBoarding/OnBoardingViewController.swift
@@ -68,12 +68,11 @@ public final class OnBoardingViewController: ViewController {
 
         // 버튼 상태 업데이트
         primaryButton.configuration?.title = vm.primaryButtonTitle
-        primaryButton.isUserInteractionEnabled = vm.isPrimaryButtonEnabled
+        primaryButton.isHidden = !vm.isPrimaryButtonEnabled
         secondButton.configuration?.title = vm.secondButtonTitle
         secondButton.isUserInteractionEnabled = vm.isSecondButtonEnabled
         primaryButton.configuration?.baseBackgroundColor = vm
-            .isPrimaryButtonBgColor ? (vm.isPrimaryButtonEnabled ? UIColor.point600 : UIColor.gray600) : UIColor
-            .point200
+            .isPrimaryButtonBgColor ? UIColor.point600 : UIColor.point200
             .withAlphaComponent(Constant.backgroundOpacity)
         primaryButton.configuration?.baseForegroundColor = UIColor.gray900
         // paginView

--- a/Presentation/Sources/View/OnBoarding/OnBoardingViewController.swift
+++ b/Presentation/Sources/View/OnBoarding/OnBoardingViewController.swift
@@ -132,7 +132,8 @@ public final class OnBoardingViewController: ViewController {
 
     private func setupCardConstraint() {
         let isPad = UIDevice.current.userInterfaceIdiom == .pad || UIDevice.current.model.lowercased().contains("ipad")
-        let topConstant: CGFloat = isPad ? Constant.onBoardingPagingViewTopMarginForiPad : Constant.onBoardingPagingViewTopMargin
+        let topConstant: CGFloat = isPad ? Constant.onBoardingPagingViewTopMarginForiPad : Constant
+            .onBoardingPagingViewTopMargin
 
         NSLayoutConstraint.activate([
             // 페이징 뷰 위치 제약 (페이지네이션과 다음 버튼 사이)

--- a/Presentation/Sources/View/Recording/DownloadOnDeviceViewController.swift
+++ b/Presentation/Sources/View/Recording/DownloadOnDeviceViewController.swift
@@ -128,9 +128,11 @@ public final class DownloadOnDeviceViewController: UIViewController, Alertable {
             downloadModelCard.trailingAnchor.constraint(equalTo: subTitleLabel.trailingAnchor),
 
             // subTitleLabel2
-            subTitle2Label.topAnchor.constraint(equalTo: infoBox.bottomAnchor, constant: 24),
+            subTitle2Label.bottomAnchor.constraint(equalTo: bottomArea.topAnchor, constant: -12),
             subTitle2Label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             subTitle2Label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            subTitle2Label.topAnchor.constraint(greaterThanOrEqualTo: infoBox.bottomAnchor, constant: 12),
+            subTitle2Label.topAnchor.constraint(greaterThanOrEqualTo: downloadModelCard.bottomAnchor, constant: 12),
 
             // bottomArea
             bottomArea.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),

--- a/Presentation/Sources/View/Recording/DownloadOnDeviceViewController.swift
+++ b/Presentation/Sources/View/Recording/DownloadOnDeviceViewController.swift
@@ -64,7 +64,8 @@ public final class DownloadOnDeviceViewController: UIViewController, Alertable {
         symbolName: "externaldrive",
         modelName: "Whisper",
         style: .default,
-        storage: vm.status.storage
+        storage: vm.status.storage,
+        modelSize: vm.modelSize
     )
 
     // MARK: - Initialize
@@ -184,7 +185,8 @@ private extension DownloadOnDeviceViewController {
         if isShowingCard {
             downloadModelCard.updateStatus(
                 vm.status.storage,
-                errorMessage: vm.errorMessage
+                errorMessage: vm.errorMessage,
+                modelSize: vm.modelSize
             )
         }
     }

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingStep.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingStep.swift
@@ -43,7 +43,7 @@ enum Step: Equatable {
         case .download:
             OnBoardingItem(
                 headline: "기기에서 바로 작동하도록,\n몇 가지를 준비할게요.",
-                body: "녹음과 요약을 기기 안에서 처리하기 위해\n필요한 모델을 다운로드해요.\nWi-Fi 환경을 권장하며\n나중에 설정에서도 다운로드할 수 있어요.",
+                body: "녹음과 요약을 기기 안에서 처리하기 위해\n필요한 모델을 다운로드해요.\nWi-Fi 환경을 권장하며\n나중에 설정에서도 다운로드할 수 있어요."
             )
         case .finish:
             OnBoardingItem(

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingStep.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingStep.swift
@@ -43,7 +43,7 @@ enum Step: Equatable {
         case .download:
             OnBoardingItem(
                 headline: "기기에서 바로 작동하도록,\n몇 가지를 준비할게요.",
-                body: "녹음과 요약을 기기 안에서 처리하기 위해\n필요한 모델을 다운로드해요.\nWi-Fi 환경을 권장하며\n나중에 설정에서도 다운로드할 수 있어요."
+                body: "녹음과 요약을 기기 안에서 처리하기 위해\n필요한 모델을 다운로드해요. Wi-Fi 환경을 권장하며 나중에 설정에서도 다운로드할 수 있어요."
             )
         case .finish:
             OnBoardingItem(

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingStep.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingStep.swift
@@ -13,30 +13,12 @@ struct OnBoardingItem: Equatable {
     }
 }
 
-enum Step: Int, CaseIterable, Equatable {
-    case first = 0
+enum Step: Equatable {
+    case first
     case second
     case micPermission
     case download
     case finish
-
-    static func matchingStep(_ val: Int) -> Step {
-        switch val {
-        case 0:
-            return .first
-        case 1:
-            return .second
-        case 2:
-            return .micPermission
-        case 3:
-            return .download
-        case 4:
-            return .finish
-        default:
-            AppLogger.warning("매칭되지 않는 Int값이 들어왔습니다, value: \(val)")
-            return .first
-        }
-    }
 
     var item: OnBoardingItem {
         switch self {
@@ -61,7 +43,7 @@ enum Step: Int, CaseIterable, Equatable {
         case .download:
             OnBoardingItem(
                 headline: "기기에서 바로 작동하도록,\n몇 가지를 준비할게요.",
-                body: "녹음과 요약을 기기 안에서 처리하기 위해\n필요한 모델을 다운로드 해요.\nWi-Fi연결을 권장하며 몇 분 정도 걸려요."
+                body: "녹음과 요약을 기기 안에서 처리하기 위해\n필요한 모델을 다운로드해요.\nWi-Fi 환경을 권장하며\n나중에 설정에서도 다운로드할 수 있어요.",
             )
         case .finish:
             OnBoardingItem(
@@ -70,41 +52,17 @@ enum Step: Int, CaseIterable, Equatable {
             )
         }
     }
+}
 
-    func next() -> Self {
-        switch self {
-        case .first:
-            return .second
-        case .second:
-            return .micPermission
-        case .micPermission:
-            return .download
-        case .download:
-            return .finish
-        case .finish:
-            return .finish
-        }
+extension Step: CaseIterable {
+    static var allCases: [Step] {
+        [.first, .second, .micPermission, .download, .finish]
     }
+}
 
-    func prev() -> Self {
-        switch self {
-        case .first:
-            return .first
-        case .second:
-            return .first
-        case .micPermission:
-            return .second
-        case .download:
-            return .micPermission
-        case .finish:
-            return .download
-        }
-    }
-
-    func skip() -> Self {
-        if self == .first {
-            return .finish
-        }
-        return self
+extension Step {
+    var isDownload: Bool {
+        if case .download = self { return true }
+        return false
     }
 }

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
@@ -202,7 +202,7 @@ extension OnBoardingViewModel {
         let support = await availableSupportModelRepository.checkMLXSupportModel()
         modelSupport = support.model == .gemma4_e2b_4bit
         if modelSupport {
-            self.modelSize = await mlxRepository.modelSize
+            modelSize = await mlxRepository.modelSize
             steps = [.first, .second, .micPermission, .download, .finish]
         } else {
             steps = [.first, .second, .micPermission, .finish]

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
@@ -124,6 +124,20 @@ public final class OnBoardingViewModel {
             return false
         }
     }
+    
+    var isSecondButtonBgColor: Bool {
+        switch currentStep {
+        case .download:
+            switch status.storage {
+            case .downloading:
+                return true
+            default:
+                return false
+            }
+        default:
+            return false
+        }
+    }
 
     // MARK: - Setters
 

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
@@ -57,7 +57,7 @@ public final class OnBoardingViewModel {
         storage: .notDownloaded
     )
     private(set) var scrollEnabled: Bool = true
-
+    private(set) var modelSize: String = ""
     private var isPaging: Bool = false
     private(set) var steps: [Step] = Step.allCases
 
@@ -68,7 +68,7 @@ public final class OnBoardingViewModel {
         case .download:
             switch status.storage {
             case .downloading:
-                return "다운로드 중입니다..."
+                return ""
             case .downloaded:
                 return "다음"
             case .failed:
@@ -148,7 +148,7 @@ extension OnBoardingViewModel {
             isPaging = true
             finishOnBoarding()
         default: // 다음
-            guard currentStep != .download else {
+            guard !currentStep.isDownload else {
                 switch status.storage {
                 case .downloading:
                     return
@@ -201,7 +201,12 @@ extension OnBoardingViewModel {
     func checkModelSupport() async {
         let support = await availableSupportModelRepository.checkMLXSupportModel()
         modelSupport = support.model == .gemma4_e2b_4bit
-        steps = modelSupport ? Step.allCases : Step.allCases.filter { $0 != .download }
+        if modelSupport {
+            self.modelSize = await mlxRepository.modelSize
+            steps = [.first, .second, .micPermission, .download, .finish]
+        } else {
+            steps = [.first, .second, .micPermission, .finish]
+        }
         if !steps.contains(currentStep) {
             currentStep = .finish
         }
@@ -321,6 +326,12 @@ extension OnBoardingViewModel {
         }
 
         struct PreviewOnDeviceRepository: OnDeviceRepository {
+            var modelSize: String {
+                get async {
+                    "0 MB"
+                }
+            }
+
             func checkStatus() async -> Domain.OnDeviceStatus {
                 .init(storage: .downloaded)
             }

--- a/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
+++ b/Presentation/Sources/ViewModel/OnBoarding/OnBoardingViewModel.swift
@@ -124,7 +124,7 @@ public final class OnBoardingViewModel {
             return false
         }
     }
-    
+
     var isSecondButtonBgColor: Bool {
         switch currentStep {
         case .download:

--- a/Presentation/Sources/ViewModel/Recording/DownloadOnDeviceViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/DownloadOnDeviceViewModel.swift
@@ -18,7 +18,7 @@ public final class DownloadOnDeviceViewModel {
     private(set) var status: OnDeviceStatus = .init(storage: .notDownloaded)
     private(set) var errorMessage: String?
     private(set) var modelSize: String = ""
-    
+
     public weak var coordinator: DownloadOnDeviceCoordinatorDelegate?
     private let onDeviceStatusUseCase: any OnDeviceStatusUseCase
 
@@ -47,14 +47,13 @@ public final class DownloadOnDeviceViewModel {
 // MARK: - Actions
 
 extension DownloadOnDeviceViewModel {
-    
     /// 모델 다운로드 용량 크기를 가져옵니다.
     func onAppearSize() {
         Task {
             modelSize = await onDeviceStatusUseCase.fetchModelSize(model: .whisper)
         }
     }
-    
+
     /// 온디바이스 모델(Whisper)의 상태 스트림을 구독하여 상태를 관찰합니다.
     private func observeDownloadStatus() {
         statusObservationTask?.cancel()

--- a/Presentation/Sources/ViewModel/Recording/DownloadOnDeviceViewModel.swift
+++ b/Presentation/Sources/ViewModel/Recording/DownloadOnDeviceViewModel.swift
@@ -17,7 +17,8 @@ public final class DownloadOnDeviceViewModel {
     /// 온디바이스 모델의 통합 상태값
     private(set) var status: OnDeviceStatus = .init(storage: .notDownloaded)
     private(set) var errorMessage: String?
-
+    private(set) var modelSize: String = ""
+    
     public weak var coordinator: DownloadOnDeviceCoordinatorDelegate?
     private let onDeviceStatusUseCase: any OnDeviceStatusUseCase
 
@@ -38,6 +39,7 @@ public final class DownloadOnDeviceViewModel {
         onDeviceStatusUseCase: any OnDeviceStatusUseCase
     ) {
         self.onDeviceStatusUseCase = onDeviceStatusUseCase
+        onAppearSize()
         observeDownloadStatus()
     }
 }
@@ -45,6 +47,14 @@ public final class DownloadOnDeviceViewModel {
 // MARK: - Actions
 
 extension DownloadOnDeviceViewModel {
+    
+    /// 모델 다운로드 용량 크기를 가져옵니다.
+    func onAppearSize() {
+        Task {
+            modelSize = await onDeviceStatusUseCase.fetchModelSize(model: .whisper)
+        }
+    }
+    
     /// 온디바이스 모델(Whisper)의 상태 스트림을 구독하여 상태를 관찰합니다.
     private func observeDownloadStatus() {
         statusObservationTask?.cancel()

--- a/Presentation/Sources/ViewModel/Setting/SettingViewModel+Preview.swift
+++ b/Presentation/Sources/ViewModel/Setting/SettingViewModel+Preview.swift
@@ -68,6 +68,10 @@ import Foundation
             func download(model: ChaGokModel) async throws(OnDeviceStatusUseCaseError) {}
 
             func delete(model: ChaGokModel) async throws(DeleteOnDeviceRepositoryError) {}
+
+            func fetchModelSize(model: ChaGokModel) async -> String {
+                return "약 75 MB"
+            }
         }
     }
 #endif

--- a/Presentation/Tests/OnBoarding/OnBoardingViewModelTests.swift
+++ b/Presentation/Tests/OnBoarding/OnBoardingViewModelTests.swift
@@ -87,7 +87,8 @@ final class OnBoardingViewModelTests: XCTestCase {
     func test_마지막스텝인경우_버튼타이틀과_상태가_변경된다() {
         let sut = makeSUT()
 
-        sut.viewModel.syncPageState(nextStep: Step.finish.rawValue) // 4
+        let finishIndex = sut.viewModel.steps.firstIndex(of: .finish) ?? 4
+        sut.viewModel.syncPageState(nextStep: finishIndex)
 
         XCTAssertEqual(sut.viewModel.currentStep, .finish)
         XCTAssertEqual(sut.viewModel.primaryButtonTitle, "시작하기")
@@ -107,7 +108,8 @@ final class OnBoardingViewModelTests: XCTestCase {
         await sut.mockSTTRepo.setCheckResult(.notDetermined)
         await sut.mockSTTRepo.setRequestResult(.success(.authorized))
 
-        sut.viewModel.syncPageState(nextStep: Step.micPermission.rawValue)
+        let micPermissionIndex = sut.viewModel.steps.firstIndex(of: .micPermission) ?? 2
+        sut.viewModel.syncPageState(nextStep: micPermissionIndex)
 
         // Task 내부 비동기 호출 대기 (안전하게 0.3초 대기)
         try? await Task.sleep(nanoseconds: 300_000_000)
@@ -131,13 +133,14 @@ final class OnBoardingViewModelTests: XCTestCase {
             scrolledIndex = nextIndex
         }
 
-        XCTAssertEqual(scrolledIndex, Step.second.rawValue) // 1
+        XCTAssertEqual(scrolledIndex, 1)
     }
 
     func test_primaryButtonAction_마지막스텝에서_온보딩을_완료하고_화면을_전환한다() async {
         let sut = makeSUT()
 
-        sut.viewModel.syncPageState(nextStep: Step.finish.rawValue)
+        let finishIndex = sut.viewModel.steps.firstIndex(of: .finish) ?? 4
+        sut.viewModel.syncPageState(nextStep: finishIndex)
 
         sut.mockCheckFirstLaunchRepo.setReturnValue(true)
         sut.mockFolderRepo.setCreateResult(.success(Folder(name: Policy.defaultFolderName, kind: .default)))
@@ -173,7 +176,7 @@ final class OnBoardingViewModelTests: XCTestCase {
             scrolledIndex = nextIndex
         }
 
-        XCTAssertEqual(scrolledIndex, Step.micPermission.rawValue)
+        XCTAssertEqual(scrolledIndex, 2)
     }
 
     func test_secondButtonAction_중간스텝에서_이전버튼을_누르면_이전스텝으로_이동한다() async {
@@ -187,7 +190,8 @@ final class OnBoardingViewModelTests: XCTestCase {
         await sut.mockSTTRepo.setCheckResult(.notDetermined)
         await sut.mockSTTRepo.setRequestResult(.success(.authorized))
 
-        sut.viewModel.syncPageState(nextStep: Step.micPermission.rawValue)
+        let micPermissionIndex = sut.viewModel.steps.firstIndex(of: .micPermission) ?? 2
+        sut.viewModel.syncPageState(nextStep: micPermissionIndex)
 
         // 백그라운드 Task가 안전하게 완료될 수 있도록 약간의 딜레이 부여
         try? await Task.sleep(nanoseconds: 300_000_000)
@@ -197,7 +201,7 @@ final class OnBoardingViewModelTests: XCTestCase {
             scrolledIndex = nextIndex
         }
 
-        XCTAssertEqual(scrolledIndex, Step.second.rawValue)
+        XCTAssertEqual(scrolledIndex, 1)
     }
 
     func test_checkModelSupport호출시_지원하는기기이면_modelSupport가true가된다() async {
@@ -221,7 +225,10 @@ final class OnBoardingViewModelTests: XCTestCase {
         sut.mockMLXRepo.downloadResult = .success(())
 
         await sut.viewModel.checkModelSupport()
-        sut.viewModel.syncPageState(nextStep: Step.download.rawValue)
+        let downloadIndex = sut.viewModel.steps.firstIndex { if case .download = $0 { return true }
+            return false
+        } ?? 3
+        sut.viewModel.syncPageState(nextStep: downloadIndex)
 
         sut.viewModel.primaryButtonAction { _ in }
         try? await Task.sleep(nanoseconds: 300_000_000) // 다운로드 완료 비동기 대기

--- a/Presentation/Tests/Recording/DownloadOnDeviceViewModelTests.swift
+++ b/Presentation/Tests/Recording/DownloadOnDeviceViewModelTests.swift
@@ -42,6 +42,10 @@ final class DownloadMockOnDeviceStatusUseCase: OnDeviceStatusUseCase, @unchecked
     func checkStatus(model: ChaGokModel) async -> OnDeviceStatus {
         return OnDeviceStatus(storage: .notDownloaded)
     }
+
+    func fetchModelSize(model: ChaGokModel) async -> String {
+        return "약 75 MB"
+    }
 }
 
 @MainActor

--- a/Presentation/Tests/Setting/SettingViewModelTests.swift
+++ b/Presentation/Tests/Setting/SettingViewModelTests.swift
@@ -71,6 +71,17 @@ final class SettingMockOnDeviceStatusUseCase: OnDeviceStatusUseCase, @unchecked 
     func checkStatus(model: ChaGokModel) async -> OnDeviceStatus {
         return checkStatusResult
     }
+
+    func fetchModelSize(model: ChaGokModel) async -> String {
+        switch model {
+        case .whisper:
+            return "약 75 MB"
+        case .gemma4_e2b_4bit:
+            return "약 3.58 GB"
+        case .none:
+            return ""
+        }
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## ✨ 작업 요약
> iPad 다운로드 가이드 라벨 잘림 현상 수정, 툴팁 슬라이드&페이드 애니메이션 전환 구현 및 다운로드 시트 가이드 라벨 레이아웃 보강

- iPad 환경 및 기기 가로 규격에서 가이드 라벨(`TimelineGuideLabel`)이 한 줄로 잘리는 오토 레이아웃 버그를 해결했습니다.
- 툴팁 변경 시 자연스럽게 위로 사라지며 투명해졌다가 아래서 올라오는 Slide & Fade 애니메이션을 적용했습니다.
- 온디바이스 다운로드 시트(`DownloadOnDeviceViewController`) 내 Wi-Fi 권장 라벨을 하단 버튼 바로 위(12pt)에 일관되게 고정되도록 제약조건을 수정했습니다.

---

## 📋 구체적인 내용
- **추가/변경된 동작**:
  - `TimelineGuideLabel.swift`:
    - `layoutSubviews` 내에서 bounds 너비에 맞게 `preferredMaxLayoutWidth`를 동적으로 갱신하고 `invalidateIntrinsicContentSize()`를 호출하여 여러 줄 텍스트가 항상 정확한 세로 높이를 가지도록 개선
    - 기존 `CATransition` 밀어내기 효과 대신, `UIView.animate` 기반의 Slide & Fade 애니메이션(위로 올라가며 투명해진 뒤, 아래에서 불투명하게 올라옴)으로 전환 효과 리팩토링
    - 타이머 중지(`stopTimer`) 시점에 alpha와 transform 상태를 원상태(`.identity`, `1`)로 안전하게 리셋하는 로직 추가
  - `OnBoardingDownloadView.swift`:
    - 스택 뷰 구조 내 `spacerView` 전후의 custom spacing을 `0`으로 명시하고 content hugging 및 compression resistance 우선순위를 `.defaultLow`로 지정하여, 공간 부족 시 가이드 라벨 영역을 침범하거나 불필요한 기본 간격(32pt)을 남기지 않고 완벽히 `0`으로 수축되도록 보강
  - `DownloadOnDeviceViewController.swift`:
    - Wi-Fi 권장 라벨(`subTitle2Label`)의 top 제약조건을 제거하고, 하단 버튼 영역(`bottomArea.topAnchor`) 위 `12pt`에 위치하도록 bottom 제약조건으로 변경
    - 화면 크기가 극히 좁을 때 상단 카드 컴포넌트(`infoBox`, `downloadModelCard`)와 겹치는 현상을 방지하고자 `greaterThanOrEqualTo` 안전 마진 제약조건(12pt) 추가
- **영향 받는 화면/모듈**:
  - `Presentation` 모듈 (온보딩 다운로드 뷰, 온디바이스 다운로드 바텀 시트)

---

## 🔗 연관 이슈

- closed #

---

## 🧩 설계·구현 노트
> 왜 이렇게 구현했는지, 대안과 비교한 점 (선택)

- **선택한 방식**
  - **`preferredMaxLayoutWidth` 설정**: 스크롤 뷰나 가로 스택 뷰 내부에 멀티라인 라벨이 들어갈 때 오토레이아웃 엔진이 잘못된 크기(1줄 크기)로 높이를 캐싱하는 문제를 해결하는 검증된 iOS 표준 방식을 사용했습니다.
  - **`UIView.animate` 체이닝**: `CATransition`은 투명도 조절과 곡선 커스텀이 까다롭기 때문에, 0.25초 단위의 두 단계 페이드 인/아웃 방식 UIKit 애니메이션을 활용해 사용자에게 한층 더 부드럽고 완성도 높은 모션을 제공하도록 설계했습니다.
  - **Spacer Spacing 수축**: stack view 내부에서 spacer가 줄어들어도 spacing(32pt)이 낭비되는 문제를 custom spacing을 0으로 명시적으로 차단하여 고쳤습니다.
- **고려했다가 제외한 방식**
  - **고정 높이(Constraint Height) 부여**: 라벨의 다국어 대응이나 텍스트 길이에 따라 유동적인 변경이 불가능하여 제외했습니다.
  - **`CATransition`에 불투명도 속성 추가 시도**: CoreAnimation 트랜지션의 특성상 텍스트 속성 업데이트 시점과 정확한 애니메이션 타이밍 동기화가 어려워 순수 UIKit 애니메이션 방식으로 선회했습니다.

---

## ✅ 확인 사항
> PR 전 직접 확인한 것

- [x] 정상 플로우 동작 확인
- [x] 엣지 케이스 / 빈 값·에러 처리 확인
- [ ] (UI 변경 시) 스크린샷 또는 GIF 첨부
- [ ] (로직 추가 시) 테스트 추가 여부

---

## 👀 리뷰 포인트

- [x] 설계·구조 적절성
- [x] 로직·엣지 케이스
- [x] 예외/에러 핸들링
- [x] UI/UX (해당 시)
- [ ] 성능·의존성 (해당 시)

**특히 봐줬으면 하는 부분**
- `TimelineGuideLabel`의 애니메이션 전환 딜레이(0.25초 + 0.25초)가 자연스럽게 동작하는지 확인해 주세요.
- 온바인딩 다운로드 뷰와 바텀 시트 뷰에서 iPad 및 소형 iPhone 기기 레이아웃이 찌그러지거나 잘리지 않는지 확인 바랍니다.

---

## 📚 참고

- 2.1.0 Performance: App Completeness
- 4.0.0 Design: Preamble
- 4.2.3 Design: Minimum Functionality
