### PR TITLE
폴더 이동 휴지통 폴더 조회 로직 수정합니다.

### DIFF
--- a/Presentation/Sources/ViewModel/MoveVoiceNote/MoveFolderListViewModel.swift
+++ b/Presentation/Sources/ViewModel/MoveVoiceNote/MoveFolderListViewModel.swift
@@ -60,7 +60,7 @@ public final class MoveFolderListViewModel {
         do {
             guard let currentFolderID = voiceNotes.first?.folderID else { return }
             let folders = try folderUseCase.fetchAll()
-            let otherFolders = folders.filter { $0.id != currentFolderID }
+            let otherFolders = folders.filter { $0.id != currentFolderID && $0.kind != .trash }
             send(.internal(.foldersLoaded(otherFolders)))
         } catch {
             AppLogger.error(error)


### PR DESCRIPTION
## ✨ 작업 요약                                                                                                                                 
- 폴더 이동 대상 목록에서 휴지통 폴더(`.trash`)가 노출되지 않도록 필터링을 추가했습니다.                                                        
                                                                                                                                        
## 📋 구체적인 내용                                                                                                                             
- 추가/변경된 동작:                                                                                                                             
- `MoveFolderListViewModel`에서 이동 가능한 대상 폴더를 필터링할 때 `kind != .trash` 조건을 추가해 휴지통 폴더를 제외했습니다.                
- 영향 받는 화면/모듈:
- 음성 메모 이동 화면 (폴더 목록) / `MoveFolder` 모듈

---

## 🔗 연관 이슈

- closed #

---

## 🧩 설계·구현 노트
- **선택한 방식**
- 기존 ID 필터링 조건(`$0.id != currentFolderID`)만으로는 휴지통 폴더가 걸러지지 않기 때문에, 명시적으로 `kind != .trash` 조건을 추가하여     
안전하게 제외했습니다.

---

## ✅ 확인 사항
- [x] 정상 플로우 동작 확인
- [x] 엣지 케이스 / 빈 값·에러 처리 확인

---

## 👀 리뷰 포인트
- [x] 로직·엣지 케이스 (이동 폴더 목록에서 휴지통 폴더가 올바르게 필터링되는지)